### PR TITLE
chore: #138 CI 워크플로우 추가 — lint/test/build 자동 가드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  ci:
+    name: lint / test / build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test
+
+      - name: Build
+        run: npm run build

--- a/src/components/ChartSidePanel.jsx
+++ b/src/components/ChartSidePanel.jsx
@@ -823,6 +823,9 @@ export default function ChartSidePanel({ item, krwRate = DEFAULT_KRW_RATE, onClo
 
       {/* 패널 — full-height 슬라이드 */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="종목 상세"
         className="fixed top-0 right-0 bg-white shadow-2xl flex flex-col w-full sm:w-[min(620px,48vw)]"
         style={{
           zIndex: 151,

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -116,6 +116,7 @@ export default function Header({
           {onDarkToggle && (
             <button
               onClick={onDarkToggle}
+              aria-label={dark ? '라이트 모드로 전환' : '다크 모드로 전환'}
               title={dark ? '라이트 모드로 전환' : '다크 모드로 전환'}
               className="flex items-center justify-center w-8 h-8 rounded-lg text-[#6B7684] hover:bg-[#F2F4F6] hover:text-[#191F28] transition-colors"
             >


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` 신규 추가
- PR/push to main 트리거 → `npm run lint / test / build` 순차 실행
- tsbot의 `ci.yml` 포팅 (typecheck는 v5 스크립트 없어 생략)

## 안전장치
- 현재는 **경고 모드** (실패해도 머지 가능)
- 안정화 확인 후 별도 작업으로 ruleset에 `Require status checks` 연결 예정

## Test plan
- [ ] PR 생성 직후 CI 자동 실행 확인
- [ ] lint/test/build 각 단계 통과 여부 확인
- [ ] 실패 시 원인 파악 후 수정

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)