### PR TITLE
fix: stabilize home dashboard market widgets

### DIFF
--- a/src/components/SurgeBanner.jsx
+++ b/src/components/SurgeBanner.jsx
@@ -147,78 +147,80 @@ const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], indices
         </span>
       </div>
 
-      {/* ticker track */}
-      <div className="ticker-track" style={{ '--dur': `${dur}s` }}>
-        {items.map((item, i) => {
-          // afterHours 표시: 정규장 외 시간에 시간외 데이터가 있을 때
-          const showAfterHours = item.afterHoursPrice != null && item.afterHoursPct != null;
-          const displayPct     = showAfterHours ? item.afterHoursPct : item.pct;
-          const isUp           = displayPct > 0;
-          const isDown         = displayPct < 0;
+      <div className="flex-1 min-w-0 overflow-hidden">
+        {/* ticker track */}
+        <div className="ticker-track" style={{ '--dur': `${dur}s` }}>
+          {items.map((item, i) => {
+            // afterHours 표시: 정규장 외 시간에 시간외 데이터가 있을 때
+            const showAfterHours = item.afterHoursPrice != null && item.afterHoursPct != null;
+            const displayPct     = showAfterHours ? item.afterHoursPct : item.pct;
+            const isUp           = displayPct > 0;
+            const isDown         = displayPct < 0;
 
-          return (
-            <button
-              key={`${i}-${item.symbol}`}
-              type="button"
-              className="inline-flex items-center gap-1.5 px-3 h-full cursor-pointer transition-opacity hover:opacity-70 focus:outline-none bg-transparent border-0"
-              onClick={() => item._raw && onClick?.(item._raw)}
-            >
-              {/* 시장 컬러 도트 */}
-              <span
-                className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                style={{ background: MARKET_DOT[item.market] ?? C.dotIdleSolid }}
-              />
-
-              {/* 종목명 (국내는 이름, 해외/코인은 심볼) */}
-              <span
-                className="text-[11px] font-bold tracking-tight"
-                style={{ color: C.symbolText }}
+            return (
+              <button
+                key={`${i}-${item.symbol}`}
+                type="button"
+                className="inline-flex items-center gap-1.5 px-3 h-full cursor-pointer transition-opacity hover:opacity-70 focus:outline-none bg-transparent border-0 whitespace-nowrap"
+                onClick={() => item._raw && onClick?.(item._raw)}
               >
-                {item.market === 'kr' ? (item.name || item.symbol) : item.symbol}
-              </span>
-
-              {/* 지수 모드: 지수 값 */}
-              {item._value > 0 && (
+                {/* 시장 컬러 도트 */}
                 <span
-                  className="text-[11px] font-mono tabular-nums"
-                  style={{ color: C.valueText }}
-                >
-                  {item._value >= 1000
-                    ? item._value.toLocaleString('ko-KR', { maximumFractionDigits: 0 })
-                    : item._value.toFixed(2)}
-                </span>
-              )}
+                  className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                  style={{ background: MARKET_DOT[item.market] ?? C.dotIdleSolid }}
+                />
 
-              {/* 시간외 배지 */}
-              {showAfterHours && (
+                {/* 종목명 (국내는 이름, 해외/코인은 심볼) */}
                 <span
-                  className="text-[9px] font-semibold px-1 rounded"
-                  style={{
-                    background: C.afterHoursBg,
-                    color: C.afterHoursText,
-                    letterSpacing: '0.04em',
-                  }}
+                  className="text-[11px] font-bold tracking-tight"
+                  style={{ color: C.symbolText }}
                 >
-                  시간외
+                  {item.market === 'kr' ? (item.name || item.symbol) : item.symbol}
                 </span>
-              )}
 
-              {/* 등락률 */}
-              <span
-                className="text-[11px] font-semibold tabular-nums font-mono"
-                style={{ color: isUp ? C.pctUp : isDown ? C.pctDown : C.pctFlat }}
-              >
-                {isUp ? '+' : ''}{displayPct.toFixed(2)}%
-              </span>
+                {/* 지수 모드: 지수 값 */}
+                {item._value > 0 && (
+                  <span
+                    className="text-[11px] font-mono tabular-nums"
+                    style={{ color: C.valueText }}
+                  >
+                    {item._value >= 1000
+                      ? item._value.toLocaleString('ko-KR', { maximumFractionDigits: 0 })
+                      : item._value.toFixed(2)}
+                  </span>
+                )}
 
-              {/* 구분선 */}
-              <span
-                className="w-px h-3 flex-shrink-0 ml-1"
-                style={{ background: C.separator }}
-              />
-            </button>
-          );
-        })}
+                {/* 시간외 배지 */}
+                {showAfterHours && (
+                  <span
+                    className="text-[9px] font-semibold px-1 rounded"
+                    style={{
+                      background: C.afterHoursBg,
+                      color: C.afterHoursText,
+                      letterSpacing: '0.04em',
+                    }}
+                  >
+                    시간외
+                  </span>
+                )}
+
+                {/* 등락률 */}
+                <span
+                  className="text-[11px] font-semibold tabular-nums font-mono"
+                  style={{ color: isUp ? C.pctUp : isDown ? C.pctDown : C.pctFlat }}
+                >
+                  {isUp ? '+' : ''}{displayPct.toFixed(2)}%
+                </span>
+
+                {/* 구분선 */}
+                <span
+                  className="w-px h-3 flex-shrink-0 ml-1"
+                  style={{ background: C.separator }}
+                />
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/components/home/CommandCenterWidget.jsx
+++ b/src/components/home/CommandCenterWidget.jsx
@@ -2,7 +2,7 @@
 import { useMemo } from 'react';
 import { useSignals, useTopSignals } from '../../hooks/useSignals';
 import { useFearGreed } from '../../hooks/useFearGreed';
-import { calcTemperature, calcFallbackTemperature } from '../../utils/temperature';
+import { calcTemperature, calcFallbackTemperature, mergeTemperature } from '../../utils/temperature';
 import { extractName, getEasyLabel } from '../../utils/signalLabel';
 import { TYPE_META } from '../../engine/signalTypes';
 import MarketIndexSection from './MarketIndexSection';
@@ -28,8 +28,7 @@ function TemperatureBar({ indices, krwRate, allItems }) {
   const fallback = useMemo(() => calcFallbackTemperature(allItems), [allItems]);
   const { crypto, us, kr } = useFearGreed();
 
-  const isFallback = temp.count === 0;
-  const displayTemp = isFallback && fallback ? { ...temp, score: fallback.score, label: fallback.label } : temp;
+  const displayTemp = useMemo(() => mergeTemperature(temp, fallback), [temp, fallback]);
   const zone = ZONE[displayTemp.label] || ZONE['중립'];
   const gaugeWidth = Math.round(((displayTemp.score + 1) / 2) * 100);
 
@@ -50,6 +49,11 @@ function TemperatureBar({ indices, krwRate, allItems }) {
         <span className="text-[13px] font-bold flex-shrink-0" style={{ color: zone.text }}>
           {displayTemp.label} {gaugeWidth}%
         </span>
+        {displayTemp.source === 'blended' && (
+          <span className="text-[11px] font-medium flex-shrink-0 text-[#8B95A1]">
+            실시간 보정
+          </span>
+        )}
         {fgScore != null && (
           <span className="text-[12px] font-semibold flex-shrink-0 px-2.5 py-0.5 rounded-xl" style={{ background: 'rgba(255,149,0,0.06)', color: '#FF9500' }}>
             탐욕 {fgScore}
@@ -266,7 +270,8 @@ function WatchlistMini({ watchedItems, popularItems, toggle, onItemClick }) {
                   className="flex-shrink-0 flex items-center gap-1.5 px-2.5 py-1.5 rounded-full border border-[#F2F3F5] cursor-pointer hover:bg-[#F2F4F6] transition-colors"
                   onClick={() => onItemClick?.(item)}
                 >
-                  <span className="text-[11px] font-semibold text-[#191F28] whitespace-nowrap">{item.name?.slice(0, 6)}</span>
+                  <TickerLogo item={item} size={18} />
+                  <span className="text-[11px] font-semibold text-[#191F28] whitespace-nowrap max-w-[96px] truncate">{item.name || item.symbol}</span>
                   <span className="text-[10px] font-bold tabular-nums font-mono whitespace-nowrap" style={{ color }}>
                     {isUp ? '+' : ''}{(Number.isFinite(pct) ? pct : 0).toFixed(1)}%
                   </span>

--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -49,9 +49,17 @@ export default function SignalBoardWidget({ onItemClick }) {
   // 통합 리스트: 모든 시그널 (세력 포착 포함)
   const combinedList = useMemo(() => {
     const all = [...bullSignals, ...bearSignals, ...neutralSignals];
-    // 강도순 재정렬
-    all.sort((a, b) => (b.strength || 0) - (a.strength || 0));
-    return all;
+    all.sort((a, b) => (b.strength || 0) - (a.strength || 0) || (b.timestamp || 0) - (a.timestamp || 0));
+
+    const deduped = [];
+    const seen = new Set();
+    for (const signal of all) {
+      const dedupeKey = signal.symbol || `${signal.market || 'meta'}:${signal.type}:${signal.name || signal.label || ''}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      deduped.push(signal);
+    }
+    return deduped;
   }, [bullSignals, bearSignals, neutralSignals]);
 
   const displayList = expanded ? combinedList : combinedList.slice(0, 5);

--- a/src/components/home/TickerLogo.jsx
+++ b/src/components/home/TickerLogo.jsx
@@ -1,5 +1,5 @@
 // 공통 종목 로고 컴포넌트 — getLogoUrls fallback 체인 + 이니셜 아바타
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { getLogoUrls, getAvatarBg } from './utils';
 
 /**
@@ -7,9 +7,11 @@ import { getLogoUrls, getAvatarBg } from './utils';
  * size: px 단위 (기본 24)
  */
 export default function TickerLogo({ item, size = 24 }) {
-  const logoUrls = getLogoUrls(item);
-  const [logoIdx, setLogoIdx] = useState(0);
+  const logoUrls = useMemo(() => getLogoUrls(item), [item]);
   const bg = getAvatarBg(item.symbol);
+  const logoKey = `${item.id || ''}:${item.symbol || ''}:${item.image || ''}:${item._market || item.market || ''}`;
+  const [logoState, setLogoState] = useState(() => ({ key: logoKey, idx: 0 }));
+  const logoIdx = logoState.key === logoKey ? logoState.idx : 0;
 
   const sizeStyle = { width: size, height: size, minWidth: size, minHeight: size };
   const fontSize = Math.max(8, Math.round(size * 0.375));
@@ -19,7 +21,12 @@ export default function TickerLogo({ item, size = 24 }) {
       <img
         src={logoUrls[logoIdx]}
         alt={item.symbol}
-        onError={() => setLogoIdx(i => i + 1)}
+        onError={() => {
+          setLogoState(prev => ({
+            key: logoKey,
+            idx: (prev.key === logoKey ? prev.idx : 0) + 1,
+          }));
+        }}
         className="rounded-full object-contain bg-white border border-[#F2F4F6] p-0.5 flex-shrink-0"
         style={sizeStyle}
       />

--- a/src/components/home/utils.js
+++ b/src/components/home/utils.js
@@ -83,6 +83,29 @@ export function getAvatarBg(symbol) {
   return PALETTE[Math.abs((symbol || '').split('').reduce((h, c) => c.charCodeAt(0) + ((h << 5) - h), 0)) % PALETTE.length] || '#8B95A1';
 }
 
+const COIN_PAPRIKA_IDS = {
+  BTC: 'btc-bitcoin',
+  ETH: 'eth-ethereum',
+  XRP: 'xrp-xrp',
+  SOL: 'sol-solana',
+  DOGE: 'doge-dogecoin',
+  ADA: 'ada-cardano',
+  BNB: 'bnb-binance-coin',
+  AVAX: 'avax-avalanche',
+  DOT: 'dot-polkadot',
+  LINK: 'link-chainlink',
+  TON: 'ton-toncoin',
+  TRX: 'trx-tron',
+  BCH: 'bch-bitcoin-cash',
+  LTC: 'ltc-litecoin',
+  SHIB: 'shib-shiba-inu',
+  UNI: 'uni-uniswap',
+  ATOM: 'atom-cosmos',
+  ETC: 'etc-ethereum-classic',
+  XLM: 'xlm-stellar',
+  HBAR: 'hbar-hedera-hashgraph',
+};
+
 // ─── 종목/코인 로고 URL fallback 체인 ─────────────────────────
 // 반환: [url1, url2, ...] — 순서대로 시도, 모두 실패 시 이니셜 아바타
 export function getLogoUrls(item) {
@@ -90,10 +113,13 @@ export function getLogoUrls(item) {
   const market = item._market || (item.market === 'coin' ? 'COIN' : item.market === 'kr' ? 'KR' : item.market === 'us' ? 'US' : '');
 
   if (market === 'COIN' || item.id) {
-    // 코인: CoinGecko → CoinCap → cryptocurrency-icons
+    // 코인: 원본 이미지 → CoinPaprika → CoinCap → cryptocurrency-icons
     const urls = [];
     if (item.image) urls.push(item.image);
+    const paprikaId = item.id?.includes('-') ? item.id : COIN_PAPRIKA_IDS[sym.toUpperCase()];
+    if (paprikaId) urls.push(`https://static.coinpaprika.com/coin/${paprikaId}/logo.png`);
     urls.push(`https://assets.coincap.io/assets/icons/${sym.toLowerCase()}@2x.png`);
+    urls.push(`https://cdn.jsdelivr.net/gh/spothq/cryptocurrency-icons@master/128/color/${sym.toLowerCase()}.png`);
     urls.push(`https://raw.githubusercontent.com/spothq/cryptocurrency-icons/master/128/color/${sym.toLowerCase()}.png`);
     return urls;
   }

--- a/src/components/home/widgets/MarketSentimentWidget.jsx
+++ b/src/components/home/widgets/MarketSentimentWidget.jsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from 'react';
 import { useSignals } from '../../../hooks/useSignals';
 import { useFearGreed, getFgColor } from '../../../hooks/useFearGreed';
 import { TYPE_META } from '../../../engine/signalTypes';
-import { calcTemperature, calcFallbackTemperature } from '../../../utils/temperature';
+import { calcTemperature, calcFallbackTemperature, mergeTemperature } from '../../../utils/temperature';
 
 // ── 게이지 존 스타일 (5단계) ──
 const ZONE = {
@@ -75,9 +75,7 @@ export default function MarketSentimentWidget({ allItems = [] }) {
   const fallback = useMemo(() => calcFallbackTemperature(allItems), [allItems]);
   const { crypto, us, kr } = useFearGreed();
 
-  // 시그널 0건일 때 가격 기반 fallback 사용 여부
-  const isFallback = temp.count === 0;
-  const displayTemp = isFallback && fallback ? { ...temp, score: fallback.score, label: fallback.label } : temp;
+  const displayTemp = useMemo(() => mergeTemperature(temp, fallback), [temp, fallback]);
   const zone = ZONE[displayTemp.label] || ZONE['중립'];
   const message = MESSAGE_MAP[displayTemp.label] || MESSAGE_MAP['중립'];
   const gaugeWidth = Math.round(((displayTemp.score + 1) / 2) * 100);
@@ -96,7 +94,7 @@ export default function MarketSentimentWidget({ allItems = [] }) {
   }, [signals]);
 
   // 시그널 0건 + fallback도 없으면 스켈레톤
-  if (isFallback && !fallback) {
+  if (temp.count === 0 && !fallback) {
     return (
       <div
         data-testid="market-sentiment"
@@ -135,7 +133,7 @@ export default function MarketSentimentWidget({ allItems = [] }) {
 
       {/* 한 줄 해석 */}
       <p className="text-[13px] font-medium text-[#333D4B] mb-3">
-        "{isFallback ? '시그널 수집 중... 가격 기준 임시 온도에요' : message}"
+        "{displayTemp.source !== 'signals' ? '시그널과 가격 흐름을 함께 반영한 온도에요' : message}"
       </p>
 
       {/* 게이지 바 */}

--- a/src/index.css
+++ b/src/index.css
@@ -151,6 +151,9 @@
   .ticker-wrap { overflow: hidden; }
   .ticker-track {
     display: inline-flex;
+    width: max-content;
+    white-space: nowrap;
+    will-change: transform;
     animation: ticker var(--dur, 40s) linear infinite;
   }
   .ticker-track:hover { animation-play-state: paused; }

--- a/src/utils/temperature.js
+++ b/src/utils/temperature.js
@@ -1,46 +1,148 @@
 // 시장 온도 계산 유틸리티 — MarketSentimentWidget에서 추출
 import { getPct } from '../components/home/utils';
 
+function labelFromScore(score, { directionalCount = 0, recentDirectionalCount = 0 } = {}) {
+  const hasModerateCoverage = directionalCount >= 4;
+  const hasStrongCoverage = directionalCount >= 8 && recentDirectionalCount >= 3;
+
+  if (score <= -0.6) return hasStrongCoverage ? '강한 경계' : '약세 우위';
+  if (score <= -0.22) return hasModerateCoverage ? '약세 우위' : '중립';
+  if (score < 0.22) return '중립';
+  if (score < 0.6) return hasModerateCoverage ? '강세 징후' : '중립';
+  return hasStrongCoverage ? '강한 강세' : '강세 징후';
+}
+
 // ── 시그널 기반 온도 계산 ──
 export function calcTemperature(signals) {
-  if (!signals.length) return { score: 0, label: '중립', count: 0, bullCount: 0, bearCount: 0, neutralCount: 0 };
-  let bullWeight = 0, bearWeight = 0, neutralCount = 0;
-  for (const sig of signals) {
-    const w = sig.strength || 1;
-    if (sig.direction === 'bullish') bullWeight += w;
-    else if (sig.direction === 'bearish') bearWeight += w;
-    else neutralCount++;
+  if (!signals.length) {
+    return {
+      score: 0,
+      label: '중립',
+      count: 0,
+      bullCount: 0,
+      bearCount: 0,
+      neutralCount: 0,
+      directionalCount: 0,
+      recentDirectionalCount: 0,
+      freshness: 0,
+      latestSignalAt: null,
+    };
   }
+
+  const now = Date.now();
+  const recentWindowMs = 3 * 60 * 1000;
+  let bullWeight = 0;
+  let bearWeight = 0;
+  let neutralCount = 0;
+  let bullCount = 0;
+  let bearCount = 0;
+  let directionalCount = 0;
+  let recentDirectionalCount = 0;
+  let freshnessSum = 0;
+  let latestSignalAt = 0;
+
+  for (const sig of signals) {
+    const createdAt = sig.timestamp ?? now;
+    const ttl = Math.max(1, (sig.expiresAt ?? now) - createdAt);
+    const age = Math.max(0, now - createdAt);
+    const freshness = Math.max(0.35, 1 - (age / ttl) * 0.65);
+    const weight = (sig.strength || 1) * freshness;
+
+    latestSignalAt = Math.max(latestSignalAt, createdAt);
+    freshnessSum += freshness;
+
+    if (sig.direction === 'bullish') {
+      bullWeight += weight;
+      bullCount++;
+      directionalCount++;
+      if (age <= recentWindowMs) recentDirectionalCount++;
+    } else if (sig.direction === 'bearish') {
+      bearWeight += weight;
+      bearCount++;
+      directionalCount++;
+      if (age <= recentWindowMs) recentDirectionalCount++;
+    } else {
+      neutralCount++;
+    }
+  }
+
   const total = bullWeight + bearWeight;
-  const score = total === 0 ? 0 : (bullWeight - bearWeight) / total;
-  // 시그널 5개 미만이면 극단 라벨 방지 — 최대 "중립"까지만 허용
-  // (부팅 시드 3개만으로 "강한 강세" 표시 방지)
-  const hasEnoughSignals = signals.length >= 5;
-  let label;
-  if (score <= -0.5) label = hasEnoughSignals ? '강한 경계' : '중립';
-  else if (score <= -0.15) label = hasEnoughSignals ? '약세 우위' : '중립';
-  else if (score < 0.15) label = '중립';
-  else if (score < 0.5) label = hasEnoughSignals ? '강세 징후' : '중립';
-  else label = hasEnoughSignals ? '강한 강세' : '중립';
-  return { score, label, count: signals.length,
-    bullCount: signals.filter(s => s.direction === 'bullish').length,
-    bearCount: signals.filter(s => s.direction === 'bearish').length,
-    neutralCount };
+  const rawScore = total === 0 ? 0 : (bullWeight - bearWeight) / total;
+  const coverage = Math.min(1, directionalCount / 8);
+  const recency = Math.min(1, recentDirectionalCount / 4);
+  const confidence = directionalCount === 0 ? 0 : Math.max(0.3, (coverage * 0.65) + (recency * 0.35));
+  const score = rawScore * confidence;
+  const label = labelFromScore(score, { directionalCount, recentDirectionalCount });
+
+  return {
+    score,
+    rawScore,
+    label,
+    count: signals.length,
+    bullCount,
+    bearCount,
+    neutralCount,
+    directionalCount,
+    recentDirectionalCount,
+    freshness: signals.length ? freshnessSum / signals.length : 0,
+    latestSignalAt: latestSignalAt || null,
+  };
 }
 
 // ── 가격 기반 fallback 온도 계산 ──
 export function calcFallbackTemperature(allItems) {
   if (!allItems?.length) return null;
-  const pcts = allItems.map(i => getPct(i)).filter(p => !isNaN(p));
-  if (!pcts.length) return null;
-  const avg = pcts.reduce((a, b) => a + b, 0) / pcts.length;
-  // 평균 등락률을 -1 ~ +1 스코어로 변환 (+-5% 기준 클램핑)
-  const score = Math.max(-1, Math.min(1, avg / 5));
-  let label;
-  if (score <= -0.5) label = '강한 경계';
-  else if (score <= -0.15) label = '약세 우위';
-  else if (score < 0.15) label = '중립';
-  else if (score < 0.5) label = '강세 징후';
-  else label = '강한 강세';
-  return { score, label, avgPct: avg };
+  const groups = { KR: [], US: [], COIN: [] };
+
+  for (const item of allItems) {
+    const pct = getPct(item);
+    if (!Number.isFinite(pct)) continue;
+    const market = item._market || (item.id || item.market === 'coin' ? 'COIN' : item.market === 'kr' ? 'KR' : item.market === 'us' ? 'US' : null);
+    if (market && groups[market]) groups[market].push(pct);
+  }
+
+  const activeMarkets = Object.entries(groups).filter(([, values]) => values.length > 0);
+  if (!activeMarkets.length) return null;
+
+  const marketScores = activeMarkets.map(([market, values]) => {
+    const sorted = [...values].sort((a, b) => a - b);
+    const trim = sorted.length >= 8 ? Math.floor(sorted.length * 0.15) : 0;
+    const trimmed = trim > 0 ? sorted.slice(trim, sorted.length - trim) : sorted;
+    const avg = trimmed.reduce((sum, value) => sum + value, 0) / trimmed.length;
+    const score = Math.max(-1, Math.min(1, avg / 3.5));
+    return { market, avgPct: avg, score, count: values.length };
+  });
+
+  const score = marketScores.reduce((sum, market) => sum + market.score, 0) / marketScores.length;
+  const avgPct = marketScores.reduce((sum, market) => sum + market.avgPct, 0) / marketScores.length;
+  const label = labelFromScore(score, {
+    directionalCount: marketScores.length * 3,
+    recentDirectionalCount: marketScores.length * 2,
+  });
+
+  return { score, label, avgPct, marketScores };
+}
+
+export function mergeTemperature(signalTemp, fallbackTemp) {
+  if (!fallbackTemp) return { ...signalTemp, source: 'signals' };
+  if (!signalTemp?.count) return { ...fallbackTemp, count: 0, source: 'fallback' };
+
+  const directionalCount = signalTemp.directionalCount ?? 0;
+  const recentDirectionalCount = signalTemp.recentDirectionalCount ?? 0;
+  const shouldBlend = directionalCount < 6 || recentDirectionalCount < 3;
+  if (!shouldBlend) return { ...signalTemp, source: 'signals' };
+
+  const signalWeight = directionalCount < 4 ? 0.4 : 0.6;
+  const fallbackWeight = 1 - signalWeight;
+  const score = (signalTemp.score * signalWeight) + (fallbackTemp.score * fallbackWeight);
+  const label = labelFromScore(score, { directionalCount, recentDirectionalCount });
+
+  return {
+    ...signalTemp,
+    score,
+    label,
+    fallbackScore: fallbackTemp.score,
+    fallbackLabel: fallbackTemp.label,
+    source: 'blended',
+  };
 }


### PR DESCRIPTION
## 요약
- 상단 검정 롤링 배너의 viewport/track 구조를 안정화해 레이아웃이 깨지지 않도록 수정했습니다.
- 시장온도 계산에 시그널 최신성, 표본 수 보정과 시장별 가격 fallback/blended 표시를 추가해 과한 강세 표시와 지연을 줄였습니다.
- 관심종목 모바일 이름 잘림, 시그널보드 동일 심볼 중복, 코인 로고 fallback 불안정을 함께 정리했습니다.

## 문제
- 상단 롤링 배너가 일부 환경에서 정상적으로 노출되지 않았습니다.
- 시장온도가 실제 체감보다 강세/강한 강세로 치우치고 갱신도 늦는 경우가 있었습니다.
- 관심종목 이름이 모바일에서 과하게 잘렸습니다.
- 시그널보드에서 동일 코인이 중복 노출되거나 BTC/ETH 등 코인 로고가 불안정했습니다.

## 변경 사항
- SurgeBanner에 전용 overflow viewport를 추가하고 ticker-track 스타일을 보강했습니다.
- src/utils/temperature.js에서 freshness, directional coverage, recent signal 수를 반영한 점수 계산으로 조정했습니다.
- 가격 fallback을 KR/US/COIN 시장별 trimmed 평균 기반으로 바꾸고, 시그널이 부족하거나 늦을 때 blended 표시를 하도록 했습니다.
- 관심종목 모바일 칩에서 고정 길이 잘림을 제거하고 로고를 함께 노출했습니다.
- TickerLogo의 상태 재사용 문제를 정리하고 CoinPaprika 기반 코인 로고 fallback 체인을 추가했습니다.
- 시그널보드는 동일 심볼 기준 대표 시그널만 보여주도록 dedupe했습니다.

## QA
- npm run build 통과
- npm run test 통과 (39 passed)
- npm run lint 실패: 저장소 전반의 기존 lint 오류/경고 66건으로 실패했고, 이번 수정 범위만의 신규 block으로 보긴 어렵습니다.
- npm run review:code 실행: artifact 생성, VERDICT: PASS 확인

Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시장 감정 데이터 실시간 보정 기능 추가
  * 코인 로고 소스 확대 (CoinPaprika, jsDelivr 추가)

* **개선 사항**
  * 티커 디스플레이 레이아웃 및 스타일 최적화
  * 지표판 신호 중복 제거 및 정렬 개선
  * 감시 목록에 회사 로고 및 이름 표시 추강
  * 로고 로딩 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->