### PR TITLE
feat: /api/ops/cron-status 크론 실패 관측 엔드포인트 (#164 Phase A)

### DIFF
--- a/api/ops/cron-status.js
+++ b/api/ops/cron-status.js
@@ -1,0 +1,69 @@
+// api/ops/cron-status.js — 크론 실패 카운트 + 마지막 에러 조회 (#164 Phase A)
+// 인증: x-ops-token 헤더 = OPS_SECRET (fallback: CRON_SECRET). 내부 관측 전용.
+// 응답: { ts, crons: { coins: { failCount, lastError }, kr: {...}, ... } }
+export const config = { runtime: 'edge' };
+
+import { Redis } from '@upstash/redis';
+
+const CRON_NAMES = ['coins', 'kr', 'us', 'signal-accuracy', 'briefing'];
+
+export default async function handler(request) {
+  const auth = (process.env.OPS_SECRET || process.env.CRON_SECRET || '').trim();
+  const token = (request.headers.get('x-ops-token') || '').trim();
+
+  if (!auth) {
+    return new Response(JSON.stringify({ error: 'server misconfigured: OPS_SECRET/CRON_SECRET 미설정' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (token !== auth) {
+    return new Response(JSON.stringify({ error: 'unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const url = process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
+  const kvToken = process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !kvToken) {
+    return new Response(JSON.stringify({ error: 'redis 미구성' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const redis = new Redis({ url, token: kvToken });
+
+  // 5개 크론 × 2 키(failCount + lastError) = 10 키 한 번에 조회
+  const keys = CRON_NAMES.flatMap((c) => [`cron:fail:${c}`, `cron:lastError:${c}`]);
+  let vals;
+  try {
+    vals = await redis.mget(...keys);
+  } catch (e) {
+    return new Response(JSON.stringify({ error: `redis mget 실패: ${String(e?.message || e)}` }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const result = {};
+  for (let i = 0; i < CRON_NAMES.length; i++) {
+    const raw = vals[i * 2 + 1];
+    let lastError = null;
+    if (raw) {
+      try {
+        lastError = typeof raw === 'string' ? JSON.parse(raw) : raw;
+      } catch { lastError = { parseError: true, raw: String(raw).slice(0, 200) }; }
+    }
+    result[CRON_NAMES[i]] = {
+      failCount: parseInt(vals[i * 2] || '0', 10),
+      lastError,
+    };
+  }
+
+  return new Response(JSON.stringify({ ts: new Date().toISOString(), crons: result }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}


### PR DESCRIPTION
## 배경

CF Workers 크론 실패 시 \`recordCronFailure()\` 가 \`cron:fail:*\` / \`cron:lastError:*\` 를 Redis 에 기록하지만 **읽는 경로 없음**. 2026-04-20 US 크론 v7 401 장애 분석 시 수동 \`curl\` 로 Upstash REST 직접 호출하던 경험 반영 — 내부 관측 API 부재가 장애 대응 지연 요인.

## 변경

\`api/ops/cron-status.js\` 신규 (Edge runtime):

- \`x-ops-token\` 헤더 인증 — \`OPS_SECRET\` 우선, fallback \`CRON_SECRET\`
- Redis \`mget\` 으로 5 크론 × 2 키 = 10 키 한 번 조회
- JSON 응답: \`{ ts, crons: { coins: { failCount, lastError }, ... } }\`

## 사용

\`\`\`bash
curl -H \"x-ops-token: \$CRON_SECRET\" \\
  https://market-dashboard-v5.vercel.app/api/ops/cron-status
\`\`\`

## Opus 리뷰 결과

VERDICT: PASS. LOW 2건만 지적:
- 토큰 비교 timing attack (LOW) — 내부 endpoint 라 감수
- \`OPS_SECRET\` fallback \`CRON_SECRET\` (LOW) — Phase A 배포 속도 위해 수용

## 다음 Phase (별도 PR)

- B: 대시보드 헤더 상태 뱃지 (react-query 30s 폴링)
- C: CF Workers Discord watchdog (failCount >= 3 시 사전 경고)

Refs #164

🤖 Generated with Claude Code [claude-opus-4-7]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* Cron 작업 상태 모니터링을 위한 새로운 API 엔드포인트 추가
* 보안 토큰 인증을 통한 요청 검증
* 5개 Cron 작업의 실패 횟수 및 오류 정보 조회 가능
* JSON 형식의 실시간 상태 정보 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->