### PR TITLE
fix: 적중률 크론 changePct sanity guard (#158)

### DIFF
--- a/api/cron/check-signal-accuracy.js
+++ b/api/cron/check-signal-accuracy.js
@@ -120,23 +120,37 @@ function isHit(direction, changePct) {
   return false;
 }
 
+// 비현실적 changePct 상한 — 단위 불일치(USD/KRW 혼합) 방어 (#158)
+// 예: 코인 시그널이 USD로 기록된 후 KRW 스냅샷과 비교돼 149,188% 같은 가짜 변동 산출.
+// 500% 초과는 실거래에서 발생 극히 드물며, 이 경계를 넘으면 데이터 품질 문제로 간주하고
+// 판정 보류 (hit_Xh NULL 유지) → signal_accuracy 뷰가 NULL을 집계 제외 (#152)해 보호됨.
+const CHANGE_PCT_SANITY_LIMIT = 500;
+
 async function evaluateHorizon(horizon, prices) {
   const pending = await listPending(horizon, 100);
   if (!pending.length) return 0;
 
   const items = [];
+  let rejected = 0;
   for (const sig of pending) {
     const curPrice = prices[sig.symbol];
     if (!curPrice || !sig.price_at_fire) continue;
     const base = Number(sig.price_at_fire);
     if (!base) continue;
     const changePct = ((curPrice - base) / base) * 100;
+    if (Math.abs(changePct) > CHANGE_PCT_SANITY_LIMIT) {
+      rejected += 1;
+      continue;
+    }
     items.push({
       id: sig.id,
       price: curPrice,
       change: +changePct.toFixed(2),
       hit: isHit(sig.direction, changePct),
     });
+  }
+  if (rejected > 0) {
+    console.warn(`[signal-accuracy] ${horizon} rejected ${rejected} signals (|change| > ${CHANGE_PCT_SANITY_LIMIT}%)`);
   }
   return updateEvaluationBatch(horizon, items);
 }


### PR DESCRIPTION
## 문제

double_bottom 시그널 118건 판정 중 코인 레코드 change_1h 비현실적(149,188%).
코인 시그널 발화 시 USD 기록(ta-indicators) vs 크론 평가 시 KRW(snapshot) → 단위 불일치.

## 조치

`evaluateHorizon`에 `Math.abs(changePct) > 500` sanity check 추가:
- 비현실적 변동은 판정 보류 (hit_Xh NULL 유지)
- signal_accuracy 뷰는 이미 NULL 제외(#152) → 통계 즉시 보호
- 모니터링용 rejected 카운트 console.warn

## 리뷰

- 🤖 code-reviewer (Opus): **PASS** (bc9b9df)
- 🔍 Codex Gate: **PASS** ("no discrete regressions")

## 기존 데이터

118건 코인 double_bottom 오염 레코드는 유지 (역사 데이터, 신규 발화만 보호).

## 후속 (별도 이슈)

- ta-indicators/snapshot 통화 정규화

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)