### PR TITLE
fix: :prev 백업 경량 재도입 — snap:* 전체 + counter 키별 (#128)

### DIFF
--- a/workers/cron/src/price-cache.js
+++ b/workers/cron/src/price-cache.js
@@ -58,10 +58,11 @@ const BACKUP_INTERVAL = 5; // 크론 5분 × 5회 = 25분 주기 (BACKUP_TTL 360
 export async function setSnap(key, data, ex) {
   if (!_redis) return false;
   try {
-    // 메인 키만 백업 대상 — SNAP_KEYS.KR/US/COINS 만 getSnapWithFallback 사용.
-    const isMainKey = key === SNAP_KEYS.KR || key === SNAP_KEYS.US || key === SNAP_KEYS.COINS;
+    // snap:* 전체 백업 — 메인 키(getSnapWithFallback) + 미국 샤드 키(api/_price-cache.js:getUsSnap)
+    // 둘 다 :prev fallback을 실제 읽음. cron:fail:* 등 기타 키는 스킵.
+    const isBackupKey = typeof key === 'string' && key.startsWith('snap:');
 
-    if (isMainKey) {
+    if (isBackupKey) {
       try {
         // 총 subrequest: incr(1) + set 메인(1) + 20%[get+set:prev = 2] = 평균 2.4/호출
         const counterKey = `setSnap:counter:${key}`;

--- a/workers/cron/src/price-cache.js
+++ b/workers/cron/src/price-cache.js
@@ -59,7 +59,7 @@ export async function setSnap(key, data, ex) {
   try {
     // 평균 subrequest: (9*1 + 1*3)/10 = 1.2회 (set 1 + 10% 확률 get+set 추가)
     try {
-      const counter = await _redis.incr('setSnap:counter');
+      const counter = await _redis.incr(`setSnap:counter:${key}`);
       if (counter % BACKUP_INTERVAL === 0) {
         const existing = await _redis.get(key);
         if (existing !== null) {

--- a/workers/cron/src/price-cache.js
+++ b/workers/cron/src/price-cache.js
@@ -49,24 +49,35 @@ export async function getSnapWithFallback(key) {
   } catch (e) { console.error(`[price-cache] 백업 조회 실패:`, e); return null; }
 }
 
-// #128: :prev 백업 경량 재도입 — counter 기반 N회 중 1회만 백업.
-// #125에서 subrequest 한계(50/invocation) 때문에 모든 setSnap 백업을 제거했으나,
-// getSnapWithFallback이 :prev를 참조하므로 fallback이 무력화 → 주기적 백업으로 복원.
-const BACKUP_INTERVAL = 10; // setSnap 10회당 1회 :prev 백업 (BACKUP_TTL은 line 33 재사용)
+// #128: :prev 백업 경량 재도입 — counter 기반 N회 중 1회, 메인 키만 백업.
+// #125에서 subrequest 한계(50/invocation) 때문에 모든 백업을 제거했으나,
+// getSnapWithFallback이 :prev를 참조하므로 fallback 무력화 → 주기적 백업 복원.
+// 샤드 키는 getSnapWithFallback 대상이 아니므로 백업 스킵(죽은 subrequest 방지).
+const BACKUP_INTERVAL = 5; // 크론 5분 × 5회 = 25분 주기 (BACKUP_TTL 3600s 대비 ~35분 마진)
 
 export async function setSnap(key, data, ex) {
   if (!_redis) return false;
   try {
-    // 평균 subrequest: (9*1 + 1*3)/10 = 1.2회 (set 1 + 10% 확률 get+set 추가)
-    try {
-      const counter = await _redis.incr(`setSnap:counter:${key}`);
-      if (counter % BACKUP_INTERVAL === 0) {
-        const existing = await _redis.get(key);
-        if (existing !== null) {
-          await _redis.set(`${key}:prev`, existing, { ex: BACKUP_TTL });
+    // 메인 키만 백업 대상 — SNAP_KEYS.KR/US/COINS 만 getSnapWithFallback 사용.
+    const isMainKey = key === SNAP_KEYS.KR || key === SNAP_KEYS.US || key === SNAP_KEYS.COINS;
+
+    if (isMainKey) {
+      try {
+        // 총 subrequest: incr(1) + set 메인(1) + 20%[get+set:prev = 2] = 평균 2.4/호출
+        const counterKey = `setSnap:counter:${key}`;
+        const counter = await _redis.incr(counterKey);
+        if (counter === 1) {
+          // 최초 생성 시 TTL 부여 → 좀비 counter 키 누적 방지 (3시간)
+          await _redis.expire(counterKey, BACKUP_TTL * 3);
         }
-      }
-    } catch { /* 백업 실패는 메인 쓰기를 막지 않음 */ }
+        if (counter % BACKUP_INTERVAL === 0) {
+          const existing = await _redis.get(key);
+          if (existing !== null) {
+            await _redis.set(`${key}:prev`, existing, { ex: BACKUP_TTL });
+          }
+        }
+      } catch (e) { console.warn('[price-cache] :prev 백업 실패', key, e?.message); }
+    }
 
     await _redis.set(key, data, { ex });
     return true;

--- a/workers/cron/src/price-cache.js
+++ b/workers/cron/src/price-cache.js
@@ -49,12 +49,25 @@ export async function getSnapWithFallback(key) {
   } catch (e) { console.error(`[price-cache] 백업 조회 실패:`, e); return null; }
 }
 
+// #128: :prev 백업 경량 재도입 — counter 기반 N회 중 1회만 백업.
+// #125에서 subrequest 한계(50/invocation) 때문에 모든 setSnap 백업을 제거했으나,
+// getSnapWithFallback이 :prev를 참조하므로 fallback이 무력화 → 주기적 백업으로 복원.
+const BACKUP_INTERVAL = 10; // setSnap 10회당 1회 :prev 백업 (BACKUP_TTL은 line 33 재사용)
+
 export async function setSnap(key, data, ex) {
   if (!_redis) return false;
   try {
-    // #125: :prev 백업 쓰기 제거 — subrequest 한계(50/invocation) 회피
-    // get+set 2회 → set 1회로 감소. 원본 snap:<key> TTL이 크론 주기의 2배이므로
-    // 크론 1회 실패는 다음 주기에 자연 복구. 장시간 다운 대비는 Worker 전체 장애 상황.
+    // 평균 subrequest: (9*1 + 1*3)/10 = 1.2회 (set 1 + 10% 확률 get+set 추가)
+    try {
+      const counter = await _redis.incr('setSnap:counter');
+      if (counter % BACKUP_INTERVAL === 0) {
+        const existing = await _redis.get(key);
+        if (existing !== null) {
+          await _redis.set(`${key}:prev`, existing, { ex: BACKUP_TTL });
+        }
+      }
+    } catch { /* 백업 실패는 메인 쓰기를 막지 않음 */ }
+
     await _redis.set(key, data, { ex });
     return true;
   } catch (e) { console.error(`[price-cache] setSnap 실패 (${key}):`, e); return false; }


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Codex gate (OpenAI)
- PASS (지적사항 처리: [채택] snap:* allowlist로 확장(685ce6a) — 샤드 fallback 보존. Opus CRITICAL과 Codex P1 양쪽 수용)

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #128

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 가격 캐시 백업 메커니즘을 개선했습니다. 이제 백업 오류가 더 이상 주요 작업을 중단하지 않습니다.

* **개선 사항**
  * 캐시 데이터 안정성을 강화하기 위해 주기적 샘플링 기반의 백업 시스템으로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->