### PR TITLE
fix: fx_impact 시그널 활성화 + gap_analysis dead path 명시화 (#113)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,7 +67,7 @@ function InstallBanner() {
 export default function App() {
   const { dark, toggle: toggleDark } = useDarkMode();
   const { watchlist, krSymbols, usSymbols } = useWatchlist();
-  const { indices, krwRate }        = useIndices();
+  const { indices, krwRate, krwRateLoaded } = useIndices();
   const krwRateRef                  = useRef(DEFAULT_KRW_RATE);
   useEffect(() => { krwRateRef.current = krwRate; }, [krwRate]);
 
@@ -364,7 +364,7 @@ export default function App() {
           {activeTab === 'home' ? (
             <HomeDashboard
               indices={indices} krStocks={krStocks} usStocks={usStocks}
-              coins={coins} etfs={mergedEtfs} krwRate={krwRate}
+              coins={coins} etfs={mergedEtfs} krwRate={krwRate} krwRateLoaded={krwRateLoaded}
               onItemClick={setSelectedItem} onNewsClick={setSelectedNews}
               onTabChange={setActiveTab}
               dataReady={pricesReady && coinsReady}

--- a/src/api/coins.js
+++ b/src/api/coins.js
@@ -237,7 +237,7 @@ export async function fetchExchangeRate() {
     if (btcKrw && btcUsd) {
       const rate = Math.round(btcKrw / btcUsd);
       saveRateCache(rate);
-      return rate;
+      return { rate, isFallback: false };
     }
   } catch {}
 
@@ -252,13 +252,15 @@ export async function fetchExchangeRate() {
     if (btcKrw && btcUsd) {
       const rate = Math.round(btcKrw / btcUsd);
       saveRateCache(rate);
-      return rate;
+      return { rate, isFallback: false };
     }
   } catch {}
 
+  // 캐시(24h)는 실제값 기반이므로 isFallback:false
   const cachedRate = loadRateCache();
-  if (cachedRate) return cachedRate;
-  return RATE_FALLBACK;
+  if (cachedRate) return { rate: cachedRate, isFallback: false };
+  // 모든 실시간/캐시 실패 → 하드코딩 폴백 (#113 Codex P2: loaded 플래그용)
+  return { rate: RATE_FALLBACK, isFallback: true };
 }
 
 // ─── Upbit만으로 빠른 가격 갱신 (10초 폴링용) ─────────────────

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -17,7 +17,7 @@ import ExploreTabsWidget from './ExploreTabsWidget';
 
 export default function HomeDashboard({
   indices = [], krStocks = [], usStocks = [], coins = [], etfs = [],
-  krwRate = DEFAULT_KRW_RATE, onItemClick, onNewsClick, onTabChange,
+  krwRate = DEFAULT_KRW_RATE, krwRateLoaded = false, onItemClick, onNewsClick, onTabChange,
   dataReady = true,
 }) {
   const queryClient = useQueryClient();
@@ -87,7 +87,7 @@ export default function HomeDashboard({
 
   // 투자자 시그널 스캔 (5분 간격 폴링) — 레버리지/인버스 ETF 제외 (일반 ETF·코인ETF 포함)
   // krwRate 주입 — fx_impact 시그널 발화용 (#113)
-  useInvestorSignals(stockItems, krwRate);
+  useInvestorSignals(stockItems, krwRate, krwRateLoaded);
 
   // 파생/소셜 시그널 스캔 (PCR, 펀딩비, 주문장, VWAP, 소셜)
   const watchlistSymbols = useMemo(() => watchedItems.map(i => i.symbol).filter(Boolean), [watchedItems]);

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -86,7 +86,8 @@ export default function HomeDashboard({
   const coinDrop= useMemo(() => [...coinItems].sort((a, b) => getPct(a) - getPct(b)).slice(0, 5), [coinItems]);
 
   // 투자자 시그널 스캔 (5분 간격 폴링) — 레버리지/인버스 ETF 제외 (일반 ETF·코인ETF 포함)
-  useInvestorSignals(stockItems);
+  // krwRate 주입 — fx_impact 시그널 발화용 (#113)
+  useInvestorSignals(stockItems, krwRate);
 
   // 파생/소셜 시그널 스캔 (PCR, 펀딩비, 주문장, VWAP, 소셜)
   const watchlistSymbols = useMemo(() => watchedItems.map(i => i.symbol).filter(Boolean), [watchedItems]);

--- a/src/hooks/useIndices.js
+++ b/src/hooks/useIndices.js
@@ -33,10 +33,12 @@ export function useIndices() {
 
   const refreshExchangeRate = useCallback(async () => {
     try {
-      const rate = await fetchExchangeRate();
+      const { rate, isFallback } = await fetchExchangeRate();
       if (rate) {
         setKrwRate(rate);
-        setKrwRateLoaded(true);
+        // 실제 fetch 또는 24h 캐시 성공 시에만 loaded=true (Codex #113 P2)
+        // isFallback=true는 모든 실시간/캐시 실패 후 하드코딩 값 → fx_impact 시그널 발화 금지
+        if (!isFallback) setKrwRateLoaded(true);
         setWhaleKrwRate(rate);
       }
     } catch (e) { console.warn('[환율] 갱신 실패:', e.message); }

--- a/src/hooks/useIndices.js
+++ b/src/hooks/useIndices.js
@@ -9,6 +9,7 @@ import { DEFAULT_KRW_RATE } from '../constants/market';
 export function useIndices() {
   const [indices, setIndices]   = useState([]);
   const [krwRate, setKrwRate]   = useState(DEFAULT_KRW_RATE);
+  const [krwRateLoaded, setKrwRateLoaded] = useState(false);
 
   const refreshIndices = useCallback(async () => {
     try {
@@ -35,6 +36,7 @@ export function useIndices() {
       const rate = await fetchExchangeRate();
       if (rate) {
         setKrwRate(rate);
+        setKrwRateLoaded(true);
         setWhaleKrwRate(rate);
       }
     } catch (e) { console.warn('[환율] 갱신 실패:', e.message); }
@@ -55,5 +57,5 @@ export function useIndices() {
     };
   }, [refreshIndices, refreshExchangeRate]);
 
-  return { indices, krwRate, refreshIndices };
+  return { indices, krwRate, krwRateLoaded, refreshIndices };
 }

--- a/src/hooks/useInvestorSignals.js
+++ b/src/hooks/useInvestorSignals.js
@@ -15,7 +15,6 @@ import { detectGap, detectRebalancingWindow, detectFxImpact } from '../engine/ta
 import { SIGNAL_TYPES, DIRECTIONS, STABLECOIN_SYMBOLS } from '../engine/signalTypes';
 import { THRESHOLDS } from '../constants/signalThresholds';
 import { clampPct } from '../utils/clampPct';
-import { DEFAULT_KRW_RATE } from '../constants/market';
 
 // 교차시장 상관관계 쌍 — leader가 먼저 움직이면 lagger가 따라갈 가능성
 const CROSS_MARKET_PAIRS = [
@@ -116,13 +115,14 @@ function calcPercentileVolume(items, market) {
  * @param {Array} allItems - 전체 종목 배열 ({ symbol, name, volume, _market } 포함)
  * @param {number} krwRate - 현재 원/달러 환율 (fx_impact 시그널 발화용, #113)
  */
-export function useInvestorSignals(allItems = [], krwRate = null) {
+export function useInvestorSignals(allItems = [], krwRate = null, krwRateLoaded = false) {
   const timerRef = useRef(null);
   const runningRef = useRef(false);
   const moodPrevRef = useRef(null); // 시장 무드 이전 상태 (메모리 기반)
   const allItemsRef = useRef(allItems); // 최신 allItems를 ref로 유지 — 타이머 리셋 방지
   const sectorRanksPrevRef = useRef(null); // 섹터 순위 이전 상태 (localStorage 대신 메모리)
   const krwRateRef = useRef(krwRate); // 최신 환율 ref
+  const krwRateLoadedRef = useRef(krwRateLoaded); // 환율 fetch 완료 여부 (sentinel 충돌 방지, #113)
   const fxPrevRef = useRef(null); // fx_impact 이전 환율 (첫 호출은 skip, #113)
 
   // allItems가 변경될 때마다 ref 갱신 — useEffect 내에서 안전하게 참조
@@ -134,6 +134,10 @@ export function useInvestorSignals(allItems = [], krwRate = null) {
   useEffect(() => {
     krwRateRef.current = krwRate;
   }, [krwRate]);
+
+  useEffect(() => {
+    krwRateLoadedRef.current = krwRateLoaded;
+  }, [krwRateLoaded]);
 
   useEffect(() => {
     let retryTimer = null; // 재시도 타이머 추적 (언마운트 시 정리)
@@ -169,7 +173,7 @@ export function useInvestorSignals(allItems = [], krwRate = null) {
         detectRebalancingSignal();
 
         // ── 신규: 환율 영향 (#113: useIndices().krwRate 주입) ──
-        detectFxImpactSignal(krwRateRef.current, fxPrevRef);
+        detectFxImpactSignal(krwRateRef.current, fxPrevRef, krwRateLoadedRef.current);
 
         // ── Tier2: 투매 감지 (캐피튤레이션) ──
         detectCapitulation(items);
@@ -593,10 +597,11 @@ function detectRebalancingSignal() {
  * 기존 구현은 allItems에서 USDKRW 심볼을 찾았으나 allItems에는 주식·코인만 포함되어 항상 skip되던 dead path.
  * @param {number|null} krwRate - 현재 원/달러 환율
  * @param {{ current: number|null }} prevRef - 이전 환율 ref (첫 호출은 skip)
+ * @param {boolean} loaded - 환율 fetch 완료 여부 (DEFAULT_KRW_RATE sentinel과 실제값 충돌 회피)
  */
-function detectFxImpactSignal(krwRate, prevRef) {
-  // 환율 없음/폴백값(DEFAULT_KRW_RATE)/동일값은 skip
-  if (!krwRate || krwRate === DEFAULT_KRW_RATE) return;
+function detectFxImpactSignal(krwRate, prevRef, loaded) {
+  // 환율 fetch 미완료 또는 값 자체가 falsy면 skip — DEFAULT_KRW_RATE 값으로는 판정하지 않음 (Codex P2)
+  if (!loaded || !krwRate) return;
 
   const prevRate = prevRef.current;
   // 첫 호출(prev=null) skip — 다음 주기부터 비교
@@ -604,13 +609,15 @@ function detectFxImpactSignal(krwRate, prevRef) {
     prevRef.current = krwRate;
     return;
   }
-  // 값 변동 없으면 ref 갱신 후 skip
+  // 값 변동 없으면 skip (prev 유지)
   if (prevRate === krwRate) return;
 
   const result = detectFxImpact(krwRate, prevRate);
   prevRef.current = krwRate;
   if (!result) return;
 
+  // type+symbol dedupe 우회 — 환율은 자주 변하므로 매 변동마다 최신 시그널로 교체 (Codex P1)
+  removeSignalByTypeAndSymbol(SIGNAL_TYPES.FX_IMPACT, 'USDKRW');
   createFxImpactSignal(krwRate, prevRate, result.changePct, result.impact);
 }
 

--- a/src/hooks/useInvestorSignals.js
+++ b/src/hooks/useInvestorSignals.js
@@ -15,6 +15,7 @@ import { detectGap, detectRebalancingWindow, detectFxImpact } from '../engine/ta
 import { SIGNAL_TYPES, DIRECTIONS, STABLECOIN_SYMBOLS } from '../engine/signalTypes';
 import { THRESHOLDS } from '../constants/signalThresholds';
 import { clampPct } from '../utils/clampPct';
+import { DEFAULT_KRW_RATE } from '../constants/market';
 
 // 교차시장 상관관계 쌍 — leader가 먼저 움직이면 lagger가 따라갈 가능성
 const CROSS_MARKET_PAIRS = [
@@ -113,18 +114,26 @@ function calcPercentileVolume(items, market) {
 /**
  * 투자자 연속 매수매도 + 거래량 이상치 시그널 훅
  * @param {Array} allItems - 전체 종목 배열 ({ symbol, name, volume, _market } 포함)
+ * @param {number} krwRate - 현재 원/달러 환율 (fx_impact 시그널 발화용, #113)
  */
-export function useInvestorSignals(allItems = []) {
+export function useInvestorSignals(allItems = [], krwRate = null) {
   const timerRef = useRef(null);
   const runningRef = useRef(false);
   const moodPrevRef = useRef(null); // 시장 무드 이전 상태 (메모리 기반)
   const allItemsRef = useRef(allItems); // 최신 allItems를 ref로 유지 — 타이머 리셋 방지
   const sectorRanksPrevRef = useRef(null); // 섹터 순위 이전 상태 (localStorage 대신 메모리)
+  const krwRateRef = useRef(krwRate); // 최신 환율 ref
+  const fxPrevRef = useRef(null); // fx_impact 이전 환율 (첫 호출은 skip, #113)
 
   // allItems가 변경될 때마다 ref 갱신 — useEffect 내에서 안전하게 참조
   useEffect(() => {
     allItemsRef.current = allItems;
   }, [allItems]);
+
+  // krwRate ref 갱신 — 타이머 리셋 방지
+  useEffect(() => {
+    krwRateRef.current = krwRate;
+  }, [krwRate]);
 
   useEffect(() => {
     let retryTimer = null; // 재시도 타이머 추적 (언마운트 시 정리)
@@ -159,8 +168,8 @@ export function useInvestorSignals(allItems = []) {
         // ── 신규: 리밸런싱 경고 ──
         detectRebalancingSignal();
 
-        // ── 신규: 환율 영향 ──
-        detectFxImpactSignal(items);
+        // ── 신규: 환율 영향 (#113: useIndices().krwRate 주입) ──
+        detectFxImpactSignal(krwRateRef.current, fxPrevRef);
 
         // ── Tier2: 투매 감지 (캐피튤레이션) ──
         detectCapitulation(items);
@@ -534,7 +543,11 @@ function detectMarketMoodShift(allItems, moodPrevRef) {
   }
 }
 
-/** 갭 분석 — sparkline/캔들 데이터가 있는 종목의 전일 종가 vs 당일 시가 갭 감지 */
+/** 갭 분석 — 전일 종가 vs 당일 시가 갭 감지
+ * TODO(#113-gap): 현재 allItems에는 OHLC 캔들이 없고 sparkline(숫자 배열)만 있어
+ * detectGap(prev.close/curr.open 기대)이 항상 null 반환 → 시그널 발화 불능.
+ * R2-A로 Top-N OHLC 훅(useGapCandles) 신설 후 활성화 예정. 현재는 명시적 skip. */
+let _gapDeadPathLogged = false;
 function detectGapSignals(allItems) {
   if (!allItems?.length) return;
   const T_GAP = THRESHOLDS.GAP;
@@ -546,9 +559,17 @@ function detectGapSignals(allItems) {
     );
     if (existing) continue;
 
-    // sparkline 데이터에서 캔들 추출 (open/close 필요)
-    const candles = item.candles ?? item.sparkline;
+    // TODO(#113-gap): candles는 OHLC 객체 배열이어야 함. sparkline(숫자 배열)은 부적합 → skip.
+    const candles = item.candles;
     if (!Array.isArray(candles) || candles.length < 2) continue;
+    if (candles[0]?.close === undefined) {
+      // 명시적 dead path — OHLC 훅 도입 전까지 skip. 1회만 기록.
+      if (!_gapDeadPathLogged) {
+        console.debug('[#113-gap] gap_analysis skipped — candles lack OHLC; awaits useGapCandles hook');
+        _gapDeadPathLogged = true;
+      }
+      continue;
+    }
 
     const result = detectGap(candles);
     if (!result || Math.abs(result.gapPct) < T_GAP.MIN_PCT) continue;
@@ -568,24 +589,29 @@ function detectRebalancingSignal() {
   createRebalancingSignal(result.isQuarterEnd, result.daysLeft);
 }
 
-/** 환율 영향 — allItems에서 USDKRW 환율 데이터 추출 후 변동 감지 */
-function detectFxImpactSignal(allItems) {
-  if (!allItems?.length) return;
+/** 환율 영향 — useIndices().krwRate를 직접 주입받아 이전 값과 비교 (#113)
+ * 기존 구현은 allItems에서 USDKRW 심볼을 찾았으나 allItems에는 주식·코인만 포함되어 항상 skip되던 dead path.
+ * @param {number|null} krwRate - 현재 원/달러 환율
+ * @param {{ current: number|null }} prevRef - 이전 환율 ref (첫 호출은 skip)
+ */
+function detectFxImpactSignal(krwRate, prevRef) {
+  // 환율 없음/폴백값(DEFAULT_KRW_RATE)/동일값은 skip
+  if (!krwRate || krwRate === DEFAULT_KRW_RATE) return;
 
-  // 환율 데이터는 별도 심볼 또는 메타데이터에서 추출
-  const fxItem = allItems.find(i =>
-    i.symbol === 'USDKRW' || i.symbol === 'USD/KRW' || i.symbol === 'KRW=X',
-  );
-  if (!fxItem) return;
+  const prevRate = prevRef.current;
+  // 첫 호출(prev=null) skip — 다음 주기부터 비교
+  if (prevRate == null) {
+    prevRef.current = krwRate;
+    return;
+  }
+  // 값 변동 없으면 ref 갱신 후 skip
+  if (prevRate === krwRate) return;
 
-  const rate = fxItem.price ?? fxItem.close ?? fxItem.currentPrice ?? 0;
-  const prevRate = fxItem.prevClose ?? fxItem.previousClose ?? 0;
-  if (!rate || !prevRate) return;
-
-  const result = detectFxImpact(rate, prevRate);
+  const result = detectFxImpact(krwRate, prevRate);
+  prevRef.current = krwRate;
   if (!result) return;
 
-  createFxImpactSignal(rate, prevRate, result.changePct, result.impact);
+  createFxImpactSignal(krwRate, prevRate, result.changePct, result.impact);
 }
 
 /** 투매 감지 (캐피튤레이션) — 가격 급락 + 거래량 폭발 + 공포 극대 */


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Codex gate (OpenAI)
- PASS (지적사항 처리: [채택] Codex P1: removeSignalByTypeAndSymbol(FX_IMPACT, USDKRW) 호출 후 createFxImpactSignal로 매 변동마다 새 시그널 생성 — dedupe 우회.)

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #113

---
🤖 Generated by Claude Code [claude-sonnet-4-6]