### PR TITLE
fix: update-coins 데드 소스 제거 — Upbit 전용 (#167)

### DIFF
--- a/workers/cron/src/crons/update-coins.js
+++ b/workers/cron/src/crons/update-coins.js
@@ -1,20 +1,14 @@
-// crons/update-coins.js — 코인 가격 갱신 (CF Workers 이식)
-// Upbit REST (primary) → Bithumb REST (fallback), CoinPaprika 병렬 보강.
-// #104 B1/B2/B4 수정:
-//   B1 — Promise.all 단일 실패점 → allSettled 로 부분 성공 허용
-//   B2 — CoinPaprika limit=100 → 300 + priceUsd=0 필터링
-//   B4 — Upbit ticker 전종목 실패 시 Bithumb public/ticker/ALL_KRW fallback
+// crons/update-coins.js — 코인 가격 갱신 (CF Workers, Upbit 전용)
+// 2026-04-20 #167: Bithumb fallback / CoinPaprika / CoinGecko 제거.
+//   사유: priceUsd / marketCap / volume24h 가 프로덕션에서 항상 0 → 실효성 0.
+//   Upbit REST(ticker/all 1 call + 실패 시 청크 fallback)만 유지.
 //
-// 타임아웃 예산 (Edge runtime 기본 30s maxDuration):
-//   Phase 1: markets(5s) || paprika(4s) 병렬 → ~5s
-//   Phase 2: upbit tickers chunks(6s) 병렬   → ~6s
-//   Phase 3: bithumb(10s) — Phase 2 전부 실패시에만 실행 → 최대 +10s
-//   Worst case (primary 타임아웃 후 fallback): ~5 + 6 + 10 = ~21s < 30s
+// 타임아웃 예산 (CF Workers 기본 maxDuration 30s):
+//   Phase 1: Upbit markets(5s) 단독 → ~5s
+//   Phase 2: ticker/all(6s) or 청크 fallback(6s) → ~6s
+//   Worst case: ~11s
 
 import { SNAP_KEYS, SNAP_TTL, setSnap, recordCronFailure } from '../price-cache.js';
-
-// 외부 API 호출 시 CF Worker IP 차단 방지용 User-Agent
-const UA_HEADER = { 'User-Agent': 'MarketRadar/5.0' };
 
 // #104 Opus: Upbit markets 전량 실패 + Bithumb fallback 경로에서도 최소한의 한글명 보장.
 // 라이브 Upbit 한글명 매핑을 1-off 로 추출 (Top 40 KRW 마켓).
@@ -87,157 +81,32 @@ async function fetchUpbitTickers(markets, timeoutMs = 6000) {
   return results.flat();
 }
 
-// #104 B4: Bithumb REST fallback — Upbit 완전 실패 시만 호출
-// 응답 스키마: { status, data: { BTC: {...}, ETH: {...}, ..., date: "..." } }
-// Upbit 티커 포맷으로 정규화하여 동일 파이프라인에 흘려보냄.
-//
-// ⚠️ 변동률 의미 주의 (#104 Opus 리뷰):
-//   - Upbit `signed_change_rate` = (현재가 - 전일 종가) / 전일 종가 → 24h 기준
-//   - Bithumb `opening_price`    = 00:00 KST 기준 일일 시가 (일중 리셋)
-//   직접 (close-open)/open 을 쓰면 "24h 변동률" 이 "일중 변동률" 로 의미가 바뀐다.
-//   Bithumb 는 `fluctate_rate_24H` 필드(24h 변동률, %, 문자열)를 제공하므로 이쪽을 사용.
-async function fetchBithumbTickers() {
-  const res = await fetch('https://api.bithumb.com/public/ticker/ALL_KRW', {
-    headers: { Accept: 'application/json' },
-    signal: AbortSignal.timeout(10000),
-  });
-  if (!res.ok) throw new Error(`Bithumb ALL_KRW HTTP ${res.status}`);
-  const json = await res.json();
-  if (json.status !== '0000' || !json.data) {
-    throw new Error(`Bithumb 응답 비정상: status=${json.status}`);
-  }
-  const tickers = [];
-  for (const [symbol, row] of Object.entries(json.data)) {
-    // non-coin 필드(`date` 등) 방어: closing_price 존재 여부를 primary gate 로.
-    if (!row || typeof row !== 'object' || row.closing_price == null) continue;
-    const close = parseFloat(row.closing_price);
-    if (!Number.isFinite(close) || close <= 0) continue;
-    // 24h 변동률: fluctate_rate_24H(%) 만 사용.
-    // prev_closing_price 는 "전일 종가" 로 00:00 KST 리셋되는 일일 기준이라
-    // "24h 롤링" 의미가 아님 → Upbit signed_change_rate 와 드리프트. 없으면 0.
-    let changeRate = 0;
-    const rate24H = parseFloat(row.fluctate_rate_24H);
-    if (Number.isFinite(rate24H)) {
-      changeRate = rate24H / 100; // Upbit 와 동일하게 0.05 = 5%
-    }
-    tickers.push({
-      market: `KRW-${symbol}`,
-      trade_price: close,
-      signed_change_rate: changeRate,
-      acc_trade_price_24h: parseFloat(row.acc_trade_value_24H) || 0,
-      high_price: parseFloat(row.max_price) || 0,
-      low_price:  parseFloat(row.min_price) || 0,
-      _source: 'bithumb',
-    });
-  }
-  if (!tickers.length) throw new Error('Bithumb: 유효한 티커 없음');
-  return tickers;
-}
-
-// CoinPaprika 글로벌 시세 조회 (USD + KRW)
-// #104 B2: limit 100 → 300 으로 상향해 Upbit KRW 244 개 커버 (+ 마진).
-// #117: limit 300 → 500 으로 추가 상향 + 실패 시 1회 재시도.
-//       시총 300위 밖 코인(WAXP, CARV, LSK 등) 컷오프 해소.
-// #104 Opus: paprika 는 보강 데이터라 실패해도 snapshot 저장에 영향 없음.
-// Edge 10s 예산을 지키기 위해 타임아웃 10s → 4s 로 축소. 실패는 allSettled 가 흡수.
-// #132: CoinPaprika 상업 라이선스 필요 (402). 보조 데이터 소스로 유지하되 실패 허용.
-async function fetchCoinPaprikaOnce() {
-  const res = await fetch('https://api.coinpaprika.com/v1/tickers?limit=500&quotes=KRW,USD', {
-    headers: { Accept: 'application/json', ...UA_HEADER },
-    signal: AbortSignal.timeout(4000),
-  });
-  if (!res.ok) throw new Error(`CoinPaprika HTTP ${res.status}`);
-  return res.json();
-}
-
-async function fetchCoinPaprika() {
-  try {
-    return await fetchCoinPaprikaOnce();
-  } catch (e) {
-    // #117: 1회 재시도 (네트워크 일시 실패 대응). 재시도도 실패하면 throw하여
-    // 호출부 allSettled가 rejected로 감지하고 정확히 경고 로그를 남기도록 한다.
-    console.warn('[update-coins] CoinPaprika 1차 실패 재시도:', e.message);
-    return await fetchCoinPaprikaOnce();
-  }
-}
-
-// #117: CoinGecko 2차 fallback — paprika 누락 심볼만 보강
-// 무료 tier 30 req/min. page=1,2 두 번만 호출 → 500개 커버 (안전 마진 충분).
-// Promise.allSettled 로 단일 페이지 실패는 흡수. 완전 실패 시 빈 배열.
-// #132: User-Agent 추가 — CF Worker IP에서 CoinGecko 403 방지
-async function fetchCoinGeckoPage(page, timeoutMs = 4000) {
-  const url = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=250&page=${page}`;
-  const res = await fetch(url, {
-    headers: { Accept: 'application/json', ...UA_HEADER },
-    signal: AbortSignal.timeout(timeoutMs),
-  });
-  if (!res.ok) throw new Error(`CoinGecko page=${page} HTTP ${res.status}`);
-  return res.json();
-}
-
-async function fetchCoinGecko() {
-  const settled = await Promise.allSettled([
-    fetchCoinGeckoPage(1),
-    fetchCoinGeckoPage(2),
-  ]);
-  const merged = [];
-  for (const r of settled) {
-    if (r.status === 'fulfilled' && Array.isArray(r.value)) {
-      merged.push(...r.value);
-    } else if (r.status === 'rejected') {
-      console.warn('[update-coins] CoinGecko 페이지 실패:', r.reason?.message);
-    }
-  }
-  return merged;
-}
-
 export async function updateCoins(env) {
   try {
-    // 1단계: Upbit 마켓 목록 + CoinPaprika 동시 조회
-    // #104 B1: Promise.all 단일 실패점 제거 → allSettled 로 부분 성공 허용.
-    const [marketsRes, paprikaRes] = await Promise.allSettled([
-      fetchUpbitMarkets(),
-      fetchCoinPaprika(),
-    ]);
-    const markets = marketsRes.status === 'fulfilled' ? marketsRes.value : null;
-    const paprikaData = paprikaRes.status === 'fulfilled' ? paprikaRes.value : [];
-    if (marketsRes.status === 'rejected') {
-      console.warn('[update-coins] Upbit markets 실패:', marketsRes.reason?.message);
-    }
-    if (paprikaRes.status === 'rejected') {
-      console.warn('[update-coins] CoinPaprika 실패 (보강 데이터 생략):', paprikaRes.reason?.message);
+    // 1단계: Upbit 마켓 목록 (한국어 이름 매핑용)
+    let markets = null;
+    try {
+      markets = await fetchUpbitMarkets();
+    } catch (e) {
+      console.warn('[update-coins] Upbit markets 실패:', e.message);
     }
 
-    // 2단계: Upbit 티커 — ticker/all 우선(1회 요청), 청크 fallback, Bithumb 최종
+    // 2단계: Upbit 티커 — ticker/all 우선(1회 요청), 실패 시 청크 fallback
     // #133: ticker/all API로 전종목 단일 요청 (기존 100개 청크 분할 N회 → 1회)
     let tickers = null;
-    let tickerSource = 'upbit';
     try {
       tickers = await fetchUpbitTickerAll();
     } catch (e) {
       console.warn('[update-coins] ticker/all 실패, 청크 fallback:', e.message);
       if (markets && markets.length > 0) {
-        try {
-          tickers = await fetchUpbitTickers(markets);
-        } catch (e2) {
-          console.warn('[update-coins] Upbit 청크도 실패:', e2.message);
-        }
+        tickers = await fetchUpbitTickers(markets);
       }
     }
     if (!tickers || tickers.length === 0) {
-      try {
-        tickers = await fetchBithumbTickers();
-        tickerSource = 'bithumb';
-        console.log(`[update-coins] Bithumb fallback 성공: ${tickers.length}개`);
-      } catch (e) {
-        throw new Error(`Upbit + Bithumb 모두 실패: ${e.message}`);
-      }
+      throw new Error('Upbit 티커 수집 전량 실패');
     }
 
     // 마켓 이름 매핑 (market code → korean_name)
-    // #104 Codex P2: Bithumb fallback 경로에서 Upbit markets 재시도는 Edge 10s
-    // 예산을 추가로 5~8s 깎아 먹을 수 있음. 따라서 markets 가 없어도 재시도하지 않고
-    // 바로 static COIN_KR_NAMES_FALLBACK 으로 주요 코인을 커버.
     const nameMap = new Map();
     if (markets) {
       for (const m of markets) {
@@ -250,59 +119,12 @@ export async function updateCoins(env) {
       if (!nameMap.has(key)) nameMap.set(key, kr);
     }
 
-    // CoinPaprika 심볼 매핑 (symbol → { priceUsd, marketCap, volume24h })
-    // #104 B2: priceUsd=0 인 row 는 맵에 넣지 않음 — 조용한 0 값 차단.
-    //         호출자는 paprika 누락을 "데이터 없음(0)" 으로 깔끔하게 처리.
-    // #104 Codex: 동일 티커 중복(다른 프로젝트가 같은 심볼) 시 시가총액 큰 쪽을
-    //            유지. paprika 는 market cap 내림차순 정렬이므로 first-wins 로 충분.
-    const paprikaMap = new Map();
-    for (const coin of paprikaData) {
-      if (!coin.symbol) continue;
-      const key = coin.symbol.toUpperCase();
-      if (paprikaMap.has(key)) continue; // 먼저 들어온(=더 큰 시총) row 유지
-      const priceUsd  = coin.quotes?.USD?.price ?? 0;
-      const marketCap = coin.quotes?.USD?.market_cap ?? 0;
-      const volume24h = coin.quotes?.USD?.volume_24h ?? 0;
-      if (priceUsd <= 0) continue;
-      paprikaMap.set(key, { priceUsd, marketCap, volume24h });
-    }
-
-    // #117: CoinGecko 2차 fallback — paprika 누락(=priceUsd<=0) 심볼만 보강.
-    // paprika 에 이미 있는 심볼은 덮어쓰지 않음 (시총 큰 쪽 유지 정책 보존).
-    // Upbit KRW 마켓 심볼 집합을 먼저 만들어 "결손 여부" 를 계산.
-    const needGecko = new Set();
-    for (const t of tickers) {
-      const sym = t.market.replace('KRW-', '').toUpperCase();
-      if (!paprikaMap.has(sym)) needGecko.add(sym);
-    }
-    let geckoFillCount = 0;
-    if (needGecko.size > 0) {
-      const geckoData = await fetchCoinGecko();
-      // CoinGecko 도 market_cap_desc 정렬 → first-wins 로 시총 큰 쪽 유지.
-      const geckoSeen = new Set();
-      for (const coin of geckoData) {
-        if (!coin?.symbol) continue;
-        const key = coin.symbol.toUpperCase();
-        if (geckoSeen.has(key)) continue;
-        geckoSeen.add(key);
-        if (!needGecko.has(key)) continue; // paprika 커버 심볼은 건너뜀
-        const priceUsd  = Number(coin.current_price) || 0;
-        const marketCap = Number(coin.market_cap) || 0;
-        const volume24h = Number(coin.total_volume) || 0;
-        if (priceUsd <= 0) continue;
-        paprikaMap.set(key, { priceUsd, marketCap, volume24h });
-        geckoFillCount += 1;
-      }
-    }
-
-    // Upbit/Bithumb 티커 → 통합 형태 변환
+    // Upbit 티커 → 통합 형태 변환
+    // #167: priceUsd/marketCap/volume24h(USD) 는 CoinPaprika/CoinGecko 제거로 0 고정.
+    //       priceUsd 는 클라이언트(coinWs.js)가 priceKrw / 환율로 계산해 복구.
     const items = tickers.map((t) => {
       const symbol = t.market.replace('KRW-', '');
-      const paprika = paprikaMap.get(symbol) || {};
-
-      // 변동률: Upbit/Bithumb 정규화된 signed_change_rate 는 소수 (0.05 = 5%)
       const change24h = (t.signed_change_rate ?? 0) * 100;
-
       return {
         id: symbol.toLowerCase(),
         symbol,
@@ -310,32 +132,22 @@ export async function updateCoins(env) {
         market: 'coin',
         priceKrw: t.trade_price ?? 0,
         change24h: parseFloat(change24h.toFixed(2)),
-        // CoinPaprika 보강 데이터 (없으면 0)
-        priceUsd: paprika.priceUsd ?? 0,
-        marketCap: paprika.marketCap ?? 0,
-        volume24h: paprika.volume24h ?? 0,
-        // Upbit/Bithumb 추가 데이터
+        priceUsd: 0,
+        marketCap: 0,
+        volume24h: 0,
         accTradePrice24h: t.acc_trade_price_24h ?? 0,
         highPrice: t.high_price ?? 0,
         lowPrice: t.low_price ?? 0,
       };
     });
-    // #117: 커버리지 관측 로그 — paprika 와 CoinGecko fallback 기여분 분리 표기.
-    const paprikaBase = paprikaMap.size - geckoFillCount;
-    const missingMeta = items.filter((it) => (it.priceUsd ?? 0) <= 0).length;
-    console.log(
-      `[update-coins] 저장: ${items.length}개 ` +
-      `(source=${tickerSource}, paprika=${paprikaBase} coingecko_fallback=${geckoFillCount} missing_meta=${missingMeta})`,
-    );
+    console.log(`[update-coins] 저장: ${items.length}개 (source=upbit)`);
 
-    // Redis 저장
     if (items.length > 0) {
       await setSnap(SNAP_KEYS.COINS, items, SNAP_TTL.COINS);
     }
 
     return { ok: true, count: items.length };
   } catch (err) {
-    // Cron 실패 기록 (모니터링용) — 기록 실패가 에러 응답을 덮어쓰지 않도록 방어
     try { await recordCronFailure('coins', String(err?.message || err)); } catch (_) { /* 무시 */ }
     throw err;
   }


### PR DESCRIPTION
## 배경

2026-04-20 프로덕션 \`/api/snapshot?debug=1\` 확인 결과 모든 코인의 \`priceUsd\` / \`marketCap\` / \`volume24h\` 가 **이미 전부 0** — CoinPaprika(402 상업 라이선스 필요) · CoinGecko(403/rate limit) 가 실제로 데이터 반영 안 함.

## 변경

### 제거 (212줄)
- \`fetchBithumbTickers\` — Upbit 전체 실패 시 fallback (장기간 미발동)
- \`fetchCoinPaprika\` / \`fetchCoinPaprikaOnce\` — priceUsd 보강 (실효성 0)
- \`fetchCoinGecko\` / \`fetchCoinGeckoPage\` — paprika 누락 보강 (실효성 0)
- \`updateCoins()\` 내부 paprikaMap / needGecko / fallback 로직
- UA_HEADER 상수

### 유지
- \`fetchUpbitMarkets\` (한국어 이름 매핑)
- \`fetchUpbitTickerAll\` (전종목 1 call)
- \`fetchUpbitTickers\` (청크 fallback)

## 필드 처리

| 필드 | 현재 (before PR) | 본 PR 이후 |
|---|---|---|
| priceKrw, change24h, highPrice, lowPrice, accTradePrice24h | Upbit → 정상 | 변화 없음 |
| priceUsd | **이미 0** (paprika/gecko 실패) | 0 — coinWs.js:162에서 priceKrw/환율로 클라이언트 복구 |
| marketCap, volume24h(USD) | **이미 0** | 0 |

**실질 데이터 손실 없음** — 이미 0이던 값이 명시적으로 0으로 기록될 뿐.

## 효과

- update-coins.js: 342 → 154줄 (55% 감소)
- subrequest 4개 절감 (paprika 1 + gecko 2 + bithumb fallback 1)
- 실패 진단 단순화: Upbit만 확인하면 됨

## Codex gate 지적 3건 기각 사유

| 지적 | 판단 | 사유 |
|---|---|---|
| P2 marketCap 0 → WatchlistTable 집계 무너짐 | **기각** | 프로덕션에서 **이미 marketCap=0**. 본 PR 이전에도 totalMCap/btcDominance 등이 snapshot 기반 집계 시 0이었음. Regression 아님 |
| P2 priceUsd 0 → 김치 프리미엄 cold load 시 null | **기각** | 프로덕션에서 **이미 priceUsd=0**. 김치 프리미엄은 이전부터 WS 연결 후 재계산으로만 복구 가능했음 |
| P3 volume24h 0 → 볼륨 필터/시그널 regression | **기각** | 프로덕션에서 **이미 volume24h=0**. 필터/시그널이 지금도 잘못 계산 중. 본 PR 범위 외 |

**증거:**
\`\`\`bash
curl -s 'https://market-dashboard-v5.vercel.app/api/snapshot?debug=1' \\
  | python3 -c 'import sys,json; d=json.load(sys.stdin); [print(c) for c in d[\"coins\"][:3]]'
\`\`\`
결과: 모든 코인 \`priceUsd: 0, marketCap: 0, volume24h: 0\` (본 PR 이전 상태).

정확한 USD 시세·시가총액·볼륨이 필요하다면 별도 이슈(유료 소스 검토)로 분리 권장.

## 검증

- 로컬 \`npm run build\` PASS (2233 modules, 587ms)
- 문법 체크 \`node --check\` PASS
- Opus code-reviewer: PASS

Closes #167

🤖 Generated with Claude Code [claude-opus-4-7]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **리팩토링**
  * 암호화폐 시세 수집 시스템을 개선했습니다. 업비트 데이터를 주요 소스로 통합하고, 추가 폴백 경로 및 다중 데이터 소스 처리 로직을 제거하여 시스템을 간소화했습니다. 에러 처리 프로세스도 단순화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->