### PR TITLE
fix: 종목 상세 패널 role=dialog + 다크모드 aria-label (#137)

### DIFF
--- a/src/components/ChartSidePanel.jsx
+++ b/src/components/ChartSidePanel.jsx
@@ -823,6 +823,9 @@ export default function ChartSidePanel({ item, krwRate = DEFAULT_KRW_RATE, onClo
 
       {/* 패널 — full-height 슬라이드 */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="종목 상세"
         className="fixed top-0 right-0 bg-white shadow-2xl flex flex-col w-full sm:w-[min(620px,48vw)]"
         style={{
           zIndex: 151,

--- a/src/components/ChartSidePanel.jsx
+++ b/src/components/ChartSidePanel.jsx
@@ -816,6 +816,7 @@ export default function ChartSidePanel({ item, krwRate = DEFAULT_KRW_RATE, onClo
     <>
       {/* 딤 오버레이 */}
       <div
+        aria-hidden="true"
         className="fixed inset-0 bg-black/30"
         style={{ zIndex: 150 }}
         onClick={onClose}
@@ -825,7 +826,7 @@ export default function ChartSidePanel({ item, krwRate = DEFAULT_KRW_RATE, onClo
       <div
         role="dialog"
         aria-modal="true"
-        aria-label="종목 상세"
+        aria-label={`${item?.name || item?.symbol || '종목'} 상세`}
         className="fixed top-0 right-0 bg-white shadow-2xl flex flex-col w-full sm:w-[min(620px,48vw)]"
         style={{
           zIndex: 151,

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -116,6 +116,7 @@ export default function Header({
           {onDarkToggle && (
             <button
               onClick={onDarkToggle}
+              aria-label={dark ? '라이트 모드로 전환' : '다크 모드로 전환'}
               title={dark ? '라이트 모드로 전환' : '다크 모드로 전환'}
               className="flex items-center justify-center w-8 h-8 rounded-lg text-[#6B7684] hover:bg-[#F2F4F6] hover:text-[#191F28] transition-colors"
             >


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
- [STYLE] `aria-modal="true"` 선언했으나 포커스 트랩/초기 포커스/닫힘 시 포커스 복원이 없음. 현 diff는 회귀가 아니며, 별도 이슈로 관리 권장.
- [STYLE] Header의 `title`과 `aria-label`이 동일 문구 — 스크린리더 중복 발화 가능하나 시각 툴팁 용도로 유지해도 무방. 유지 OK.
- [STYLE] 딤 오버레이(L818)는 `aria-hidden`/`tabIndex=-1` 없음 — 포커스 트랩 작업 시 함께 정리하면 좋음.

### Codex gate (OpenAI)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #137

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 상세 정보 패널과 다크 모드 토글 버튼에 접근성 속성을 추가하여 보조 기술 사용자의 이용 편의성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->