### PR TITLE
fix: stabilize home dashboard market widgets

### DIFF
--- a/src/components/SurgeBanner.jsx
+++ b/src/components/SurgeBanner.jsx
@@ -148,7 +148,7 @@ const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], indices
       </div>
 
       <div className="flex-1 min-w-0 overflow-hidden">
-        {/* ticker track */}
+        {/* 티커 이동 영역 */}
         <div className="ticker-track" style={{ '--dur': `${dur}s` }}>
           {items.map((item, i) => {
             // afterHours 표시: 정규장 외 시간에 시간외 데이터가 있을 때

--- a/src/components/SurgeBanner.jsx
+++ b/src/components/SurgeBanner.jsx
@@ -147,78 +147,80 @@ const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], indices
         </span>
       </div>
 
-      {/* ticker track */}
-      <div className="ticker-track" style={{ '--dur': `${dur}s` }}>
-        {items.map((item, i) => {
-          // afterHours 표시: 정규장 외 시간에 시간외 데이터가 있을 때
-          const showAfterHours = item.afterHoursPrice != null && item.afterHoursPct != null;
-          const displayPct     = showAfterHours ? item.afterHoursPct : item.pct;
-          const isUp           = displayPct > 0;
-          const isDown         = displayPct < 0;
+      <div className="flex-1 min-w-0 overflow-hidden">
+        {/* ticker track */}
+        <div className="ticker-track" style={{ '--dur': `${dur}s` }}>
+          {items.map((item, i) => {
+            // afterHours 표시: 정규장 외 시간에 시간외 데이터가 있을 때
+            const showAfterHours = item.afterHoursPrice != null && item.afterHoursPct != null;
+            const displayPct     = showAfterHours ? item.afterHoursPct : item.pct;
+            const isUp           = displayPct > 0;
+            const isDown         = displayPct < 0;
 
-          return (
-            <button
-              key={`${i}-${item.symbol}`}
-              type="button"
-              className="inline-flex items-center gap-1.5 px-3 h-full cursor-pointer transition-opacity hover:opacity-70 focus:outline-none bg-transparent border-0"
-              onClick={() => item._raw && onClick?.(item._raw)}
-            >
-              {/* 시장 컬러 도트 */}
-              <span
-                className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                style={{ background: MARKET_DOT[item.market] ?? C.dotIdleSolid }}
-              />
-
-              {/* 종목명 (국내는 이름, 해외/코인은 심볼) */}
-              <span
-                className="text-[11px] font-bold tracking-tight"
-                style={{ color: C.symbolText }}
+            return (
+              <button
+                key={`${i}-${item.symbol}`}
+                type="button"
+                className="inline-flex items-center gap-1.5 px-3 h-full cursor-pointer transition-opacity hover:opacity-70 focus:outline-none bg-transparent border-0 whitespace-nowrap"
+                onClick={() => item._raw && onClick?.(item._raw)}
               >
-                {item.market === 'kr' ? (item.name || item.symbol) : item.symbol}
-              </span>
-
-              {/* 지수 모드: 지수 값 */}
-              {item._value > 0 && (
+                {/* 시장 컬러 도트 */}
                 <span
-                  className="text-[11px] font-mono tabular-nums"
-                  style={{ color: C.valueText }}
-                >
-                  {item._value >= 1000
-                    ? item._value.toLocaleString('ko-KR', { maximumFractionDigits: 0 })
-                    : item._value.toFixed(2)}
-                </span>
-              )}
+                  className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                  style={{ background: MARKET_DOT[item.market] ?? C.dotIdleSolid }}
+                />
 
-              {/* 시간외 배지 */}
-              {showAfterHours && (
+                {/* 종목명 (국내는 이름, 해외/코인은 심볼) */}
                 <span
-                  className="text-[9px] font-semibold px-1 rounded"
-                  style={{
-                    background: C.afterHoursBg,
-                    color: C.afterHoursText,
-                    letterSpacing: '0.04em',
-                  }}
+                  className="text-[11px] font-bold tracking-tight"
+                  style={{ color: C.symbolText }}
                 >
-                  시간외
+                  {item.market === 'kr' ? (item.name || item.symbol) : item.symbol}
                 </span>
-              )}
 
-              {/* 등락률 */}
-              <span
-                className="text-[11px] font-semibold tabular-nums font-mono"
-                style={{ color: isUp ? C.pctUp : isDown ? C.pctDown : C.pctFlat }}
-              >
-                {isUp ? '+' : ''}{displayPct.toFixed(2)}%
-              </span>
+                {/* 지수 모드: 지수 값 */}
+                {item._value > 0 && (
+                  <span
+                    className="text-[11px] font-mono tabular-nums"
+                    style={{ color: C.valueText }}
+                  >
+                    {item._value >= 1000
+                      ? item._value.toLocaleString('ko-KR', { maximumFractionDigits: 0 })
+                      : item._value.toFixed(2)}
+                  </span>
+                )}
 
-              {/* 구분선 */}
-              <span
-                className="w-px h-3 flex-shrink-0 ml-1"
-                style={{ background: C.separator }}
-              />
-            </button>
-          );
-        })}
+                {/* 시간외 배지 */}
+                {showAfterHours && (
+                  <span
+                    className="text-[9px] font-semibold px-1 rounded"
+                    style={{
+                      background: C.afterHoursBg,
+                      color: C.afterHoursText,
+                      letterSpacing: '0.04em',
+                    }}
+                  >
+                    시간외
+                  </span>
+                )}
+
+                {/* 등락률 */}
+                <span
+                  className="text-[11px] font-semibold tabular-nums font-mono"
+                  style={{ color: isUp ? C.pctUp : isDown ? C.pctDown : C.pctFlat }}
+                >
+                  {isUp ? '+' : ''}{displayPct.toFixed(2)}%
+                </span>
+
+                {/* 구분선 */}
+                <span
+                  className="w-px h-3 flex-shrink-0 ml-1"
+                  style={{ background: C.separator }}
+                />
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/components/home/CommandCenterWidget.jsx
+++ b/src/components/home/CommandCenterWidget.jsx
@@ -2,7 +2,7 @@
 import { useMemo } from 'react';
 import { useSignals, useTopSignals } from '../../hooks/useSignals';
 import { useFearGreed } from '../../hooks/useFearGreed';
-import { calcTemperature, calcFallbackTemperature } from '../../utils/temperature';
+import { calcTemperature, calcFallbackTemperature, mergeTemperature } from '../../utils/temperature';
 import { extractName, getEasyLabel } from '../../utils/signalLabel';
 import { TYPE_META } from '../../engine/signalTypes';
 import MarketIndexSection from './MarketIndexSection';
@@ -28,8 +28,7 @@ function TemperatureBar({ indices, krwRate, allItems }) {
   const fallback = useMemo(() => calcFallbackTemperature(allItems), [allItems]);
   const { crypto, us, kr } = useFearGreed();
 
-  const isFallback = temp.count === 0;
-  const displayTemp = isFallback && fallback ? { ...temp, score: fallback.score, label: fallback.label } : temp;
+  const displayTemp = useMemo(() => mergeTemperature(temp, fallback), [temp, fallback]);
   const zone = ZONE[displayTemp.label] || ZONE['중립'];
   const gaugeWidth = Math.round(((displayTemp.score + 1) / 2) * 100);
 
@@ -50,6 +49,11 @@ function TemperatureBar({ indices, krwRate, allItems }) {
         <span className="text-[13px] font-bold flex-shrink-0" style={{ color: zone.text }}>
           {displayTemp.label} {gaugeWidth}%
         </span>
+        {displayTemp.source === 'blended' && (
+          <span className="text-[11px] font-medium flex-shrink-0 text-[#8B95A1]">
+            실시간 보정
+          </span>
+        )}
         {fgScore != null && (
           <span className="text-[12px] font-semibold flex-shrink-0 px-2.5 py-0.5 rounded-xl" style={{ background: 'rgba(255,149,0,0.06)', color: '#FF9500' }}>
             탐욕 {fgScore}
@@ -266,7 +270,8 @@ function WatchlistMini({ watchedItems, popularItems, toggle, onItemClick }) {
                   className="flex-shrink-0 flex items-center gap-1.5 px-2.5 py-1.5 rounded-full border border-[#F2F3F5] cursor-pointer hover:bg-[#F2F4F6] transition-colors"
                   onClick={() => onItemClick?.(item)}
                 >
-                  <span className="text-[11px] font-semibold text-[#191F28] whitespace-nowrap">{item.name?.slice(0, 6)}</span>
+                  <TickerLogo item={item} size={18} />
+                  <span className="text-[11px] font-semibold text-[#191F28] whitespace-nowrap max-w-[96px] truncate">{item.name || item.symbol}</span>
                   <span className="text-[10px] font-bold tabular-nums font-mono whitespace-nowrap" style={{ color }}>
                     {isUp ? '+' : ''}{(Number.isFinite(pct) ? pct : 0).toFixed(1)}%
                   </span>

--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -49,9 +49,17 @@ export default function SignalBoardWidget({ onItemClick }) {
   // 통합 리스트: 모든 시그널 (세력 포착 포함)
   const combinedList = useMemo(() => {
     const all = [...bullSignals, ...bearSignals, ...neutralSignals];
-    // 강도순 재정렬
-    all.sort((a, b) => (b.strength || 0) - (a.strength || 0));
-    return all;
+    all.sort((a, b) => (b.strength || 0) - (a.strength || 0) || (b.timestamp || 0) - (a.timestamp || 0));
+
+    const deduped = [];
+    const seen = new Set();
+    for (const signal of all) {
+      const dedupeKey = signal.symbol || `${signal.market || 'meta'}:${signal.type}:${signal.name || signal.label || ''}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      deduped.push(signal);
+    }
+    return deduped;
   }, [bullSignals, bearSignals, neutralSignals]);
 
   const displayList = expanded ? combinedList : combinedList.slice(0, 5);

--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -50,16 +50,7 @@ export default function SignalBoardWidget({ onItemClick }) {
   const combinedList = useMemo(() => {
     const all = [...bullSignals, ...bearSignals, ...neutralSignals];
     all.sort((a, b) => (b.strength || 0) - (a.strength || 0) || (b.timestamp || 0) - (a.timestamp || 0));
-
-    const deduped = [];
-    const seen = new Set();
-    for (const signal of all) {
-      const dedupeKey = signal.symbol || `${signal.market || 'meta'}:${signal.type}:${signal.name || signal.label || ''}`;
-      if (seen.has(dedupeKey)) continue;
-      seen.add(dedupeKey);
-      deduped.push(signal);
-    }
-    return deduped;
+    return all;
   }, [bullSignals, bearSignals, neutralSignals]);
 
   const displayList = expanded ? combinedList : combinedList.slice(0, 5);

--- a/src/components/home/TickerLogo.jsx
+++ b/src/components/home/TickerLogo.jsx
@@ -1,5 +1,5 @@
 // 공통 종목 로고 컴포넌트 — getLogoUrls fallback 체인 + 이니셜 아바타
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { getLogoUrls, getAvatarBg } from './utils';
 
 /**
@@ -7,9 +7,11 @@ import { getLogoUrls, getAvatarBg } from './utils';
  * size: px 단위 (기본 24)
  */
 export default function TickerLogo({ item, size = 24 }) {
-  const logoUrls = getLogoUrls(item);
-  const [logoIdx, setLogoIdx] = useState(0);
+  const logoUrls = useMemo(() => getLogoUrls(item), [item]);
   const bg = getAvatarBg(item.symbol);
+  const logoKey = `${item.id || ''}:${item.symbol || ''}:${item.image || ''}:${item._market || item.market || ''}`;
+  const [logoState, setLogoState] = useState(() => ({ key: logoKey, idx: 0 }));
+  const logoIdx = logoState.key === logoKey ? logoState.idx : 0;
 
   const sizeStyle = { width: size, height: size, minWidth: size, minHeight: size };
   const fontSize = Math.max(8, Math.round(size * 0.375));
@@ -19,7 +21,12 @@ export default function TickerLogo({ item, size = 24 }) {
       <img
         src={logoUrls[logoIdx]}
         alt={item.symbol}
-        onError={() => setLogoIdx(i => i + 1)}
+        onError={() => {
+          setLogoState(prev => ({
+            key: logoKey,
+            idx: (prev.key === logoKey ? prev.idx : 0) + 1,
+          }));
+        }}
         className="rounded-full object-contain bg-white border border-[#F2F4F6] p-0.5 flex-shrink-0"
         style={sizeStyle}
       />

--- a/src/components/home/utils.js
+++ b/src/components/home/utils.js
@@ -116,7 +116,10 @@ export function getLogoUrls(item) {
     // 코인: 원본 이미지 → CoinPaprika → CoinCap → cryptocurrency-icons
     const urls = [];
     if (item.image) urls.push(item.image);
-    const paprikaId = item.id?.includes('-') ? item.id : COIN_PAPRIKA_IDS[sym.toUpperCase()];
+    const normalizedSymbol = sym.toLowerCase();
+    const paprikaId = item.id?.toLowerCase()?.startsWith(`${normalizedSymbol}-`)
+      ? item.id
+      : COIN_PAPRIKA_IDS[sym.toUpperCase()];
     if (paprikaId) urls.push(`https://static.coinpaprika.com/coin/${paprikaId}/logo.png`);
     urls.push(`https://assets.coincap.io/assets/icons/${sym.toLowerCase()}@2x.png`);
     urls.push(`https://cdn.jsdelivr.net/gh/spothq/cryptocurrency-icons@master/128/color/${sym.toLowerCase()}.png`);

--- a/src/components/home/utils.js
+++ b/src/components/home/utils.js
@@ -83,6 +83,29 @@ export function getAvatarBg(symbol) {
   return PALETTE[Math.abs((symbol || '').split('').reduce((h, c) => c.charCodeAt(0) + ((h << 5) - h), 0)) % PALETTE.length] || '#8B95A1';
 }
 
+const COIN_PAPRIKA_IDS = {
+  BTC: 'btc-bitcoin',
+  ETH: 'eth-ethereum',
+  XRP: 'xrp-xrp',
+  SOL: 'sol-solana',
+  DOGE: 'doge-dogecoin',
+  ADA: 'ada-cardano',
+  BNB: 'bnb-binance-coin',
+  AVAX: 'avax-avalanche',
+  DOT: 'dot-polkadot',
+  LINK: 'link-chainlink',
+  TON: 'ton-toncoin',
+  TRX: 'trx-tron',
+  BCH: 'bch-bitcoin-cash',
+  LTC: 'ltc-litecoin',
+  SHIB: 'shib-shiba-inu',
+  UNI: 'uni-uniswap',
+  ATOM: 'atom-cosmos',
+  ETC: 'etc-ethereum-classic',
+  XLM: 'xlm-stellar',
+  HBAR: 'hbar-hedera-hashgraph',
+};
+
 // ─── 종목/코인 로고 URL fallback 체인 ─────────────────────────
 // 반환: [url1, url2, ...] — 순서대로 시도, 모두 실패 시 이니셜 아바타
 export function getLogoUrls(item) {
@@ -90,10 +113,13 @@ export function getLogoUrls(item) {
   const market = item._market || (item.market === 'coin' ? 'COIN' : item.market === 'kr' ? 'KR' : item.market === 'us' ? 'US' : '');
 
   if (market === 'COIN' || item.id) {
-    // 코인: CoinGecko → CoinCap → cryptocurrency-icons
+    // 코인: 원본 이미지 → CoinPaprika → CoinCap → cryptocurrency-icons
     const urls = [];
     if (item.image) urls.push(item.image);
+    const paprikaId = item.id?.includes('-') ? item.id : COIN_PAPRIKA_IDS[sym.toUpperCase()];
+    if (paprikaId) urls.push(`https://static.coinpaprika.com/coin/${paprikaId}/logo.png`);
     urls.push(`https://assets.coincap.io/assets/icons/${sym.toLowerCase()}@2x.png`);
+    urls.push(`https://cdn.jsdelivr.net/gh/spothq/cryptocurrency-icons@master/128/color/${sym.toLowerCase()}.png`);
     urls.push(`https://raw.githubusercontent.com/spothq/cryptocurrency-icons/master/128/color/${sym.toLowerCase()}.png`);
     return urls;
   }

--- a/src/components/home/widgets/MarketSentimentWidget.jsx
+++ b/src/components/home/widgets/MarketSentimentWidget.jsx
@@ -133,7 +133,9 @@ export default function MarketSentimentWidget({ allItems = [] }) {
 
       {/* 한 줄 해석 */}
       <p className="text-[13px] font-medium text-[#333D4B] mb-3">
-        "{displayTemp.source !== 'signals' ? '시그널과 가격 흐름을 함께 반영한 온도에요' : message}"
+        "{displayTemp.source === 'blended' || displayTemp.source === 'fallback'
+          ? '시그널과 가격 흐름을 함께 반영한 온도에요'
+          : message}"
       </p>
 
       {/* 게이지 바 */}

--- a/src/components/home/widgets/MarketSentimentWidget.jsx
+++ b/src/components/home/widgets/MarketSentimentWidget.jsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from 'react';
 import { useSignals } from '../../../hooks/useSignals';
 import { useFearGreed, getFgColor } from '../../../hooks/useFearGreed';
 import { TYPE_META } from '../../../engine/signalTypes';
-import { calcTemperature, calcFallbackTemperature } from '../../../utils/temperature';
+import { calcTemperature, calcFallbackTemperature, mergeTemperature } from '../../../utils/temperature';
 
 // ── 게이지 존 스타일 (5단계) ──
 const ZONE = {
@@ -75,9 +75,7 @@ export default function MarketSentimentWidget({ allItems = [] }) {
   const fallback = useMemo(() => calcFallbackTemperature(allItems), [allItems]);
   const { crypto, us, kr } = useFearGreed();
 
-  // 시그널 0건일 때 가격 기반 fallback 사용 여부
-  const isFallback = temp.count === 0;
-  const displayTemp = isFallback && fallback ? { ...temp, score: fallback.score, label: fallback.label } : temp;
+  const displayTemp = useMemo(() => mergeTemperature(temp, fallback), [temp, fallback]);
   const zone = ZONE[displayTemp.label] || ZONE['중립'];
   const message = MESSAGE_MAP[displayTemp.label] || MESSAGE_MAP['중립'];
   const gaugeWidth = Math.round(((displayTemp.score + 1) / 2) * 100);
@@ -96,7 +94,7 @@ export default function MarketSentimentWidget({ allItems = [] }) {
   }, [signals]);
 
   // 시그널 0건 + fallback도 없으면 스켈레톤
-  if (isFallback && !fallback) {
+  if (temp.count === 0 && !fallback) {
     return (
       <div
         data-testid="market-sentiment"
@@ -135,7 +133,7 @@ export default function MarketSentimentWidget({ allItems = [] }) {
 
       {/* 한 줄 해석 */}
       <p className="text-[13px] font-medium text-[#333D4B] mb-3">
-        "{isFallback ? '시그널 수집 중... 가격 기준 임시 온도에요' : message}"
+        "{displayTemp.source !== 'signals' ? '시그널과 가격 흐름을 함께 반영한 온도에요' : message}"
       </p>
 
       {/* 게이지 바 */}

--- a/src/index.css
+++ b/src/index.css
@@ -151,6 +151,9 @@
   .ticker-wrap { overflow: hidden; }
   .ticker-track {
     display: inline-flex;
+    width: max-content;
+    white-space: nowrap;
+    will-change: transform;
     animation: ticker var(--dur, 40s) linear infinite;
   }
   .ticker-track:hover { animation-play-state: paused; }

--- a/src/utils/temperature.js
+++ b/src/utils/temperature.js
@@ -120,11 +120,15 @@ export function calcFallbackTemperature(allItems) {
     recentDirectionalCount: marketScores.length * 2,
   });
 
-  return { score, label, avgPct, marketScores };
+  return { score, label, avgPct, marketScores, partial: marketScores.length < 2 };
 }
 
 export function mergeTemperature(signalTemp, fallbackTemp) {
   if (!fallbackTemp) return { ...signalTemp, source: 'signals' };
+  if (fallbackTemp.partial) {
+    if (!signalTemp?.count) return { score: 0, label: '중립', count: 0, source: 'pending' };
+    return { ...signalTemp, source: 'signals' };
+  }
   if (!signalTemp?.count) return { ...fallbackTemp, count: 0, source: 'fallback' };
 
   const directionalCount = signalTemp.directionalCount ?? 0;

--- a/src/utils/temperature.js
+++ b/src/utils/temperature.js
@@ -1,46 +1,148 @@
 // 시장 온도 계산 유틸리티 — MarketSentimentWidget에서 추출
 import { getPct } from '../components/home/utils';
 
+function labelFromScore(score, { directionalCount = 0, recentDirectionalCount = 0 } = {}) {
+  const hasModerateCoverage = directionalCount >= 4;
+  const hasStrongCoverage = directionalCount >= 8 && recentDirectionalCount >= 3;
+
+  if (score <= -0.6) return hasStrongCoverage ? '강한 경계' : '약세 우위';
+  if (score <= -0.22) return hasModerateCoverage ? '약세 우위' : '중립';
+  if (score < 0.22) return '중립';
+  if (score < 0.6) return hasModerateCoverage ? '강세 징후' : '중립';
+  return hasStrongCoverage ? '강한 강세' : '강세 징후';
+}
+
 // ── 시그널 기반 온도 계산 ──
 export function calcTemperature(signals) {
-  if (!signals.length) return { score: 0, label: '중립', count: 0, bullCount: 0, bearCount: 0, neutralCount: 0 };
-  let bullWeight = 0, bearWeight = 0, neutralCount = 0;
-  for (const sig of signals) {
-    const w = sig.strength || 1;
-    if (sig.direction === 'bullish') bullWeight += w;
-    else if (sig.direction === 'bearish') bearWeight += w;
-    else neutralCount++;
+  if (!signals.length) {
+    return {
+      score: 0,
+      label: '중립',
+      count: 0,
+      bullCount: 0,
+      bearCount: 0,
+      neutralCount: 0,
+      directionalCount: 0,
+      recentDirectionalCount: 0,
+      freshness: 0,
+      latestSignalAt: null,
+    };
   }
+
+  const now = Date.now();
+  const recentWindowMs = 3 * 60 * 1000;
+  let bullWeight = 0;
+  let bearWeight = 0;
+  let neutralCount = 0;
+  let bullCount = 0;
+  let bearCount = 0;
+  let directionalCount = 0;
+  let recentDirectionalCount = 0;
+  let freshnessSum = 0;
+  let latestSignalAt = 0;
+
+  for (const sig of signals) {
+    const createdAt = sig.timestamp ?? now;
+    const ttl = Math.max(1, (sig.expiresAt ?? now) - createdAt);
+    const age = Math.max(0, now - createdAt);
+    const freshness = Math.max(0.35, 1 - (age / ttl) * 0.65);
+    const weight = (sig.strength || 1) * freshness;
+
+    latestSignalAt = Math.max(latestSignalAt, createdAt);
+    freshnessSum += freshness;
+
+    if (sig.direction === 'bullish') {
+      bullWeight += weight;
+      bullCount++;
+      directionalCount++;
+      if (age <= recentWindowMs) recentDirectionalCount++;
+    } else if (sig.direction === 'bearish') {
+      bearWeight += weight;
+      bearCount++;
+      directionalCount++;
+      if (age <= recentWindowMs) recentDirectionalCount++;
+    } else {
+      neutralCount++;
+    }
+  }
+
   const total = bullWeight + bearWeight;
-  const score = total === 0 ? 0 : (bullWeight - bearWeight) / total;
-  // 시그널 5개 미만이면 극단 라벨 방지 — 최대 "중립"까지만 허용
-  // (부팅 시드 3개만으로 "강한 강세" 표시 방지)
-  const hasEnoughSignals = signals.length >= 5;
-  let label;
-  if (score <= -0.5) label = hasEnoughSignals ? '강한 경계' : '중립';
-  else if (score <= -0.15) label = hasEnoughSignals ? '약세 우위' : '중립';
-  else if (score < 0.15) label = '중립';
-  else if (score < 0.5) label = hasEnoughSignals ? '강세 징후' : '중립';
-  else label = hasEnoughSignals ? '강한 강세' : '중립';
-  return { score, label, count: signals.length,
-    bullCount: signals.filter(s => s.direction === 'bullish').length,
-    bearCount: signals.filter(s => s.direction === 'bearish').length,
-    neutralCount };
+  const rawScore = total === 0 ? 0 : (bullWeight - bearWeight) / total;
+  const coverage = Math.min(1, directionalCount / 8);
+  const recency = Math.min(1, recentDirectionalCount / 4);
+  const confidence = directionalCount === 0 ? 0 : Math.max(0.3, (coverage * 0.65) + (recency * 0.35));
+  const score = rawScore * confidence;
+  const label = labelFromScore(score, { directionalCount, recentDirectionalCount });
+
+  return {
+    score,
+    rawScore,
+    label,
+    count: signals.length,
+    bullCount,
+    bearCount,
+    neutralCount,
+    directionalCount,
+    recentDirectionalCount,
+    freshness: signals.length ? freshnessSum / signals.length : 0,
+    latestSignalAt: latestSignalAt || null,
+  };
 }
 
 // ── 가격 기반 fallback 온도 계산 ──
 export function calcFallbackTemperature(allItems) {
   if (!allItems?.length) return null;
-  const pcts = allItems.map(i => getPct(i)).filter(p => !isNaN(p));
-  if (!pcts.length) return null;
-  const avg = pcts.reduce((a, b) => a + b, 0) / pcts.length;
-  // 평균 등락률을 -1 ~ +1 스코어로 변환 (+-5% 기준 클램핑)
-  const score = Math.max(-1, Math.min(1, avg / 5));
-  let label;
-  if (score <= -0.5) label = '강한 경계';
-  else if (score <= -0.15) label = '약세 우위';
-  else if (score < 0.15) label = '중립';
-  else if (score < 0.5) label = '강세 징후';
-  else label = '강한 강세';
-  return { score, label, avgPct: avg };
+  const groups = { KR: [], US: [], COIN: [] };
+
+  for (const item of allItems) {
+    const pct = getPct(item);
+    if (!Number.isFinite(pct)) continue;
+    const market = item._market || (item.id || item.market === 'coin' ? 'COIN' : item.market === 'kr' ? 'KR' : item.market === 'us' ? 'US' : null);
+    if (market && groups[market]) groups[market].push(pct);
+  }
+
+  const activeMarkets = Object.entries(groups).filter(([, values]) => values.length > 0);
+  if (!activeMarkets.length) return null;
+
+  const marketScores = activeMarkets.map(([market, values]) => {
+    const sorted = [...values].sort((a, b) => a - b);
+    const trim = sorted.length >= 8 ? Math.floor(sorted.length * 0.15) : 0;
+    const trimmed = trim > 0 ? sorted.slice(trim, sorted.length - trim) : sorted;
+    const avg = trimmed.reduce((sum, value) => sum + value, 0) / trimmed.length;
+    const score = Math.max(-1, Math.min(1, avg / 3.5));
+    return { market, avgPct: avg, score, count: values.length };
+  });
+
+  const score = marketScores.reduce((sum, market) => sum + market.score, 0) / marketScores.length;
+  const avgPct = marketScores.reduce((sum, market) => sum + market.avgPct, 0) / marketScores.length;
+  const label = labelFromScore(score, {
+    directionalCount: marketScores.length * 3,
+    recentDirectionalCount: marketScores.length * 2,
+  });
+
+  return { score, label, avgPct, marketScores };
+}
+
+export function mergeTemperature(signalTemp, fallbackTemp) {
+  if (!fallbackTemp) return { ...signalTemp, source: 'signals' };
+  if (!signalTemp?.count) return { ...fallbackTemp, count: 0, source: 'fallback' };
+
+  const directionalCount = signalTemp.directionalCount ?? 0;
+  const recentDirectionalCount = signalTemp.recentDirectionalCount ?? 0;
+  const shouldBlend = directionalCount < 6 || recentDirectionalCount < 3;
+  if (!shouldBlend) return { ...signalTemp, source: 'signals' };
+
+  const signalWeight = directionalCount < 4 ? 0.4 : 0.6;
+  const fallbackWeight = 1 - signalWeight;
+  const score = (signalTemp.score * signalWeight) + (fallbackTemp.score * fallbackWeight);
+  const label = labelFromScore(score, { directionalCount, recentDirectionalCount });
+
+  return {
+    ...signalTemp,
+    score,
+    label,
+    fallbackScore: fallbackTemp.score,
+    fallbackLabel: fallbackTemp.label,
+    source: 'blended',
+  };
 }

--- a/src/utils/temperature.js
+++ b/src/utils/temperature.js
@@ -1,5 +1,4 @@
 // 시장 온도 계산 유틸리티 — MarketSentimentWidget에서 추출
-import { getPct } from '../components/home/utils';
 
 function labelFromScore(score, { directionalCount = 0, recentDirectionalCount = 0 } = {}) {
   const hasModerateCoverage = directionalCount >= 4;
@@ -95,7 +94,9 @@ export function calcFallbackTemperature(allItems) {
   const groups = { KR: [], US: [], COIN: [] };
 
   for (const item of allItems) {
-    const pct = getPct(item);
+    const isCoin = !!(item.id || item._market === 'COIN' || item.market === 'coin');
+    const rawPct = isCoin ? item.change24h : item.changePct;
+    const pct = Number.isFinite(rawPct) ? rawPct : NaN;
     if (!Number.isFinite(pct)) continue;
     const market = item._market || (item.id || item.market === 'coin' ? 'COIN' : item.market === 'kr' ? 'KR' : item.market === 'us' ? 'US' : null);
     if (market && groups[market]) groups[market].push(pct);


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Codex gate (OpenAI)
- PASS (지적사항 처리: [채택] SignalBoard 심볼 dedupe 제거 / CoinPaprika ID fallback 보정 / partial market fallback blend 차단)

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #107

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시장 심리도에 신호+보정 혼합(실시간 보정) 표시 추가
  * 암호화폐 로고 폴백 소스 확대

* **개선 사항**
  * 신호 정렬 시 동점은 최신순으로 결정되도록 개선
  * 모바일 위시리스트 항목에 로고와 이름 표시 및 폭 제약 적용
  * 티커 트랙 래핑/애니메이션 처리 개선으로 표시 안정성 향상
  * 시장 심리도 계산 로직 및 표현 정확도 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->