### PR TITLE
fix: /api/snapshot Cache-Control 강화 — Upstash bandwidth 절감

### DIFF
--- a/api/snapshot.js
+++ b/api/snapshot.js
@@ -103,11 +103,19 @@ export default async function handler(request) {
       });
     }
 
+    // Cache-Control 설계 (Upstash bandwidth 보호):
+    // - max-age=0: 브라우저 HTTP 캐시 비활성 → 클라이언트 ETag 재검증 경로 보존
+    // - s-maxage=60: Vercel edge CDN 60초 캐싱 → Vercel Function 호출 최소화
+    // - stale-while-revalidate 미사용: 백그라운드 갱신 중 stale 반환 방지
+    //   (KR 랭킹/급등 뷰는 refreshKoreanStocks가 fallback/워치리스트만 갱신하고
+    //    나머지는 snapshot seed에 의존 → swr로 수분 stale 누적 시 서비스 본질 훼손.
+    //    /api/cron/check-signal-accuracy의 server-side snapshot 소비도 stale 누적 위험.
+    //    → swr 없이 stale 상한을 60s로 제한.)
     return new Response(body, {
       status: 200,
       headers: {
         ...CORS_HEADERS,
-        'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=15',
+        'Cache-Control': 'public, max-age=0, s-maxage=60',
         'ETag': etag,
       },
     });

--- a/src/api/snapshot.js
+++ b/src/api/snapshot.js
@@ -2,7 +2,7 @@
 // /api/snapshot (Edge → Redis) 캐시된 전체 시세를 한 번에 가져옴
 // [최적화] ETag/304 지원 — 데이터 미변경 시 빈 응답으로 전송량 절감
 
-const SNAPSHOT_TTL = 25 * 1000; // 25초 (서버 s-maxage=30보다 짧게)
+const SNAPSHOT_TTL = 60 * 1000; // 60초 (서버 s-maxage=60과 동기화 — 중복 호출 방지)
 let _cache = null;
 let _cacheTs = 0;
 let _inflight = null;


### PR DESCRIPTION
## 최종 구현

### 서버 (api/snapshot.js)
```
Cache-Control: public, max-age=0, s-maxage=60
```
- **max-age=0**: 브라우저 HTTP 캐시 비활성화 → 클라이언트 ETag 재검증 경로 보존
- **s-maxage=60**: Vercel edge CDN 60초 캐싱 → Vercel Function 호출 최소화
- **stale-while-revalidate 미사용** (의도적): KR 랭킹/급등 뷰가 snapshot seed에 의존하는데 swr로 수분 stale이 누적되면 서비스 본질("급상승 종목 빠른 캐치") 훼손. /api/cron/check-signal-accuracy의 server-side 소비도 stale 누적 위험 → stale 상한을 60s로 제한

### 클라이언트 (src/api/snapshot.js)
```
SNAPSHOT_TTL: 25 * 1000 → 60 * 1000
```
- 서버 s-maxage=60과 동기화하여 동일 세션 내 중복 호출 방지

## 효과
- Upstash GET 빈도 대폭 감소 → bandwidth 절감
- Fixed \$10 플랜의 50GB/월 bandwidth 한도 대비 여유 확보

## 봇 리뷰 대응

### Gemini (medium) — TTL 불일치
**채택** (c750c16): SNAPSHOT_TTL 25s → 60s 동기화

### CodeRabbit (major) — 커밋 메시지/코드 불일치
**부분 채택**: iteration 과정에서 최초 커밋 메시지에 "swr 15→300"이 남아있지만, 최종 구현은 swr 미사용. 위 "최종 구현" 섹션이 ground truth.

### Copilot
리뷰 실패 (도구 에러). 재요청 불가능한 상태.

## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Codex gate (OpenAI)
PASS

Closes #129

---
🤖 Generated by Claude Code [claude-sonnet-4-6]