### PR TITLE
fix: hantoo-chart.js 날짜 계산 UTC→KST 통일

### DIFF
--- a/api/hantoo-chart.js
+++ b/api/hantoo-chart.js
@@ -21,13 +21,16 @@ export default async function handler(req, res) {
   const validPeriod = ['D', 'W', 'M'].includes(period) ? period : 'D';
 
   // 기간 계산 — 일봉 5개월, 주봉 1년, 월봉 5년
-  const endDate = new Date();
+  // KIS API는 서울 시간(KST) 기준 날짜를 사용 → Asia/Seoul 타임존으로 통일
+  const seoulStr = d => new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul', year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(d).replace(/-/g, '');
+
+  const now = new Date();
   const startDate = new Date();
   if (validPeriod === 'D') startDate.setMonth(startDate.getMonth() - 5);
   else if (validPeriod === 'W') startDate.setFullYear(startDate.getFullYear() - 1);
   else startDate.setFullYear(startDate.getFullYear() - 5);
-
-  const fmt = d => d.toISOString().slice(0, 10).replace(/-/g, '');
 
   try {
     const token = await getHantooToken();
@@ -35,8 +38,8 @@ export default async function handler(req, res) {
     const url = new URL(`${HANTOO_BASE}/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice`);
     url.searchParams.set('FID_COND_MRKT_DIV_CODE', 'J');
     url.searchParams.set('FID_INPUT_ISCD', symbol);
-    url.searchParams.set('FID_INPUT_DATE_1', fmt(startDate));
-    url.searchParams.set('FID_INPUT_DATE_2', fmt(endDate));
+    url.searchParams.set('FID_INPUT_DATE_1', seoulStr(startDate));
+    url.searchParams.set('FID_INPUT_DATE_2', seoulStr(now));
     url.searchParams.set('FID_PERIOD_DIV_CODE', validPeriod);
 
     const apiRes = await fetch(url.toString(), {


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Codex gate (OpenAI)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* API 날짜 쿼리의 시간대 처리를 UTC에서 서울 표준시(KST)로 변경하여 올바른 날짜 범위로 데이터를 조회하도록 수정했습니다. 날짜 입력값이 이제 정확한 서울 시간대를 기준으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->