### PR TITLE
fix: vwap_deviation 시그널 일시 비활성화 — 적중률 0% (#155)

### DIFF
--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -549,20 +549,21 @@ export function createOrderFlowSignal(symbol, bidVolume, askVolume) {
   }));
 }
 
-/** VWAP 편차 평균회귀 시그널 */
-export function createVWAPSignal(symbol, name, market, currentPrice, vwap) {
-  if (!vwap || !currentPrice) return null;
-  const deviation = ((currentPrice - vwap) / vwap) * 100;
-  if (Math.abs(deviation) < 3) return null;
-  // 평균회귀: VWAP 위로 이탈 → 하방, 아래로 이탈 → 상방
-  const direction = deviation > 0 ? DIRECTIONS.BEARISH : DIRECTIONS.BULLISH;
-  const strength = Math.abs(deviation) > 5 ? 4 : 3;
-  const title = `${name} VWAP 대비 ${deviation > 0 ? '+' : ''}${deviation.toFixed(1)}% — 평균회귀 가능`;
-  return addSignal(createSignal({
-    type: SIGNAL_TYPES.VWAP_DEVIATION,
-    symbol, name, market, direction, strength,
-    title, meta: { currentPrice, vwap, deviation },
-  }));
+/** VWAP 편차 평균회귀 시그널 — [비활성] 적중률 0% (#155, 2026-04-20)
+ *
+ * 실사용 데이터 453건 판정 결과 1h/4h/24h 적중률 모두 0.0%.
+ * 원인: 평균회귀 가정(VWAP 위 이탈 → 하방, 아래 이탈 → 상방)이 현재 시장 regime에서 실패.
+ *   - 391 bearish (deviation > 0) → 1h 평균 +0.01% 상승 (복귀 없음)
+ *   - 62  bullish (deviation < 0) → 1h 평균 +0.01% (반등 없음)
+ *
+ * 복원 조건 (둘 중 하나 충족 시):
+ *   1) 장기 타임프레임(24h+) 전용 판정 로직 도입
+ *   2) 방향 반전(추세 추종) 버전 A/B 테스트로 유의미한 적중률 확보
+ *
+ * 기존 호출부는 유지 — 본 함수가 null을 반환해 신규 시그널 발화만 중단.
+ */
+export function createVWAPSignal(_symbol, _name, _market, _currentPrice, _vwap) {
+  return null;
 }
 
 /** 소셜 감성 시그널 — 최소 표본 5건 (완화), 상수 기반 임계값 */


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
- [STYLE] 비활성화 방식이 적절. 함수 시그니처 유지로 호출부(`src/engine/signalEngine.js`) 수정 불필요, null 반환은 기존 early-return 경로와 동일해 호출부 호환성 보장.
- [STYLE] 주석 품질 우수 — 근거(1h/4h/24h 0%), 세부 분포(391 bearish / 62 bullish), 복원 조건 2가지, 이슈 번호(#155)·날짜(2026-04-20) 모두 명시. 향후 되살릴 때 판단 근거가 된다.
- [STYLE] `SIGNAL_TYPES.VWAP_DEVIATION` 상수는 유지됨 — 과거 시그널의 `signal_accuracy` 뷰/DB 레코드 조회 위해 필요하므로 유지 적절.
- [PERF] 무관 — 계산·객체 생성 제거로 미미하게 개선.
- [HIGH] 호출부가 null 반환을 안전하게 처리하는지 → 원본도 `!vwap || !currentPrice`, `|deviation| < 3`에서 null 반환했으므로 기존 경로와 동일. 리스크 없음.

### Codex gate (OpenAI)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #155

---
🤖 Generated by Claude Code [claude-sonnet-4-6]