### PR TITLE
fix: 백업 키(:prev) TTL 1h → 24h — 장 마감 시세 유지 (#176)

### DIFF
--- a/api/_price-cache.js
+++ b/api/_price-cache.js
@@ -31,8 +31,8 @@ export const SNAP_TTL = {
   ETF: 600,
 };
 
-// 백업 키 TTL (초) — 1시간
-const BACKUP_TTL = 3600;
+// 백업 키 TTL (초) — #176: 1h → 24h. 미장/국장 장 마감 quiet window 커버.
+const BACKUP_TTL = 86400;
 
 // 단일 키 조회
 export async function getSnap(key) {

--- a/workers/cron/src/price-cache.js
+++ b/workers/cron/src/price-cache.js
@@ -31,7 +31,10 @@ export const SNAP_TTL = {
   ETF: 600,
 };
 
-const BACKUP_TTL = 3600;
+// #176: 1h → 24h. 미장 quiet window(ET post 20 UTC ~ pre 08 UTC = 11h) 를 커버해
+//       사용자가 자정~새벽에 앱 열 때 \"--\" 표시되는 치명적 UX 회피.
+//       KR 주말은 24h 로 부분 커버 (토요일까지). 월요일 오전 누출은 별도 이슈.
+const BACKUP_TTL = 86400;
 
 export async function getSnap(key) {
   if (!_redis) return null;


### PR DESCRIPTION
## 배경

BACKUP_TTL 3600(1h) 로는 미장 야간/주말 quiet window 커버 불가 → 사용자가 자정~새벽에 앱 열면 전종목 \`--\` 표시. 치명적 UX 결함.

## 변경

\`BACKUP_TTL\` 3600 → 86400 (1h → 24h). 양쪽 파일 동기.

## 효과

| 시나리오 | Before | After |
|---|---|---|
| 미장 야간 (ET 20:00~04:00) | 전종목 \`--\` (1h 후) | 전일 종가 유지 ✅ |
| KR 금→토 주말 | 1h 후 빈 상태 | 금요일 종가 유지 ✅ |
| 코인 (24/7) | 영향 없음 | 영향 없음 |

## Out of scope

- UI \"장 마감 / HH:MM 기준\" 배지 — 사용자 혼동 방지용, 별도 이슈
- KR 월요일 오전 60h 커버 → TTL 72h+ 필요, 별도 검토

## Opus 리뷰

VERDICT: PASS. HIGH/CRITICAL 0건.

Closes #176

🤖 Generated with Claude Code [claude-opus-4-7]