### PR TITLE
fix: 시세 데이터 결손/단일실패점 4건 일괄 수정 (#104)

### DIFF
--- a/api/cron/update-coins.js
+++ b/api/cron/update-coins.js
@@ -22,10 +22,10 @@ const COIN_KR_NAMES_FALLBACK = {
 };
 
 // Upbit 전종목 KRW 마켓 목록 조회
-async function fetchUpbitMarkets() {
+async function fetchUpbitMarkets(timeoutMs = 5000) {
   const res = await fetch('https://api.upbit.com/v1/market/all?isDetails=false', {
     headers: { Accept: 'application/json' },
-    signal: AbortSignal.timeout(8000),
+    signal: AbortSignal.timeout(timeoutMs),
   });
   if (!res.ok) throw new Error(`Upbit markets HTTP ${res.status}`);
   const data = await res.json();
@@ -36,7 +36,9 @@ async function fetchUpbitMarkets() {
 // Upbit 티커 배치 조회 — 100개씩 청크 분할 (URL 길이 제한 대비)
 const TICKER_BATCH_SIZE = 100;
 
-async function fetchUpbitTickers(markets) {
+async function fetchUpbitTickers(markets, timeoutMs = 6000) {
+  // #104 Codex P1: Edge runtime 10s 총 예산 — primary 10s 타임아웃이면
+  // Bithumb fallback 에 쓸 시간이 0 이 됨. 6s 로 타이트하게.
   const chunks = [];
   for (let i = 0; i < markets.length; i += TICKER_BATCH_SIZE) {
     chunks.push(markets.slice(i, i + TICKER_BATCH_SIZE));
@@ -47,7 +49,7 @@ async function fetchUpbitTickers(markets) {
       const marketStr = chunk.map((m) => m.market).join(',');
       const res = await fetch(`https://api.upbit.com/v1/ticker?markets=${marketStr}`, {
         headers: { Accept: 'application/json' },
-        signal: AbortSignal.timeout(10000),
+        signal: AbortSignal.timeout(timeoutMs),
       });
       if (!res.ok) throw new Error(`Upbit ticker HTTP ${res.status}`);
       return res.json();
@@ -143,8 +145,7 @@ export default async function handler(request) {
       fetchUpbitMarkets(),
       fetchCoinPaprika(),
     ]);
-    // `let` — 아래 Bithumb fallback 분기에서 markets 재시도 가능.
-    let markets = marketsRes.status === 'fulfilled' ? marketsRes.value : null;
+    const markets = marketsRes.status === 'fulfilled' ? marketsRes.value : null;
     const paprikaData = paprikaRes.status === 'fulfilled' ? paprikaRes.value : [];
     if (marketsRes.status === 'rejected') {
       console.warn('[update-coins] Upbit markets 실패:', marketsRes.reason?.message);
@@ -177,24 +178,16 @@ export default async function handler(request) {
     }
 
     // 마켓 이름 매핑 (market code → korean_name)
-    // #104 Opus 리뷰: Bithumb fallback 경로에서도 한글명 노출을 위해 markets
-    // 호출을 한 번 더 재시도 (보통 markets 는 ticker 보다 훨씬 가벼워 두 번째 시도 성공률 높음).
-    // 그래도 실패하면 static COIN_KR_NAMES 로 주요 코인만 커버.
-    if (!markets) {
-      try {
-        markets = await fetchUpbitMarkets();
-        console.log('[update-coins] Upbit markets 재시도 성공 — 한글명 주입');
-      } catch (e) {
-        console.warn('[update-coins] Upbit markets 재시도 실패, static 한글명 map 사용:', e.message);
-      }
-    }
+    // #104 Codex P2: Bithumb fallback 경로에서 Upbit markets 재시도는 Edge 10s
+    // 예산을 추가로 5~8s 깎아 먹을 수 있음. 따라서 markets 가 없어도 재시도하지 않고
+    // 바로 static COIN_KR_NAMES_FALLBACK 으로 주요 코인을 커버.
     const nameMap = new Map();
     if (markets) {
       for (const m of markets) {
         nameMap.set(m.market, m.korean_name || m.english_name || m.market);
       }
     }
-    // static fallback: 주요 상위 코인 한글명 (markets 전부 실패 시 최소 커버리지)
+    // static fallback: 주요 상위 코인 한글명 (markets 실패 시 최소 커버리지)
     for (const [sym, kr] of Object.entries(COIN_KR_NAMES_FALLBACK)) {
       const key = `KRW-${sym}`;
       if (!nameMap.has(key)) nameMap.set(key, kr);

--- a/api/cron/update-coins.js
+++ b/api/cron/update-coins.js
@@ -10,14 +10,17 @@ import { SNAP_KEYS, SNAP_TTL, setSnap, recordCronFailure } from '../_price-cache
 
 // #104 Opus: Upbit markets 전량 실패 + Bithumb fallback 경로에서도 최소한의 한글명 보장.
 // 라이브 Upbit 한글명 매핑을 1-off 로 추출 (Top 40 KRW 마켓).
+// ※ 리브랜드 반영: MATIC → POL, RNDR → RENDER (2024 마이그레이션).
+//   fetchUpbitMarkets 가 성공한 정상 경로는 이 정적 맵을 덮어쓰지 않으므로
+//   Upbit 공식 한글명과의 표기 drift 위험은 최소화됨.
 const COIN_KR_NAMES_FALLBACK = {
   BTC: '비트코인', ETH: '이더리움', XRP: '리플', SOL: '솔라나', DOGE: '도지코인',
   ADA: '에이다', AVAX: '아발란체', DOT: '폴카닷', TRX: '트론', LINK: '체인링크',
-  MATIC: '폴리곤', NEAR: '니어프로토콜', BCH: '비트코인캐시', LTC: '라이트코인', SHIB: '시바이누',
+  POL: '폴리곤 에코시스템 토큰', NEAR: '니어프로토콜', BCH: '비트코인캐시', LTC: '라이트코인', SHIB: '시바이누',
   ATOM: '코스모스', UNI: '유니스왑', XLM: '스텔라루멘', ETC: '이더리움클래식', FIL: '파일코인',
   APT: '앱토스', ARB: '아비트럼', OP: '옵티미즘', STX: '스택스', HBAR: '헤데라',
-  SUI: '수이', TIA: '셀레스티아', INJ: '인젝티브', SEI: '세이', PYTH: '피스네트워크',
-  JUP: '주피터', IMX: '이뮤터블엑스', RNDR: '렌더토큰', GRT: '더그래프', AAVE: '에이브',
+  SUI: '수이', TIA: '셀레스티아', INJ: '인젝티브', SEI: '세이', PYTH: '파이스네트워크',
+  JUP: '주피터', IMX: '이뮤터블엑스', RENDER: '렌더토큰', GRT: '더그래프', AAVE: '에이브',
   SAND: '샌드박스', MANA: '디센트럴랜드', AXS: '엑시인피니티', APE: '에이프코인', GMT: '스테픈',
 };
 
@@ -90,14 +93,13 @@ async function fetchBithumbTickers() {
     if (!row || typeof row !== 'object' || row.closing_price == null) continue;
     const close = parseFloat(row.closing_price);
     if (!Number.isFinite(close) || close <= 0) continue;
-    // 24h 변동률: fluctate_rate_24H(%) 우선, 없으면 prev_closing_price 기반 계산.
+    // 24h 변동률: fluctate_rate_24H(%) 만 사용.
+    // prev_closing_price 는 "전일 종가" 로 00:00 KST 리셋되는 일일 기준이라
+    // "24h 롤링" 의미가 아님 → Upbit signed_change_rate 와 드리프트. 없으면 0.
     let changeRate = 0;
     const rate24H = parseFloat(row.fluctate_rate_24H);
     if (Number.isFinite(rate24H)) {
       changeRate = rate24H / 100; // Upbit 와 동일하게 0.05 = 5%
-    } else {
-      const prev = parseFloat(row.prev_closing_price);
-      if (prev > 0) changeRate = (close - prev) / prev;
     }
     tickers.push({
       market: `KRW-${symbol}`,
@@ -115,12 +117,12 @@ async function fetchBithumbTickers() {
 
 // CoinPaprika 글로벌 시세 조회 (USD + KRW)
 // #104 B2: limit 100 → 300 으로 상향해 Upbit KRW 244 개 커버 (+ 마진).
-// 500 은 과다 → rate limit 소진 가속 우려 (Opus 리뷰).
-// 실패·부분응답은 호출자가 처리.
+// #104 Opus: paprika 는 보강 데이터라 실패해도 snapshot 저장에 영향 없음.
+// Edge 10s 예산을 지키기 위해 타임아웃 10s → 4s 로 축소. 실패는 allSettled 가 흡수.
 async function fetchCoinPaprika() {
   const res = await fetch('https://api.coinpaprika.com/v1/tickers?limit=300&quotes=KRW,USD', {
     headers: { Accept: 'application/json' },
-    signal: AbortSignal.timeout(10000),
+    signal: AbortSignal.timeout(4000),
   });
   if (!res.ok) return [];
   return res.json();

--- a/api/cron/update-coins.js
+++ b/api/cron/update-coins.js
@@ -1,5 +1,9 @@
 // api/cron/update-coins.js — 코인 가격 갱신 Edge Cron
-// Upbit REST + CoinPaprika 병렬 호출 → Redis 저장
+// Upbit REST (primary) → Bithumb REST (fallback), CoinPaprika 병렬 보강.
+// #104 B1/B2/B4 수정:
+//   B1 — Promise.all 단일 실패점 → allSettled 로 부분 성공 허용
+//   B2 — CoinPaprika limit=100 → 500 + priceUsd=0 필터링
+//   B4 — Upbit ticker 전종목 실패 시 Bithumb public/ticker/ALL_KRW fallback
 export const config = { runtime: 'edge' };
 
 import { SNAP_KEYS, SNAP_TTL, setSnap, recordCronFailure } from '../_price-cache.js';
@@ -46,9 +50,45 @@ async function fetchUpbitTickers(markets) {
   return results.flat();
 }
 
+// #104 B4: Bithumb REST fallback — Upbit 완전 실패 시만 호출
+// 응답 스키마: { status, data: { BTC: {...}, ETH: {...}, ..., date: "..." } }
+// Upbit 티커 포맷으로 정규화하여 동일 파이프라인에 흘려보냄.
+async function fetchBithumbTickers() {
+  const res = await fetch('https://api.bithumb.com/public/ticker/ALL_KRW', {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!res.ok) throw new Error(`Bithumb ALL_KRW HTTP ${res.status}`);
+  const json = await res.json();
+  if (json.status !== '0000' || !json.data) {
+    throw new Error(`Bithumb 응답 비정상: status=${json.status}`);
+  }
+  const tickers = [];
+  for (const [symbol, row] of Object.entries(json.data)) {
+    if (symbol === 'date' || !row || typeof row !== 'object') continue;
+    const close = parseFloat(row.closing_price);
+    const open  = parseFloat(row.opening_price);
+    if (!Number.isFinite(close) || close <= 0) continue;
+    const changeRate = open > 0 ? (close - open) / open : 0;
+    tickers.push({
+      market: `KRW-${symbol}`,
+      trade_price: close,
+      signed_change_rate: changeRate, // -0.05 ~ +0.05 형태로 Upbit 호환
+      acc_trade_price_24h: parseFloat(row.acc_trade_value_24H) || 0,
+      high_price: parseFloat(row.max_price) || 0,
+      low_price:  parseFloat(row.min_price) || 0,
+      _source: 'bithumb',
+    });
+  }
+  if (!tickers.length) throw new Error('Bithumb: 유효한 티커 없음');
+  return tickers;
+}
+
 // CoinPaprika 글로벌 시세 조회 (USD + KRW)
+// #104 B2: limit 100 → 500 으로 상향해 Upbit KRW 244 개 전부 커버.
+// 실패·부분응답은 호출자가 처리.
 async function fetchCoinPaprika() {
-  const res = await fetch('https://api.coinpaprika.com/v1/tickers?limit=100&quotes=KRW,USD', {
+  const res = await fetch('https://api.coinpaprika.com/v1/tickers?limit=500&quotes=KRW,USD', {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(10000),
   });
@@ -70,38 +110,69 @@ export default async function handler(request) {
 
   try {
     // 1단계: Upbit 마켓 목록 + CoinPaprika 동시 조회
-    const [markets, paprikaData] = await Promise.all([
+    // #104 B1: Promise.all 단일 실패점 제거 → allSettled 로 부분 성공 허용.
+    const [marketsRes, paprikaRes] = await Promise.allSettled([
       fetchUpbitMarkets(),
       fetchCoinPaprika(),
     ]);
-
-    // 2단계: Upbit 티커 조회
-    const tickers = await fetchUpbitTickers(markets);
-
-    // 마켓 이름 매핑 (market code → korean_name)
-    const nameMap = new Map();
-    for (const m of markets) {
-      nameMap.set(m.market, m.korean_name || m.english_name || m.market);
+    const markets = marketsRes.status === 'fulfilled' ? marketsRes.value : null;
+    const paprikaData = paprikaRes.status === 'fulfilled' ? paprikaRes.value : [];
+    if (marketsRes.status === 'rejected') {
+      console.warn('[update-coins] Upbit markets 실패:', marketsRes.reason?.message);
+    }
+    if (paprikaRes.status === 'rejected') {
+      console.warn('[update-coins] CoinPaprika 실패 (보강 데이터 생략):', paprikaRes.reason?.message);
     }
 
-    // CoinPaprika 심볼 매핑 (symbol → { priceUsd, marketCap, volume24h })
-    const paprikaMap = new Map();
-    for (const coin of paprikaData) {
-      if (coin.symbol) {
-        paprikaMap.set(coin.symbol.toUpperCase(), {
-          priceUsd: coin.quotes?.USD?.price ?? 0,
-          marketCap: coin.quotes?.USD?.market_cap ?? 0,
-          volume24h: coin.quotes?.USD?.volume_24h ?? 0,
-        });
+    // 2단계: Upbit 티커 조회 — 실패 시 Bithumb fallback (#104 B4)
+    let tickers = null;
+    let tickerSource = 'upbit';
+    if (markets && markets.length > 0) {
+      try {
+        tickers = await fetchUpbitTickers(markets);
+      } catch (e) {
+        console.warn('[update-coins] Upbit ticker 전종목 실패, Bithumb fallback 시도:', e.message);
+        tickers = null;
+      }
+    }
+    if (!tickers || tickers.length === 0) {
+      try {
+        tickers = await fetchBithumbTickers();
+        tickerSource = 'bithumb';
+        console.log(`[update-coins] Bithumb fallback 성공: ${tickers.length}개`);
+      } catch (e) {
+        throw new Error(`Upbit + Bithumb 모두 실패: ${e.message}`);
       }
     }
 
-    // Upbit 티커 → 통합 형태 변환
+    // 마켓 이름 매핑 (market code → korean_name)
+    // Bithumb fallback 경로에는 markets 가 없을 수 있어 기본값으로 symbol 노출.
+    const nameMap = new Map();
+    if (markets) {
+      for (const m of markets) {
+        nameMap.set(m.market, m.korean_name || m.english_name || m.market);
+      }
+    }
+
+    // CoinPaprika 심볼 매핑 (symbol → { priceUsd, marketCap, volume24h })
+    // #104 B2: priceUsd=0 인 row 는 맵에 넣지 않음 — 조용한 0 값 차단.
+    //         호출자는 paprika 누락을 "데이터 없음(0)" 으로 깔끔하게 처리.
+    const paprikaMap = new Map();
+    for (const coin of paprikaData) {
+      if (!coin.symbol) continue;
+      const priceUsd  = coin.quotes?.USD?.price ?? 0;
+      const marketCap = coin.quotes?.USD?.market_cap ?? 0;
+      const volume24h = coin.quotes?.USD?.volume_24h ?? 0;
+      if (priceUsd <= 0) continue;
+      paprikaMap.set(coin.symbol.toUpperCase(), { priceUsd, marketCap, volume24h });
+    }
+
+    // Upbit/Bithumb 티커 → 통합 형태 변환
     const items = tickers.map((t) => {
       const symbol = t.market.replace('KRW-', '');
       const paprika = paprikaMap.get(symbol) || {};
 
-      // 변동률: Upbit signed_change_rate은 소수 (0.05 = 5%)
+      // 변동률: Upbit/Bithumb 정규화된 signed_change_rate 는 소수 (0.05 = 5%)
       const change24h = (t.signed_change_rate ?? 0) * 100;
 
       return {
@@ -111,16 +182,17 @@ export default async function handler(request) {
         market: 'coin',
         priceKrw: t.trade_price ?? 0,
         change24h: parseFloat(change24h.toFixed(2)),
-        // CoinPaprika 보강 데이터
+        // CoinPaprika 보강 데이터 (없으면 0)
         priceUsd: paprika.priceUsd ?? 0,
         marketCap: paprika.marketCap ?? 0,
         volume24h: paprika.volume24h ?? 0,
-        // Upbit 추가 데이터
+        // Upbit/Bithumb 추가 데이터
         accTradePrice24h: t.acc_trade_price_24h ?? 0,
         highPrice: t.high_price ?? 0,
         lowPrice: t.low_price ?? 0,
       };
     });
+    console.log(`[update-coins] 저장: ${items.length}개 (source=${tickerSource}, paprika=${paprikaMap.size})`);
 
     // Redis 저장
     if (items.length > 0) {

--- a/api/cron/update-coins.js
+++ b/api/cron/update-coins.js
@@ -204,14 +204,18 @@ export default async function handler(request) {
     // CoinPaprika 심볼 매핑 (symbol → { priceUsd, marketCap, volume24h })
     // #104 B2: priceUsd=0 인 row 는 맵에 넣지 않음 — 조용한 0 값 차단.
     //         호출자는 paprika 누락을 "데이터 없음(0)" 으로 깔끔하게 처리.
+    // #104 Codex: 동일 티커 중복(다른 프로젝트가 같은 심볼) 시 시가총액 큰 쪽을
+    //            유지. paprika 는 market cap 내림차순 정렬이므로 first-wins 로 충분.
     const paprikaMap = new Map();
     for (const coin of paprikaData) {
       if (!coin.symbol) continue;
+      const key = coin.symbol.toUpperCase();
+      if (paprikaMap.has(key)) continue; // 먼저 들어온(=더 큰 시총) row 유지
       const priceUsd  = coin.quotes?.USD?.price ?? 0;
       const marketCap = coin.quotes?.USD?.market_cap ?? 0;
       const volume24h = coin.quotes?.USD?.volume_24h ?? 0;
       if (priceUsd <= 0) continue;
-      paprikaMap.set(coin.symbol.toUpperCase(), { priceUsd, marketCap, volume24h });
+      paprikaMap.set(key, { priceUsd, marketCap, volume24h });
     }
 
     // Upbit/Bithumb 티커 → 통합 형태 변환

--- a/api/cron/update-coins.js
+++ b/api/cron/update-coins.js
@@ -8,6 +8,19 @@ export const config = { runtime: 'edge' };
 
 import { SNAP_KEYS, SNAP_TTL, setSnap, recordCronFailure } from '../_price-cache.js';
 
+// #104 Opus: Upbit markets 전량 실패 + Bithumb fallback 경로에서도 최소한의 한글명 보장.
+// 라이브 Upbit 한글명 매핑을 1-off 로 추출 (Top 40 KRW 마켓).
+const COIN_KR_NAMES_FALLBACK = {
+  BTC: '비트코인', ETH: '이더리움', XRP: '리플', SOL: '솔라나', DOGE: '도지코인',
+  ADA: '에이다', AVAX: '아발란체', DOT: '폴카닷', TRX: '트론', LINK: '체인링크',
+  MATIC: '폴리곤', NEAR: '니어프로토콜', BCH: '비트코인캐시', LTC: '라이트코인', SHIB: '시바이누',
+  ATOM: '코스모스', UNI: '유니스왑', XLM: '스텔라루멘', ETC: '이더리움클래식', FIL: '파일코인',
+  APT: '앱토스', ARB: '아비트럼', OP: '옵티미즘', STX: '스택스', HBAR: '헤데라',
+  SUI: '수이', TIA: '셀레스티아', INJ: '인젝티브', SEI: '세이', PYTH: '피스네트워크',
+  JUP: '주피터', IMX: '이뮤터블엑스', RNDR: '렌더토큰', GRT: '더그래프', AAVE: '에이브',
+  SAND: '샌드박스', MANA: '디센트럴랜드', AXS: '엑시인피니티', APE: '에이프코인', GMT: '스테픈',
+};
+
 // Upbit 전종목 KRW 마켓 목록 조회
 async function fetchUpbitMarkets() {
   const res = await fetch('https://api.upbit.com/v1/market/all?isDetails=false', {
@@ -53,6 +66,12 @@ async function fetchUpbitTickers(markets) {
 // #104 B4: Bithumb REST fallback — Upbit 완전 실패 시만 호출
 // 응답 스키마: { status, data: { BTC: {...}, ETH: {...}, ..., date: "..." } }
 // Upbit 티커 포맷으로 정규화하여 동일 파이프라인에 흘려보냄.
+//
+// ⚠️ 변동률 의미 주의 (#104 Opus 리뷰):
+//   - Upbit `signed_change_rate` = (현재가 - 전일 종가) / 전일 종가 → 24h 기준
+//   - Bithumb `opening_price`    = 00:00 KST 기준 일일 시가 (일중 리셋)
+//   직접 (close-open)/open 을 쓰면 "24h 변동률" 이 "일중 변동률" 로 의미가 바뀐다.
+//   Bithumb 는 `fluctate_rate_24H` 필드(24h 변동률, %, 문자열)를 제공하므로 이쪽을 사용.
 async function fetchBithumbTickers() {
   const res = await fetch('https://api.bithumb.com/public/ticker/ALL_KRW', {
     headers: { Accept: 'application/json' },
@@ -65,15 +84,23 @@ async function fetchBithumbTickers() {
   }
   const tickers = [];
   for (const [symbol, row] of Object.entries(json.data)) {
-    if (symbol === 'date' || !row || typeof row !== 'object') continue;
+    // non-coin 필드(`date` 등) 방어: closing_price 존재 여부를 primary gate 로.
+    if (!row || typeof row !== 'object' || row.closing_price == null) continue;
     const close = parseFloat(row.closing_price);
-    const open  = parseFloat(row.opening_price);
     if (!Number.isFinite(close) || close <= 0) continue;
-    const changeRate = open > 0 ? (close - open) / open : 0;
+    // 24h 변동률: fluctate_rate_24H(%) 우선, 없으면 prev_closing_price 기반 계산.
+    let changeRate = 0;
+    const rate24H = parseFloat(row.fluctate_rate_24H);
+    if (Number.isFinite(rate24H)) {
+      changeRate = rate24H / 100; // Upbit 와 동일하게 0.05 = 5%
+    } else {
+      const prev = parseFloat(row.prev_closing_price);
+      if (prev > 0) changeRate = (close - prev) / prev;
+    }
     tickers.push({
       market: `KRW-${symbol}`,
       trade_price: close,
-      signed_change_rate: changeRate, // -0.05 ~ +0.05 형태로 Upbit 호환
+      signed_change_rate: changeRate,
       acc_trade_price_24h: parseFloat(row.acc_trade_value_24H) || 0,
       high_price: parseFloat(row.max_price) || 0,
       low_price:  parseFloat(row.min_price) || 0,
@@ -85,10 +112,11 @@ async function fetchBithumbTickers() {
 }
 
 // CoinPaprika 글로벌 시세 조회 (USD + KRW)
-// #104 B2: limit 100 → 500 으로 상향해 Upbit KRW 244 개 전부 커버.
+// #104 B2: limit 100 → 300 으로 상향해 Upbit KRW 244 개 커버 (+ 마진).
+// 500 은 과다 → rate limit 소진 가속 우려 (Opus 리뷰).
 // 실패·부분응답은 호출자가 처리.
 async function fetchCoinPaprika() {
-  const res = await fetch('https://api.coinpaprika.com/v1/tickers?limit=500&quotes=KRW,USD', {
+  const res = await fetch('https://api.coinpaprika.com/v1/tickers?limit=300&quotes=KRW,USD', {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(10000),
   });
@@ -115,7 +143,8 @@ export default async function handler(request) {
       fetchUpbitMarkets(),
       fetchCoinPaprika(),
     ]);
-    const markets = marketsRes.status === 'fulfilled' ? marketsRes.value : null;
+    // `let` — 아래 Bithumb fallback 분기에서 markets 재시도 가능.
+    let markets = marketsRes.status === 'fulfilled' ? marketsRes.value : null;
     const paprikaData = paprikaRes.status === 'fulfilled' ? paprikaRes.value : [];
     if (marketsRes.status === 'rejected') {
       console.warn('[update-coins] Upbit markets 실패:', marketsRes.reason?.message);
@@ -134,6 +163,8 @@ export default async function handler(request) {
         console.warn('[update-coins] Upbit ticker 전종목 실패, Bithumb fallback 시도:', e.message);
         tickers = null;
       }
+    } else {
+      console.warn('[update-coins] Upbit markets 없음 — Bithumb fallback 으로 진행');
     }
     if (!tickers || tickers.length === 0) {
       try {
@@ -146,12 +177,27 @@ export default async function handler(request) {
     }
 
     // 마켓 이름 매핑 (market code → korean_name)
-    // Bithumb fallback 경로에는 markets 가 없을 수 있어 기본값으로 symbol 노출.
+    // #104 Opus 리뷰: Bithumb fallback 경로에서도 한글명 노출을 위해 markets
+    // 호출을 한 번 더 재시도 (보통 markets 는 ticker 보다 훨씬 가벼워 두 번째 시도 성공률 높음).
+    // 그래도 실패하면 static COIN_KR_NAMES 로 주요 코인만 커버.
+    if (!markets) {
+      try {
+        markets = await fetchUpbitMarkets();
+        console.log('[update-coins] Upbit markets 재시도 성공 — 한글명 주입');
+      } catch (e) {
+        console.warn('[update-coins] Upbit markets 재시도 실패, static 한글명 map 사용:', e.message);
+      }
+    }
     const nameMap = new Map();
     if (markets) {
       for (const m of markets) {
         nameMap.set(m.market, m.korean_name || m.english_name || m.market);
       }
+    }
+    // static fallback: 주요 상위 코인 한글명 (markets 전부 실패 시 최소 커버리지)
+    for (const [sym, kr] of Object.entries(COIN_KR_NAMES_FALLBACK)) {
+      const key = `KRW-${sym}`;
+      if (!nameMap.has(key)) nameMap.set(key, kr);
     }
 
     // CoinPaprika 심볼 매핑 (symbol → { priceUsd, marketCap, volume24h })

--- a/api/cron/update-coins.js
+++ b/api/cron/update-coins.js
@@ -2,8 +2,14 @@
 // Upbit REST (primary) → Bithumb REST (fallback), CoinPaprika 병렬 보강.
 // #104 B1/B2/B4 수정:
 //   B1 — Promise.all 단일 실패점 → allSettled 로 부분 성공 허용
-//   B2 — CoinPaprika limit=100 → 500 + priceUsd=0 필터링
+//   B2 — CoinPaprika limit=100 → 300 + priceUsd=0 필터링
 //   B4 — Upbit ticker 전종목 실패 시 Bithumb public/ticker/ALL_KRW fallback
+//
+// 타임아웃 예산 (Edge runtime 기본 30s maxDuration):
+//   Phase 1: markets(5s) || paprika(4s) 병렬 → ~5s
+//   Phase 2: upbit tickers chunks(6s) 병렬   → ~6s
+//   Phase 3: bithumb(10s) — Phase 2 전부 실패시에만 실행 → 최대 +10s
+//   Worst case (primary 타임아웃 후 fallback): ~5 + 6 + 10 = ~21s < 30s
 export const config = { runtime: 'edge' };
 
 import { SNAP_KEYS, SNAP_TTL, setSnap, recordCronFailure } from '../_price-cache.js';
@@ -40,8 +46,8 @@ async function fetchUpbitMarkets(timeoutMs = 5000) {
 const TICKER_BATCH_SIZE = 100;
 
 async function fetchUpbitTickers(markets, timeoutMs = 6000) {
-  // #104 Codex P1: Edge runtime 10s 총 예산 — primary 10s 타임아웃이면
-  // Bithumb fallback 에 쓸 시간이 0 이 됨. 6s 로 타이트하게.
+  // #104 Codex P1: 청크 병렬 실행이라 상한은 6s. 남은 ~24s 중 10s 를 Bithumb
+  // fallback 에 할당하고 나머지는 Phase 4 의 파이프라인 처리에 사용.
   const chunks = [];
   for (let i = 0; i < markets.length; i += TICKER_BATCH_SIZE) {
     chunks.push(markets.slice(i, i + TICKER_BATCH_SIZE));

--- a/api/cron/update-us.js
+++ b/api/cron/update-us.js
@@ -101,12 +101,15 @@ async function getSymbolList() {
     collected = { symbols: [], mcMap: {} };
   }
   // #104 Opus: 임계값 일관성 — 100 미만이면 의심스러운 수집이라 판단하고
-  //           legacy/FALLBACK 중 더 나은 쪽을 사용. 캐시 저장 기준(>100)과 통일.
-  if (collected.symbols.length >= 100 && redis) {
-    try {
-      await redis.set(SYMBOL_LIST_KEY, collected, { ex: SYMBOL_LIST_TTL });
-      console.log(`[update-us] 종목 리스트 갱신: ${collected.symbols.length}개 (marketCap 포함) → Redis 캐시`);
-    } catch (_) { /* 저장 실패해도 진행 */ }
+  //           legacy/FALLBACK 중 더 나은 쪽을 사용. 캐시 저장 기준(>=100)과 통일.
+  //           Redis 미구성 환경(로컬 등) 에서도 수집 성공 시 그대로 반환 (버그 수정).
+  if (collected.symbols.length >= 100) {
+    if (redis) {
+      try {
+        await redis.set(SYMBOL_LIST_KEY, collected, { ex: SYMBOL_LIST_TTL });
+        console.log(`[update-us] 종목 리스트 갱신: ${collected.symbols.length}개 (marketCap 포함) → Redis 캐시`);
+      } catch (_) { /* 저장 실패해도 진행 */ }
+    }
     return collected;
   }
 

--- a/api/cron/update-us.js
+++ b/api/cron/update-us.js
@@ -100,25 +100,25 @@ async function getSymbolList() {
     console.warn('[update-us] NASDAQ 수집 실패:', e.message);
     collected = { symbols: [], mcMap: {} };
   }
-  if (collected.symbols.length > 100 && redis) {
+  // #104 Opus: 임계값 일관성 — 100 미만이면 의심스러운 수집이라 판단하고
+  //           legacy/FALLBACK 중 더 나은 쪽을 사용. 캐시 저장 기준(>100)과 통일.
+  if (collected.symbols.length >= 100 && redis) {
     try {
       await redis.set(SYMBOL_LIST_KEY, collected, { ex: SYMBOL_LIST_TTL });
       console.log(`[update-us] 종목 리스트 갱신: ${collected.symbols.length}개 (marketCap 포함) → Redis 캐시`);
     } catch (_) { /* 저장 실패해도 진행 */ }
+    return collected;
   }
 
-  // NASDAQ API 실패 시:
-  //   1) 구형 캐시(array)가 남아 있으면 그걸 사용 (coverage 보존, 다음 cron 에서 재시도)
-  //   2) 그것도 없으면 하드코딩 FALLBACK_SYMBOLS 122개
-  if (collected.symbols.length < 50) {
-    if (legacyArrayCache) {
-      console.warn('[update-us] NASDAQ 실패 — 구형 array 캐시로 fallback');
-      return { symbols: legacyArrayCache, mcMap: {} };
-    }
-    console.warn('[update-us] NASDAQ API 수집 부족 — 하드코딩 fallback');
-    return { symbols: FALLBACK_SYMBOLS, mcMap: {} };
+  // NASDAQ 수집 결과가 100 미만 (장애/레이트리밋/타임아웃):
+  //   1) 구형 캐시(array)가 남아 있으면 coverage 보존
+  //   2) 없으면 FALLBACK_SYMBOLS 122개
+  if (legacyArrayCache) {
+    console.warn(`[update-us] NASDAQ 수집 부족(${collected.symbols.length}) — 구형 array 캐시 사용`);
+    return { symbols: legacyArrayCache, mcMap: {} };
   }
-  return collected;
+  console.warn(`[update-us] NASDAQ 수집 부족(${collected.symbols.length}) — 하드코딩 FALLBACK_SYMBOLS`);
+  return { symbols: FALLBACK_SYMBOLS, mcMap: {} };
 }
 
 // 하드코딩 fallback (기존 122개)
@@ -168,9 +168,10 @@ async function fetchYahooV8Single(symbol, timeoutMs = 10000, mcMap = null) {
   const resolvedSymbol = meta.symbol?.split('.')[0] ?? symbol;
   // #104 B3: Yahoo chart API 는 marketCap 을 돌려주지 않으므로 NASDAQ 수집값을 merge.
   //          meta.marketCap 은 거의 항상 undefined → 기존 fallback 은 전부 0 이었음.
-  //          `??` 를 써야 mcMap 의 0 을 "데이터 없음" 으로 의도적으로 구분할 수 있다.
-  const mcFromNasdaq = mcMap ? (mcMap[resolvedSymbol] ?? mcMap[symbol]) : undefined;
-  const marketCap = mcFromNasdaq ?? meta.marketCap ?? 0;
+  //          NASDAQ 은 시총 순 정렬이라 상위 1000 내에 0 인 종목이 극소수지만,
+  //          있다면 "누락값" 으로 간주하고 Yahoo meta 로 넘어가도록 `||` 사용.
+  const mcFromNasdaq = mcMap ? (mcMap[resolvedSymbol] || mcMap[symbol]) : 0;
+  const marketCap = mcFromNasdaq || meta.marketCap || 0;
   return {
     symbol: resolvedSymbol,
     price: parseFloat(price.toFixed(2)),

--- a/api/cron/update-us.js
+++ b/api/cron/update-us.js
@@ -70,6 +70,7 @@ async function fetchNasdaqSymbols(limit = 1000) {
 // Redis에서 종목 리스트 + marketCap 맵 가져오기 (없으면 NASDAQ API 호출 후 캐시)
 // 반환: { symbols: string[], mcMap: Record<symbol, number> }
 async function getSymbolList() {
+  let legacyArrayCache = null;
   if (redis) {
     try {
       const cached = await redis.get(SYMBOL_LIST_KEY);
@@ -79,11 +80,11 @@ async function getSymbolList() {
         return { symbols: cached.symbols, mcMap: cached.mcMap || {} };
       }
       // 구형 캐시 (plain array) — rollout 과도기 호환.
-      // marketCap 맵은 없지만 symbol 리스트 자체는 유효하므로 그대로 재사용.
-      // NASDAQ 재수집이 성공하면 다음 cron 호출에서 새 형식으로 자동 갱신됨.
+      // 여기서 즉시 return 하면 새 형식으로 갱신이 24h(TTL) 지연되므로,
+      // 폴백 변수로 보관만 하고 NASDAQ 재수집을 시도한다 (#104 Opus 리뷰).
       if (Array.isArray(cached) && cached.length > 100) {
-        console.log('[update-us] 구형 array 캐시 호환 사용 (marketCap=0, 다음 갱신 시 교체)');
-        return { symbols: cached, mcMap: {} };
+        console.log('[update-us] 구형 array 캐시 감지 → NASDAQ 재수집 시도 (성공 시 새 형식으로 교체)');
+        legacyArrayCache = cached;
       }
     } catch (_) { /* fallback */ }
   }
@@ -106,8 +107,14 @@ async function getSymbolList() {
     } catch (_) { /* 저장 실패해도 진행 */ }
   }
 
-  // NASDAQ API 실패 시 하드코딩 fallback (marketCap 없음)
+  // NASDAQ API 실패 시:
+  //   1) 구형 캐시(array)가 남아 있으면 그걸 사용 (coverage 보존, 다음 cron 에서 재시도)
+  //   2) 그것도 없으면 하드코딩 FALLBACK_SYMBOLS 122개
   if (collected.symbols.length < 50) {
+    if (legacyArrayCache) {
+      console.warn('[update-us] NASDAQ 실패 — 구형 array 캐시로 fallback');
+      return { symbols: legacyArrayCache, mcMap: {} };
+    }
     console.warn('[update-us] NASDAQ API 수집 부족 — 하드코딩 fallback');
     return { symbols: FALLBACK_SYMBOLS, mcMap: {} };
   }
@@ -161,7 +168,9 @@ async function fetchYahooV8Single(symbol, timeoutMs = 10000, mcMap = null) {
   const resolvedSymbol = meta.symbol?.split('.')[0] ?? symbol;
   // #104 B3: Yahoo chart API 는 marketCap 을 돌려주지 않으므로 NASDAQ 수집값을 merge.
   //          meta.marketCap 은 거의 항상 undefined → 기존 fallback 은 전부 0 이었음.
-  const marketCap = (mcMap && mcMap[resolvedSymbol]) || (mcMap && mcMap[symbol]) || meta.marketCap || 0;
+  //          `??` 를 써야 mcMap 의 0 을 "데이터 없음" 으로 의도적으로 구분할 수 있다.
+  const mcFromNasdaq = mcMap ? (mcMap[resolvedSymbol] ?? mcMap[symbol]) : undefined;
+  const marketCap = mcFromNasdaq ?? meta.marketCap ?? 0;
   return {
     symbol: resolvedSymbol,
     price: parseFloat(price.toFixed(2)),

--- a/api/cron/update-us.js
+++ b/api/cron/update-us.js
@@ -117,12 +117,15 @@ async function getSymbolList() {
   // NASDAQ 수집 결과가 100 미만 (장애/레이트리밋/타임아웃):
   //   1) 구형 캐시(array)가 남아 있으면 coverage 보존
   //   2) 없으면 FALLBACK_SYMBOLS 122개
+  // #104 Codex: 부분 수집한 mcMap 이 있으면 같이 전달해서 legacy 경로도
+  //           가능한 범위에서 marketCap 복구 (모두 0 으로 떨어지지 않도록).
+  const partialMcMap = collected.mcMap || {};
   if (legacyArrayCache) {
-    console.warn(`[update-us] NASDAQ 수집 부족(${collected.symbols.length}) — 구형 array 캐시 사용`);
-    return { symbols: legacyArrayCache, mcMap: {} };
+    console.warn(`[update-us] NASDAQ 수집 부족(${collected.symbols.length}) — 구형 array 캐시 사용 (부분 mcMap ${Object.keys(partialMcMap).length}건)`);
+    return { symbols: legacyArrayCache, mcMap: partialMcMap };
   }
-  console.warn(`[update-us] NASDAQ 수집 부족(${collected.symbols.length}) — 하드코딩 FALLBACK_SYMBOLS`);
-  return { symbols: FALLBACK_SYMBOLS, mcMap: {} };
+  console.warn(`[update-us] NASDAQ 수집 부족(${collected.symbols.length}) — 하드코딩 FALLBACK_SYMBOLS (부분 mcMap ${Object.keys(partialMcMap).length}건)`);
+  return { symbols: FALLBACK_SYMBOLS, mcMap: partialMcMap };
 }
 
 // 하드코딩 fallback (기존 122개)

--- a/api/cron/update-us.js
+++ b/api/cron/update-us.js
@@ -13,6 +13,9 @@ const SYMBOL_LIST_KEY = 'us:symbols'; // Redis 키
 const SHARD_CURSOR_KEY = 'us:cron:shard'; // 현재 샤드 인덱스
 
 // NASDAQ API에서 시가총액 상위 종목 수집
+// #104 B3: 반환값에 { symbol, marketCap } 맵을 포함시켜 snapshot 까지 전파.
+//          Yahoo v8 chart API 는 marketCap 을 돌려주지 않기 때문에 NASDAQ 수집
+//          단계의 값을 잃어버리면 /api/snapshot us 전종목 marketCap=0 이 된다.
 async function fetchNasdaqSymbols(limit = 1000) {
   const exchanges = ['NASDAQ', 'NYSE', 'AMEX'];
   const allSymbols = [];
@@ -50,48 +53,57 @@ async function fetchNasdaqSymbols(limit = 1000) {
   allSymbols.sort((a, b) => b.marketCap - a.marketCap);
   // 중복 심볼 제거 (GOOG vs GOOGL 등)
   const seen = new Set();
-  const unique = [];
+  const symbols = [];
+  const mcMap = {};
   for (const s of allSymbols) {
     if (seen.has(s.symbol)) continue;
     seen.add(s.symbol);
-    unique.push(s.symbol);
+    symbols.push(s.symbol);
+    mcMap[s.symbol] = s.marketCap;
   }
-  return unique.slice(0, limit);
+  return {
+    symbols: symbols.slice(0, limit),
+    mcMap, // symbol → marketCap (USD)
+  };
 }
 
-// Redis에서 종목 리스트 가져오기 (없으면 NASDAQ API 호출 후 캐시)
+// Redis에서 종목 리스트 + marketCap 맵 가져오기 (없으면 NASDAQ API 호출 후 캐시)
+// 반환: { symbols: string[], mcMap: Record<symbol, number> }
 async function getSymbolList() {
   if (redis) {
     try {
       const cached = await redis.get(SYMBOL_LIST_KEY);
-      if (Array.isArray(cached) && cached.length > 100) return cached;
+      // #104 B3: 새 캐시 형태 {symbols, mcMap} 우선, 구형 array 는 무시하고 갱신.
+      if (cached && typeof cached === 'object' && Array.isArray(cached.symbols) && cached.symbols.length > 100) {
+        return { symbols: cached.symbols, mcMap: cached.mcMap || {} };
+      }
     } catch (_) { /* fallback */ }
   }
 
   // NASDAQ API에서 수집 (총 30초 타임아웃)
-  let symbols = [];
+  let collected = { symbols: [], mcMap: {} };
   try {
-    symbols = await Promise.race([
+    collected = await Promise.race([
       fetchNasdaqSymbols(1000),
       new Promise((_, reject) => setTimeout(() => reject(new Error('NASDAQ API 총 타임아웃')), 30000)),
     ]);
   } catch (e) {
     console.warn('[update-us] NASDAQ 수집 실패:', e.message);
-    symbols = [];
+    collected = { symbols: [], mcMap: {} };
   }
-  if (symbols.length > 100 && redis) {
+  if (collected.symbols.length > 100 && redis) {
     try {
-      await redis.set(SYMBOL_LIST_KEY, symbols, { ex: SYMBOL_LIST_TTL });
-      console.log(`[update-us] 종목 리스트 갱신: ${symbols.length}개 → Redis 캐시`);
+      await redis.set(SYMBOL_LIST_KEY, collected, { ex: SYMBOL_LIST_TTL });
+      console.log(`[update-us] 종목 리스트 갱신: ${collected.symbols.length}개 (marketCap 포함) → Redis 캐시`);
     } catch (_) { /* 저장 실패해도 진행 */ }
   }
 
-  // NASDAQ API 실패 시 하드코딩 fallback
-  if (symbols.length < 50) {
+  // NASDAQ API 실패 시 하드코딩 fallback (marketCap 없음)
+  if (collected.symbols.length < 50) {
     console.warn('[update-us] NASDAQ API 수집 부족 — 하드코딩 fallback');
-    return FALLBACK_SYMBOLS;
+    return { symbols: FALLBACK_SYMBOLS, mcMap: {} };
   }
-  return symbols;
+  return collected;
 }
 
 // 하드코딩 fallback (기존 122개)
@@ -115,7 +127,7 @@ const YAHOO_HOSTS = ['query1.finance.yahoo.com', 'query2.finance.yahoo.com'];
 let _hostIdx = 0;
 function nextHost() { return YAHOO_HOSTS[(_hostIdx++) % YAHOO_HOSTS.length]; }
 
-async function fetchYahooV8Single(symbol, timeoutMs = 10000) {
+async function fetchYahooV8Single(symbol, timeoutMs = 10000, mcMap = null) {
   const host = nextHost();
   const url = `https://${host}/v8/finance/chart/${symbol}?interval=1d&range=5d&includePrePost=false`;
   const res = await fetch(url, {
@@ -138,26 +150,30 @@ async function fetchYahooV8Single(symbol, timeoutMs = 10000) {
     }
   }
   if (!prev) prev = price;
+  const resolvedSymbol = meta.symbol?.split('.')[0] ?? symbol;
+  // #104 B3: Yahoo chart API 는 marketCap 을 돌려주지 않으므로 NASDAQ 수집값을 merge.
+  //          meta.marketCap 은 거의 항상 undefined → 기존 fallback 은 전부 0 이었음.
+  const marketCap = (mcMap && mcMap[resolvedSymbol]) || (mcMap && mcMap[symbol]) || meta.marketCap || 0;
   return {
-    symbol: meta.symbol?.split('.')[0] ?? symbol,
+    symbol: resolvedSymbol,
     price: parseFloat(price.toFixed(2)),
     change: parseFloat((price - prev).toFixed(2)),
     changePct: prev > 0 ? parseFloat(((price - prev) / prev * 100).toFixed(2)) : 0,
     volume: meta.regularMarketVolume ?? 0,
-    marketCap: meta.marketCap ?? 0,
+    marketCap,
     name: meta.shortName || meta.longName || symbol,
     market: 'us',
   };
 }
 
 // 동시성 제한 배치 실행
-async function fetchBatch(symbols, timeoutMs = 10000) {
+async function fetchBatch(symbols, timeoutMs = 10000, mcMap = null) {
   const results = [];
   const failed = [];
   for (let i = 0; i < symbols.length; i += CONCURRENCY) {
     const chunk = symbols.slice(i, i + CONCURRENCY);
     const settled = await Promise.allSettled(
-      chunk.map(sym => fetchYahooV8Single(sym, timeoutMs))
+      chunk.map(sym => fetchYahooV8Single(sym, timeoutMs, mcMap))
     );
     for (let j = 0; j < settled.length; j++) {
       if (settled[j].status === 'fulfilled') results.push(settled[j].value);
@@ -181,8 +197,8 @@ export default async function handler(request) {
   }
 
   try {
-    // 1. 종목 리스트 가져오기
-    const allSymbols = await getSymbolList();
+    // 1. 종목 리스트 + marketCap 맵 가져오기 (#104 B3)
+    const { symbols: allSymbols, mcMap } = await getSymbolList();
     const totalShards = Math.ceil(allSymbols.length / SHARD_SIZE);
 
     // 2. 현재 샤드 커서 읽기
@@ -199,15 +215,15 @@ export default async function handler(request) {
     const shardSymbols = allSymbols.slice(start, start + SHARD_SIZE);
     console.log(`[update-us] 샤드 ${shard}/${totalShards - 1} (${shardSymbols.length}개, 전체 ${allSymbols.length}개)`);
 
-    // 4. Yahoo v8로 가격 조회
-    const { results: firstResults, failed } = await fetchBatch(shardSymbols);
+    // 4. Yahoo v8로 가격 조회 (#104 B3: NASDAQ mcMap 을 함께 전파)
+    const { results: firstResults, failed } = await fetchBatch(shardSymbols, 10000, mcMap);
 
     // 5. 실패분 재시도 (50% 미만일 때만)
     let retryResults = [];
     const failRatio = failed.length / shardSymbols.length;
     if (failed.length > 0 && failRatio < 0.5) {
       console.log(`[update-us] 재시도: ${failed.length}개`);
-      const { results: retried } = await fetchBatch(failed, 12000);
+      const { results: retried } = await fetchBatch(failed, 12000, mcMap);
       retryResults = retried;
     }
 

--- a/api/cron/update-us.js
+++ b/api/cron/update-us.js
@@ -73,9 +73,17 @@ async function getSymbolList() {
   if (redis) {
     try {
       const cached = await redis.get(SYMBOL_LIST_KEY);
-      // #104 B3: 새 캐시 형태 {symbols, mcMap} 우선, 구형 array 는 무시하고 갱신.
-      if (cached && typeof cached === 'object' && Array.isArray(cached.symbols) && cached.symbols.length > 100) {
+      // #104 B3: 새 캐시 형태 {symbols, mcMap} 우선.
+      if (cached && typeof cached === 'object' && !Array.isArray(cached)
+          && Array.isArray(cached.symbols) && cached.symbols.length > 100) {
         return { symbols: cached.symbols, mcMap: cached.mcMap || {} };
+      }
+      // 구형 캐시 (plain array) — rollout 과도기 호환.
+      // marketCap 맵은 없지만 symbol 리스트 자체는 유효하므로 그대로 재사용.
+      // NASDAQ 재수집이 성공하면 다음 cron 호출에서 새 형식으로 자동 갱신됨.
+      if (Array.isArray(cached) && cached.length > 100) {
+        console.log('[update-us] 구형 array 캐시 호환 사용 (marketCap=0, 다음 갱신 시 교체)');
+        return { symbols: cached, mcMap: {} };
       }
     } catch (_) { /* fallback */ }
   }

--- a/api/cron/update-us.js
+++ b/api/cron/update-us.js
@@ -75,14 +75,15 @@ async function getSymbolList() {
     try {
       const cached = await redis.get(SYMBOL_LIST_KEY);
       // #104 B3: 새 캐시 형태 {symbols, mcMap} 우선.
+      // 임계값 저장(>=100)과 통일해서 정확히 100개일 때도 캐시 재사용.
       if (cached && typeof cached === 'object' && !Array.isArray(cached)
-          && Array.isArray(cached.symbols) && cached.symbols.length > 100) {
+          && Array.isArray(cached.symbols) && cached.symbols.length >= 100) {
         return { symbols: cached.symbols, mcMap: cached.mcMap || {} };
       }
       // 구형 캐시 (plain array) — rollout 과도기 호환.
       // 여기서 즉시 return 하면 새 형식으로 갱신이 24h(TTL) 지연되므로,
       // 폴백 변수로 보관만 하고 NASDAQ 재수집을 시도한다 (#104 Opus 리뷰).
-      if (Array.isArray(cached) && cached.length > 100) {
+      if (Array.isArray(cached) && cached.length >= 100) {
         console.log('[update-us] 구형 array 캐시 감지 → NASDAQ 재수집 시도 (성공 시 새 형식으로 교체)');
         legacyArrayCache = cached;
       }


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Codex gate (OpenAI)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #104

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **개선 사항**
  * 암호화폐 가격 데이터 소스를 다중화하여 정보 가용성 및 신뢰성 강화
  * 미국 주식 데이터에 시가총액(Market Cap) 정보 포함으로 분석 기능 확대
  * 데이터 수집 실패 시 자동 폴백 메커니즘으로 서비스 안정성 및 가동 시간 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->