### PR TITLE
fix: AI 토론 LLM JSON 삽입 시 raw JSON 노출 수정

### DIFF
--- a/api/ai-debate.js
+++ b/api/ai-debate.js
@@ -104,8 +104,8 @@ export default async function handler(request) {
           ];
         }
         // LLM이 메시지 text 안에 전체 JSON을 삽입한 경우 감지 → 재파싱 (단일 depth)
-        // verdict/confidence는 원본 유지, messages만 교체
-        let reparsedMessages = null;
+        // inner JSON이 실제 응답이므로 messages/verdict/confidence 모두 복구
+        let innerResult = null;
         for (const msg of (parsed.messages ?? [])) {
           const innerText = (msg?.text ?? '').trim();
           if (!innerText.startsWith('{')) continue;
@@ -119,15 +119,21 @@ export default async function handler(request) {
               inner = JSON.parse(m[0]);
             }
             if (Array.isArray(inner?.messages) && inner.messages.length >= 2) {
-              reparsedMessages = inner.messages;
+              innerResult = inner;
               break;
             }
           } catch (e) {
             console.warn('[ai-debate] inner JSON reparse failed:', e?.message);
           }
         }
-        if (reparsedMessages) {
-          parsed = { ...parsed, messages: reparsedMessages };
+        if (innerResult) {
+          // 화이트리스트 필드만 병합 — prototype 오염 방지
+          parsed = {
+            ...parsed,
+            messages: innerResult.messages,
+            ...(innerResult.verdict  != null && { verdict:    innerResult.verdict }),
+            ...(innerResult.confidence != null && { confidence: innerResult.confidence }),
+          };
         }
       } catch {
         parsed = { messages: [{ side: 'bull', text }], verdict: '', confidence: 0.5 };


### PR DESCRIPTION
## 관련 이슈
Closes #33

## 변경 내용
LLM이 응답 메시지 `text` 필드 안에 전체 JSON을 삽입하는 경우 raw JSON이 그대로 UI에 표시되는 버그 수정.

### 핵심 변경
- `JSON.parse(innerText)` 직접 시도 → 실패 시 regex fallback (greedy 정규식 오남용 방지)
- `messages`만 교체했던 기존 방식 → `messages` + `verdict` + `confidence` 선택적 병합
- 루프 내 `parsed` 직접 재할당 → 별도 변수(`innerResult`) 사용 후 루프 외부에서 할당
- 화이트리스트 필드만 병합하여 prototype pollution 방지

## 검증
- Opus code-reviewer: PASS
- Codex gate: PASS

🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * AI 토론 응답 처리의 안정성이 개선되어 복잡한 응답 구조를 더 견고하게 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->