### PR TITLE
feat: NYSE 휴장일·조기종료일 반영 (Good Friday 등 2025~2026)

### DIFF
--- a/src/utils/marketHours.js
+++ b/src/utils/marketHours.js
@@ -79,8 +79,8 @@ export function isKoreanMarketOpen() {
 }
 
 // 미국 주식 (ET 09:30~16:00, 조기종료일 09:30~13:00)
-export function isUsMarketOpen() {
-  const est = nowEST();
+// est 파라미터: getUsMarketStatus에서 단일 스냅샷 전달 시 경계 흔들림 방지
+export function isUsMarketOpen(est = nowEST()) {
   if (!isWeekday(est) || isNyseHoliday(est)) return false;
   const h = est.getHours(), m = est.getMinutes();
   const minutes = h * 60 + m;
@@ -89,8 +89,7 @@ export function isUsMarketOpen() {
 }
 
 // 프리마켓 (ET 04:00~09:30) — 휴장일 제외
-export function isUsPreMarket() {
-  const est = nowEST();
+export function isUsPreMarket(est = nowEST()) {
   if (!isWeekday(est) || isNyseHoliday(est)) return false;
   const h = est.getHours(), m = est.getMinutes();
   const minutes = h * 60 + m;
@@ -98,8 +97,7 @@ export function isUsPreMarket() {
 }
 
 // 애프터마켓 (ET 16:00~20:00) — 조기종료일은 13:00부터, 휴장일 제외
-export function isUsAfterMarket() {
-  const est = nowEST();
+export function isUsAfterMarket(est = nowEST()) {
   if (!isWeekday(est) || isNyseHoliday(est)) return false;
   const h = est.getHours(), m = est.getMinutes();
   const minutes = h * 60 + m;
@@ -118,13 +116,14 @@ export function getKoreanMarketStatus() {
 }
 
 export function getUsMarketStatus() {
+  // 단일 스냅샷으로 모든 판정 — 경계 시점 흔들림 방지
   const est = nowEST();
   if (!isWeekday(est) || isNyseHoliday(est)) return { status: 'closed', label: '휴장', color: 'neutral' };
-  if (isUsMarketOpen()) {
+  if (isUsMarketOpen(est)) {
     if (isNyseEarlyClose(est)) return { status: 'open', label: '거래중(조기종료)', color: 'up' };
     return { status: 'open', label: '거래중', color: 'up' };
   }
-  if (isUsPreMarket()) return { status: 'pre', label: '프리마켓', color: 'neutral' };
-  if (isUsAfterMarket()) return { status: 'after', label: '애프터', color: 'neutral' };
+  if (isUsPreMarket(est)) return { status: 'pre', label: '프리마켓', color: 'neutral' };
+  if (isUsAfterMarket(est)) return { status: 'after', label: '애프터', color: 'neutral' };
   return { status: 'closed', label: '장마감', color: 'neutral' };
 }


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Codex gate (OpenAI)
- PASS (지적사항 처리: [기각] P2 수준 — 현재 2025~2026 하드코딩으로 충분, 자동계산은 백로그 등록)

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * NYSE 휴장일을 정확히 인식해 휴장으로 표시
  * 조기 종료일에 정상 마감시간을 오후 1:00 ET로 반영하고, 해당 기간을 '거래중(조기종료)'으로 표기
  * 프리·애프터마켓 판정과 전체 시장 상태 계산의 정확성 향상 (시간 스냅샷 지원 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->