### PR TITLE
fix: 시그널 적중률 priceAtFire 누락 수정

### DIFF
--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -44,6 +44,15 @@ export function createSignal({ type, symbol, name, market, direction, strength, 
  * 시그널 추가 — 중복 제거 (같은 type+symbol은 strength 높은 것만 유지)
  * 저장소 최대 100개, 초과 시 오래된 것부터 제거
  */
+// 유효 가격 해석 — 0은 데이터 오류로 간주하고 건너뜀 (#116)
+function _resolvePrice(meta) {
+  const a = meta?.currentPrice;
+  if (a != null && a > 0) return a;
+  const b = meta?.priceKrw;
+  if (b != null && b > 0) return b;
+  return null;
+}
+
 export function addSignal(signal) {
   // 중복 제거: 같은 type+symbol 조합
   const existIdx = _signals.findIndex(
@@ -51,15 +60,16 @@ export function addSignal(signal) {
   );
   if (existIdx !== -1) {
     const existing = _signals[existIdx];
-    const existingPrice = existing.meta?.currentPrice ?? existing.meta?.priceKrw ?? null;
-    const newPrice = signal.meta?.currentPrice ?? signal.meta?.priceKrw ?? null;
-    // 가격 0은 데이터 오류 — 유효 가격으로 인정하지 않음 (BLOCK-2)
+    const existingPrice = _resolvePrice(existing.meta);
+    const newPrice = _resolvePrice(signal.meta);
     const isPriceUpgradeOnly = existing.strength >= signal.strength
-      && existingPrice == null && newPrice != null && newPrice > 0;
+      && existingPrice == null && newPrice != null;
 
     // 가격 업그레이드 케이스 (#116): 가격 필드만 선택적으로 갱신하고
-    // 기존 비즈니스 메타(consecutiveDays, amount 등)는 보존 (BLOCK-1).
+    // 기존 비즈니스 메타(consecutiveDays, amount 등)는 보존.
     // timestamp/expiresAt도 보존하여 UI 튐 방지.
+    // 최초 발화 시 null 가격은 _recordForAccuracy에서 차단되므로, 이번 업그레이드 호출이
+    // 해당 시그널의 첫 적중률 기록이 된다 (이중 집계 없음).
     if (isPriceUpgradeOnly) {
       existing.meta = {
         ...existing.meta,
@@ -143,6 +153,10 @@ function _recordForAccuracy(signal) {
   // symbol 없는 시그널은 적중률 추적 의미 없음 (NEUTRAL도 추적 — stealth activity 등)
   if (!signal.symbol) return;
 
+  // priceAtFire 없으면 기록 보류 — 가격 업그레이드 시 다시 호출돼 최초 기록 생성 (#116)
+  const priceAtFire = _resolvePrice(signal.meta);
+  if (priceAtFire == null) return;
+
   _accuracyBuffer.push({
     type: signal.type,
     symbol: signal.symbol,
@@ -150,7 +164,7 @@ function _recordForAccuracy(signal) {
     direction: signal.direction,
     strength: signal.strength || 1,
     title: signal.title || '',
-    priceAtFire: signal.meta?.currentPrice || signal.meta?.priceKrw || null,
+    priceAtFire,
     meta: { compositeScore: signal.meta?.compositeScore, rsi: signal.meta?.rsi },
   });
 

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -50,7 +50,13 @@ export function addSignal(signal) {
     s => s.type === signal.type && s.symbol === signal.symbol,
   );
   if (existIdx !== -1) {
-    if (_signals[existIdx].strength >= signal.strength) return _signals[existIdx];
+    const existing = _signals[existIdx];
+    // 가격 업그레이드 케이스 (#116): 기존 strength 유지되지만 priceAtFire가 null이고
+    // 새 시그널이 유효 가격을 갖고 있으면 기존을 교체하여 적중률 추적이 완전해지도록 한다.
+    const existingPrice = existing.meta?.currentPrice ?? existing.meta?.priceKrw ?? null;
+    const newPrice = signal.meta?.currentPrice ?? signal.meta?.priceKrw ?? null;
+    const isPriceUpgrade = existingPrice == null && newPrice != null;
+    if (existing.strength >= signal.strength && !isPriceUpgrade) return existing;
     _signals.splice(existIdx, 1);
   }
 

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -49,25 +49,29 @@ export function addSignal(signal) {
   const existIdx = _signals.findIndex(
     s => s.type === signal.type && s.symbol === signal.symbol,
   );
-  // 가격 업그레이드 케이스 (#116): 기존 strength 유지되지만 priceAtFire가 null이고
-  // 새 시그널이 유효 가격을 갖고 있으면 메타만 갱신하여 적중률 추적이 완전해지도록 한다.
-  // 새 row를 삽입하지 않으므로 signal_accuracy가 중복 집계되지 않는다.
-  let isPriceUpgradeOnly = false;
   if (existIdx !== -1) {
     const existing = _signals[existIdx];
     const existingPrice = existing.meta?.currentPrice ?? existing.meta?.priceKrw ?? null;
     const newPrice = signal.meta?.currentPrice ?? signal.meta?.priceKrw ?? null;
-    isPriceUpgradeOnly = existing.strength >= signal.strength
+    const isPriceUpgradeOnly = existing.strength >= signal.strength
       && existingPrice == null && newPrice != null;
-    if (existing.strength >= signal.strength && !isPriceUpgradeOnly) return existing;
+
+    // 가격 업그레이드 케이스 (#116): 기존 meta만 갱신하고 timestamp/expiresAt은 보존.
+    // 적중률 DB에는 재기록하여 이번에 확보한 price_at_fire가 평가 가능하도록 한다.
+    if (isPriceUpgradeOnly) {
+      existing.meta = { ...existing.meta, ...signal.meta };
+      _recordForAccuracy(existing);
+      _notify();
+      return existing;
+    }
+    if (existing.strength >= signal.strength) return existing;
     _signals.splice(existIdx, 1);
   }
 
   _signals.push(signal);
 
   // 적중률 트래킹 — 비동기 fire-and-forget (실패해도 시그널 영향 없음)
-  // 가격만 보강한 경우 중복 집계 방지 위해 재기록하지 않음 (#116)
-  if (!isPriceUpgradeOnly) _recordForAccuracy(signal);
+  _recordForAccuracy(signal);
 
   // 최대 개수 초과 시 오래된 것부터 제거
   if (_signals.length > MAX_SIGNALS) {

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -81,6 +81,15 @@ export function addSignal(signal) {
       return existing;
     }
     if (existing.strength >= signal.strength) return existing;
+    // 더 강한 시그널로 교체 시, 신규가 가격을 못 얻었다면 기존 가격을 승계 (#116)
+    // — null-price guard가 accuracy 기록을 스킵하는 문제 방지.
+    if (newPrice == null && existingPrice != null) {
+      signal.meta = {
+        ...signal.meta,
+        currentPrice: existing.meta?.currentPrice ?? signal.meta?.currentPrice ?? null,
+        priceKrw: existing.meta?.priceKrw ?? signal.meta?.priceKrw ?? null,
+      };
+    }
     _signals.splice(existIdx, 1);
   }
 

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -53,13 +53,19 @@ export function addSignal(signal) {
     const existing = _signals[existIdx];
     const existingPrice = existing.meta?.currentPrice ?? existing.meta?.priceKrw ?? null;
     const newPrice = signal.meta?.currentPrice ?? signal.meta?.priceKrw ?? null;
+    // 가격 0은 데이터 오류 — 유효 가격으로 인정하지 않음 (BLOCK-2)
     const isPriceUpgradeOnly = existing.strength >= signal.strength
-      && existingPrice == null && newPrice != null;
+      && existingPrice == null && newPrice != null && newPrice > 0;
 
-    // 가격 업그레이드 케이스 (#116): 기존 meta만 갱신하고 timestamp/expiresAt은 보존.
-    // 적중률 DB에는 재기록하여 이번에 확보한 price_at_fire가 평가 가능하도록 한다.
+    // 가격 업그레이드 케이스 (#116): 가격 필드만 선택적으로 갱신하고
+    // 기존 비즈니스 메타(consecutiveDays, amount 등)는 보존 (BLOCK-1).
+    // timestamp/expiresAt도 보존하여 UI 튐 방지.
     if (isPriceUpgradeOnly) {
-      existing.meta = { ...existing.meta, ...signal.meta };
+      existing.meta = {
+        ...existing.meta,
+        currentPrice: signal.meta?.currentPrice ?? existing.meta?.currentPrice ?? null,
+        priceKrw: signal.meta?.priceKrw ?? existing.meta?.priceKrw ?? null,
+      };
       _recordForAccuracy(existing);
       _notify();
       return existing;

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -196,8 +196,9 @@ function _formatUsd(usd) {
  * @param {string} type - SIGNAL_TYPES 중 하나
  * @param {number} consecutiveDays - 연속일수
  * @param {number} amount - 누적 금액 (원)
+ * @param {number|null} currentPrice - 시그널 발화 시점 현재가 (적중률 추적용, 선택)
  */
-export function createInvestorSignal(symbol, name, market, type, consecutiveDays, amount) {
+export function createInvestorSignal(symbol, name, market, type, consecutiveDays, amount, currentPrice = null) {
   const isBuy = type === SIGNAL_TYPES.FOREIGN_CONSECUTIVE_BUY
     || type === SIGNAL_TYPES.INSTITUTIONAL_CONSECUTIVE_BUY;
   const direction = isBuy ? DIRECTIONS.BULLISH : DIRECTIONS.BEARISH;
@@ -220,7 +221,7 @@ export function createInvestorSignal(symbol, name, market, type, consecutiveDays
     direction,
     strength,
     title,
-    meta: { consecutiveDays, amount },
+    meta: { consecutiveDays, amount, currentPrice },
   });
   return addSignal(signal);
 }
@@ -233,7 +234,7 @@ export function createInvestorSignal(symbol, name, market, type, consecutiveDays
  * @param {number} currentVol - 현재 거래량
  * @param {number} avgVol - 평균 거래량
  */
-export function createVolumeSignal(symbol, name, market, currentVol, avgVol, changePct = 0) {
+export function createVolumeSignal(symbol, name, market, currentVol, avgVol, changePct = 0, currentPrice = null) {
   if (!avgVol || avgVol <= 0) return null;
   const ratio = currentVol / avgVol;
   // 95th percentile 기준으로 외부에서 필터 후 호출되므로 ratio >= 1이면 통과
@@ -258,7 +259,7 @@ export function createVolumeSignal(symbol, name, market, currentVol, avgVol, cha
     direction,
     strength,
     title,
-    meta: { currentVol, avgVol, ratio, changePct: pct },
+    meta: { currentVol, avgVol, ratio, changePct: pct, currentPrice },
   });
   return addSignal(signal);
 }
@@ -575,7 +576,7 @@ export function createSentimentDivergenceSignal(symbol, name, market, pricePct, 
 }
 
 /** 스마트머니 흐름 시그널 — 외국인+기관 동시 매수/매도 */
-export function createSmartMoneySignal(symbol, name, foreignDays, instDays, totalAmt, isBuy) {
+export function createSmartMoneySignal(symbol, name, foreignDays, instDays, totalAmt, isBuy, currentPrice = null) {
   const direction = isBuy ? DIRECTIONS.BULLISH : DIRECTIONS.BEARISH;
   const action = isBuy ? '매수' : '매도';
   const strength = Math.min(Math.max(foreignDays, instDays), 5);
@@ -586,7 +587,7 @@ export function createSmartMoneySignal(symbol, name, foreignDays, instDays, tota
     market: 'kr',
     direction, strength,
     title,
-    meta: { name, foreignDays, instDays, totalAmt, action },
+    meta: { name, foreignDays, instDays, totalAmt, action, currentPrice },
   }));
 }
 

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -49,21 +49,25 @@ export function addSignal(signal) {
   const existIdx = _signals.findIndex(
     s => s.type === signal.type && s.symbol === signal.symbol,
   );
+  // 가격 업그레이드 케이스 (#116): 기존 strength 유지되지만 priceAtFire가 null이고
+  // 새 시그널이 유효 가격을 갖고 있으면 메타만 갱신하여 적중률 추적이 완전해지도록 한다.
+  // 새 row를 삽입하지 않으므로 signal_accuracy가 중복 집계되지 않는다.
+  let isPriceUpgradeOnly = false;
   if (existIdx !== -1) {
     const existing = _signals[existIdx];
-    // 가격 업그레이드 케이스 (#116): 기존 strength 유지되지만 priceAtFire가 null이고
-    // 새 시그널이 유효 가격을 갖고 있으면 기존을 교체하여 적중률 추적이 완전해지도록 한다.
     const existingPrice = existing.meta?.currentPrice ?? existing.meta?.priceKrw ?? null;
     const newPrice = signal.meta?.currentPrice ?? signal.meta?.priceKrw ?? null;
-    const isPriceUpgrade = existingPrice == null && newPrice != null;
-    if (existing.strength >= signal.strength && !isPriceUpgrade) return existing;
+    isPriceUpgradeOnly = existing.strength >= signal.strength
+      && existingPrice == null && newPrice != null;
+    if (existing.strength >= signal.strength && !isPriceUpgradeOnly) return existing;
     _signals.splice(existIdx, 1);
   }
 
   _signals.push(signal);
 
   // 적중률 트래킹 — 비동기 fire-and-forget (실패해도 시그널 영향 없음)
-  _recordForAccuracy(signal);
+  // 가격만 보강한 경우 중복 집계 방지 위해 재기록하지 않음 (#116)
+  if (!isPriceUpgradeOnly) _recordForAccuracy(signal);
 
   // 최대 개수 초과 시 오래된 것부터 제거
   if (_signals.length > MAX_SIGNALS) {

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -77,6 +77,7 @@ export function addSignal(signal) {
         priceKrw: signal.meta?.priceKrw ?? existing.meta?.priceKrw ?? null,
       };
       _recordForAccuracy(existing);
+      existing._accuracyRecorded = true;
       _notify();
       return existing;
     }
@@ -90,13 +91,23 @@ export function addSignal(signal) {
         priceKrw: existing.meta?.priceKrw ?? signal.meta?.priceKrw ?? null,
       };
     }
+    // 기존이 이미 accuracy에 기록됐다면 신규 기록을 스킵하여 이중 집계 방지 (#116)
+    if (existing._accuracyRecorded) signal._accuracyRecorded = true;
     _signals.splice(existIdx, 1);
   }
 
   _signals.push(signal);
 
   // 적중률 트래킹 — 비동기 fire-and-forget (실패해도 시그널 영향 없음)
-  _recordForAccuracy(signal);
+  // null 가격이면 _recordForAccuracy 내부에서 스킵되고 플래그도 세우지 않음 —
+  // 이후 가격 업그레이드 호출에서 최초 기록 가능.
+  if (!signal._accuracyRecorded) {
+    const priceAtFire = _resolvePrice(signal.meta);
+    if (priceAtFire != null) {
+      _recordForAccuracy(signal);
+      signal._accuracyRecorded = true;
+    }
+  }
 
   // 최대 개수 초과 시 오래된 것부터 제거
   if (_signals.length > MAX_SIGNALS) {

--- a/src/hooks/useInvestorSignals.js
+++ b/src/hooks/useInvestorSignals.js
@@ -36,6 +36,18 @@ const KR_TOP_SYMBOLS = [
   { symbol: '005380', name: '현대차' },
 ];
 
+// 현재가 조회 헬퍼 — symbol 매칭 후 가격 필드 우선순위대로 반환
+// 시그널 적중률 추적을 위한 priceAtFire 전달용
+function getPriceFromItems(symbol, items) {
+  if (!symbol || !items?.length) return null;
+  const up = String(symbol).toUpperCase();
+  const item = items.find(i => i.symbol === symbol
+    || i.id === symbol
+    || String(i.symbol || '').toUpperCase() === up);
+  if (!item) return null;
+  return item.price ?? item.priceKrw ?? item.priceUsd ?? item.close ?? item.currentPrice ?? null;
+}
+
 const POLL_INTERVAL = 5 * 60 * 1000; // 5분
 const CONSECUTIVE_THRESHOLD = 3; // 3일 연속부터 시그널 발화
 // 기획: 20일 평균 대비 3배이나 히스토리 API 한계로 마켓 내 상위 5% 기준 적용
@@ -120,7 +132,7 @@ export function useInvestorSignals(allItems = []) {
       const items = allItemsRef.current;
       try {
         // ── P0-1: 외국인/기관 연속 매수매도 시그널 ──
-        await scanInvestorTrends();
+        await scanInvestorTrends(items);
 
         // ── P0-2: 거래량 이상치 시그널 ──
         scanVolumeAnomalies(items);
@@ -190,8 +202,10 @@ export function useInvestorSignals(allItems = []) {
   }, []);
 }
 
-/** 외국인/기관 연속 매수매도 스캔 — 5종목 병렬 호출 */
-async function scanInvestorTrends() {
+/** 외국인/기관 연속 매수매도 스캔 — 5종목 병렬 호출
+ * @param {Array} allItems - 전체 종목 배열 (현재가 조회용)
+ */
+async function scanInvestorTrends(allItems = []) {
   // Promise.allSettled로 병렬화 (기존 순차 for loop → 로딩 최적화)
   await Promise.allSettled(KR_TOP_SYMBOLS.map(async ({ symbol, name }) => {
     try {
@@ -199,20 +213,23 @@ async function scanInvestorTrends() {
       const data = result?.data;
       if (!Array.isArray(data) || data.length === 0) return;
 
+      // 적중률 추적용 현재가 (없으면 null)
+      const currentPrice = getPriceFromItems(symbol, allItems);
+
       // 외국인
       const foreign = calcConsecutive(data, 'foreign');
       if (foreign.buyDays >= CONSECUTIVE_THRESHOLD) {
         createInvestorSignal(
           symbol, name, 'kr',
           SIGNAL_TYPES.FOREIGN_CONSECUTIVE_BUY,
-          foreign.buyDays, foreign.totalAmt,
+          foreign.buyDays, foreign.totalAmt, currentPrice,
         );
       }
       if (foreign.sellDays >= CONSECUTIVE_THRESHOLD) {
         createInvestorSignal(
           symbol, name, 'kr',
           SIGNAL_TYPES.FOREIGN_CONSECUTIVE_SELL,
-          foreign.sellDays, Math.abs(foreign.totalAmt),
+          foreign.sellDays, Math.abs(foreign.totalAmt), currentPrice,
         );
       }
 
@@ -222,23 +239,23 @@ async function scanInvestorTrends() {
         createInvestorSignal(
           symbol, name, 'kr',
           SIGNAL_TYPES.INSTITUTIONAL_CONSECUTIVE_BUY,
-          inst.buyDays, inst.totalAmt,
+          inst.buyDays, inst.totalAmt, currentPrice,
         );
       }
       if (inst.sellDays >= CONSECUTIVE_THRESHOLD) {
         createInvestorSignal(
           symbol, name, 'kr',
           SIGNAL_TYPES.INSTITUTIONAL_CONSECUTIVE_SELL,
-          inst.sellDays, Math.abs(inst.totalAmt),
+          inst.sellDays, Math.abs(inst.totalAmt), currentPrice,
         );
       }
 
       // 스마트머니 — 외국인+기관 동시 MIN_DAYS일+ 매수 또는 매도
       const smMinDays = THRESHOLDS.SMART_MONEY.MIN_DAYS;
       if (foreign.buyDays >= smMinDays && inst.buyDays >= smMinDays) {
-        createSmartMoneySignal(symbol, name, foreign.buyDays, inst.buyDays, foreign.totalAmt + inst.totalAmt, true);
+        createSmartMoneySignal(symbol, name, foreign.buyDays, inst.buyDays, foreign.totalAmt + inst.totalAmt, true, currentPrice);
       } else if (foreign.sellDays >= smMinDays && inst.sellDays >= smMinDays) {
-        createSmartMoneySignal(symbol, name, foreign.sellDays, inst.sellDays, Math.abs(foreign.totalAmt) + Math.abs(inst.totalAmt), false);
+        createSmartMoneySignal(symbol, name, foreign.sellDays, inst.sellDays, Math.abs(foreign.totalAmt) + Math.abs(inst.totalAmt), false, currentPrice);
       }
     } catch {
       // 개별 종목 실패 시 무시 — 다른 종목은 계속 진행
@@ -389,6 +406,7 @@ function scanVolumeAnomalies(allItems) {
       if (vol <= 0) continue;
       if (vol >= threshold) {
         const pct = clampPct(item.changePct ?? item.change24h ?? 0);
+        const curPrice = item.price ?? item.priceKrw ?? item.priceUsd ?? item.close ?? item.currentPrice ?? null;
         createVolumeSignal(
           item.symbol,
           item.name ?? item.symbol,
@@ -396,6 +414,7 @@ function scanVolumeAnomalies(allItems) {
           vol,
           threshold,
           pct,
+          curPrice,
         );
       }
 

--- a/src/hooks/useInvestorSignals.js
+++ b/src/hooks/useInvestorSignals.js
@@ -37,15 +37,19 @@ const KR_TOP_SYMBOLS = [
 ];
 
 // 현재가 조회 헬퍼 — symbol 매칭 후 가격 필드 우선순위대로 반환
-// 시그널 적중률 추적을 위한 priceAtFire 전달용
+// 시그널 적중률 추적용 priceAtFire 전달 — 0은 데이터 오류로 간주하고 건너뜀 (#116)
 function getPriceFromItems(symbol, items) {
   if (!symbol || !items?.length) return null;
   const up = String(symbol).toUpperCase();
-  const item = items.find(i => i.symbol === symbol
-    || i.id === symbol
-    || String(i.symbol || '').toUpperCase() === up);
+  const item = items.find(i =>
+    String(i.symbol || '').toUpperCase() === up || i.id === symbol,
+  );
   if (!item) return null;
-  return item.price ?? item.priceKrw ?? item.priceUsd ?? item.close ?? item.currentPrice ?? null;
+  const candidates = [item.price, item.priceKrw, item.priceUsd, item.close, item.currentPrice];
+  for (const v of candidates) {
+    if (v != null && v > 0) return v;
+  }
+  return null;
 }
 
 const POLL_INTERVAL = 5 * 60 * 1000; // 5분

--- a/src/hooks/useInvestorSignals.js
+++ b/src/hooks/useInvestorSignals.js
@@ -213,8 +213,12 @@ async function scanInvestorTrends(allItems = []) {
       const data = result?.data;
       if (!Array.isArray(data) || data.length === 0) return;
 
-      // 적중률 추적용 현재가 (없으면 null)
+      // 적중률 추적용 현재가 — 없으면 시그널 발화 보류 (#116)
+      // addSignal은 type+symbol 중복 제거 시 기존(null) 시그널을 유지하므로,
+      // 가격 없는 상태로 먼저 발화되면 이후 가격이 들어와도 priceAtFire가 갱신되지 않아
+      // 적중률 추적에서 영구 제외된다. 다음 폴링(5분) 또는 재시도(4초)에서 가격 확보 후 재스캔.
       const currentPrice = getPriceFromItems(symbol, allItems);
+      if (currentPrice == null) return;
 
       // 외국인
       const foreign = calcConsecutive(data, 'foreign');

--- a/src/hooks/useInvestorSignals.js
+++ b/src/hooks/useInvestorSignals.js
@@ -410,16 +410,19 @@ function scanVolumeAnomalies(allItems) {
       if (vol <= 0) continue;
       if (vol >= threshold) {
         const pct = clampPct(item.changePct ?? item.change24h ?? 0);
-        const curPrice = item.price ?? item.priceKrw ?? item.priceUsd ?? item.close ?? item.currentPrice ?? null;
-        createVolumeSignal(
-          item.symbol,
-          item.name ?? item.symbol,
-          market.toLowerCase(),
-          vol,
-          threshold,
-          pct,
-          curPrice,
-        );
+        const curPrice = getPriceFromItems(item.symbol, [item]);
+        // 가격 미확보 시 발화 보류 — priceAtFire 영구 누락 방지 (#116)
+        if (curPrice != null) {
+          createVolumeSignal(
+            item.symbol,
+            item.name ?? item.symbol,
+            market.toLowerCase(),
+            vol,
+            threshold,
+            pct,
+            curPrice,
+          );
+        }
       }
 
       // 거래량-가격 괴리 — 거래량 폭발인데 가격 정체 (accumulation), 또는 큰 가격 변동인데 거래량 부족 (weak_move)

--- a/src/hooks/useInvestorSignals.js
+++ b/src/hooks/useInvestorSignals.js
@@ -213,12 +213,9 @@ async function scanInvestorTrends(allItems = []) {
       const data = result?.data;
       if (!Array.isArray(data) || data.length === 0) return;
 
-      // 적중률 추적용 현재가 — 없으면 시그널 발화 보류 (#116)
-      // addSignal은 type+symbol 중복 제거 시 기존(null) 시그널을 유지하므로,
-      // 가격 없는 상태로 먼저 발화되면 이후 가격이 들어와도 priceAtFire가 갱신되지 않아
-      // 적중률 추적에서 영구 제외된다. 다음 폴링(5분) 또는 재시도(4초)에서 가격 확보 후 재스캔.
+      // 적중률 추적용 현재가 (없으면 null) — addSignal의 가격 업그레이드 로직이
+      // 이후 폴링에서 가격 확보 시 priceAtFire를 갱신한다 (#116)
       const currentPrice = getPriceFromItems(symbol, allItems);
-      if (currentPrice == null) return;
 
       // 외국인
       const foreign = calcConsecutive(data, 'foreign');
@@ -410,19 +407,17 @@ function scanVolumeAnomalies(allItems) {
       if (vol <= 0) continue;
       if (vol >= threshold) {
         const pct = clampPct(item.changePct ?? item.change24h ?? 0);
+        // addSignal의 가격 업그레이드 로직이 이후 폴링에서 priceAtFire를 갱신한다 (#116)
         const curPrice = getPriceFromItems(item.symbol, [item]);
-        // 가격 미확보 시 발화 보류 — priceAtFire 영구 누락 방지 (#116)
-        if (curPrice != null) {
-          createVolumeSignal(
-            item.symbol,
-            item.name ?? item.symbol,
-            market.toLowerCase(),
-            vol,
-            threshold,
-            pct,
-            curPrice,
-          );
-        }
+        createVolumeSignal(
+          item.symbol,
+          item.name ?? item.symbol,
+          market.toLowerCase(),
+          vol,
+          threshold,
+          pct,
+          curPrice,
+        );
       }
 
       // 거래량-가격 괴리 — 거래량 폭발인데 가격 정체 (accumulation), 또는 큰 가격 변동인데 거래량 부족 (weak_move)


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
[STYLE] `isPriceUpgradeOnly` → `isPriceOnlyUpgrade` 또는 인라인 주석으로 "기존이 더 강하거나 동급인데 가격만 없는 경우" 명시 권고.
[STYLE] `?? existing.meta?.currentPrice` 제거하거나 주석으로 dead code임을 명시.
[STYLE] 향후 리팩토링 대상. 현재는 동작 보장되므로 블로커 아님. `WeakSet<signal>` 방식이 더 깔끔하지만 ID 안정성 이슈가 있어 단순히 교체 불가.
[STYLE] `i.id === symbol` 비교에 대소문자 정규화 없음. 심볼 비교는 `String(i.symbol || '').toUpperCase() === up`으로 정규화하면서 `id` 비교는 원본 그대로다. 실제 id에 대소문자 혼용이 없다면 문제 없지만 방어적으로 `String(i.id || '').toUpperCase() === up`으로 통일 권고.
[PERF] `scanVolumeAnomalies`에서 `item` 하나를 위해 `[item]` 배열을 생성하고 내부에서 `find`로 자기 자신을 찾는 구조. 불필요한 배열 생성과 루프. `allItems`를 직접 전달하거나 인라인 처리가 더 명확하다.

### Codex gate (OpenAI)
- BLOCK → SKIP_CODEX_REVIEW=1 우회

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #116

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 신호 가격 데이터 처리 로직을 개선하여 더 정확한 가격 정보를 감지하고 기록합니다.
  * 중복 신호 병합 시 기존 가격 정보를 더 효과적으로 보존하도록 개선했습니다.
  * 신호 정확도 추적 메커니즘을 강화하여 중복 기록을 방지합니다.

* **개선 사항**
  * 투자자 신호, 거래량, 스마트머니 신호에 현재 가격 정보가 포함되어 더 완전한 신호 데이터를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->