### PR TITLE
fix: hantoo-market-investor FID_COND 거부 시 Naver 자동 fallback (#135)

### DIFF
--- a/api/hantoo-market-investor.js
+++ b/api/hantoo-market-investor.js
@@ -82,16 +82,18 @@ export default async function handler(req, res) {
   try {
     let kospi, kosdaq;
 
-    // 한투 API 키가 설정된 경우 — 정확한 실시간 데이터
-    if (process.env.HANTOO_APP_KEY && process.env.HANTOO_APP_SECRET) {
+    // 한투 우선 시도 → 에러 시 Naver 자동 fallback (#135: FID_COND_MRKT_DIV_CODE 거부 대응)
+    try {
+      if (!process.env.HANTOO_APP_KEY || !process.env.HANTOO_APP_SECRET) {
+        throw new Error('HANTOO_APP_KEY 미설정');
+      }
       const token = await getHantooToken();
       [kospi, kosdaq] = await Promise.all([
         fetchMarketFromHantoo(token, '0001', today),
         fetchMarketFromHantoo(token, '1001', today),
       ]);
-    } else {
-      // Naver fallback — 한투 키 미설정 시
-      console.warn('[market-investor] HANTOO_APP_KEY 미설정 → Naver fallback');
+    } catch (hantooErr) {
+      console.warn('[market-investor] 한투 실패 → Naver fallback:', hantooErr.message);
       [kospi, kosdaq] = await Promise.all([
         fetchMarketFromNaver('KOSPI'),
         fetchMarketFromNaver('KOSDAQ'),

--- a/api/hantoo-market-investor.js
+++ b/api/hantoo-market-investor.js
@@ -30,7 +30,7 @@ async function fetchMarketFromHantoo(token, iscd, today) {
       tr_id:         'FHKST01010900',
       custtype:      'P',
     },
-    signal: AbortSignal.timeout(6000),
+    signal: AbortSignal.timeout(4000),
   });
 
   if (!apiRes.ok) throw new Error(`HTTP ${apiRes.status}`);
@@ -57,7 +57,7 @@ async function fetchMarketFromNaver(marketCode) {
   const naverUrl = `https://m.stock.naver.com/api/index/${marketCode}/investor`;
   const res = await fetch(
     `${PROXY}${encodeURIComponent(naverUrl)}`,
-    { signal: AbortSignal.timeout(7000) },
+    { signal: AbortSignal.timeout(5000) },
   );
   if (!res.ok) throw new Error(`Naver proxy ${res.status}`);
   const wrapper = await res.json();


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Codex gate (OpenAI)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #135

---
🤖 Generated by Claude Code [claude-sonnet-4-6]