### PR TITLE
feat: 헤더 크론 상태 뱃지 (#164 Phase B)

### DIFF
--- a/api/ops/cron-status.js
+++ b/api/ops/cron-status.js
@@ -1,28 +1,21 @@
-// api/ops/cron-status.js — 크론 실패 카운트 + 마지막 에러 조회 (#164 Phase A)
-// 인증: x-ops-token 헤더 = OPS_SECRET (fallback: CRON_SECRET). 내부 관측 전용.
-// 응답: { ts, crons: { coins: { failCount, lastError }, kr: {...}, ... } }
+// api/ops/cron-status.js — 크론 실패 카운트 조회 (#164 Phase A + B)
+// 두 가지 모드:
+//   (1) 공개 모드 (토큰 없음): 각 크론의 failCount + healthy 불린만 반환. UI 뱃지용.
+//   (2) 토큰 모드 (x-ops-token=OPS_SECRET/CRON_SECRET): lastError 상세 포함. CLI 디버깅용.
+//
+// 공개 모드는 에러 메시지 등 내부 구조 노출 가능한 정보 미포함 —
+// 클라이언트 번들에 토큰 심지 않아도 안전.
 export const config = { runtime: 'edge' };
 
 import { Redis } from '@upstash/redis';
 
 const CRON_NAMES = ['coins', 'kr', 'us', 'signal-accuracy', 'briefing'];
+const HEALTHY_THRESHOLD = 3; // failCount >= 3 이면 unhealthy
 
 export default async function handler(request) {
   const auth = (process.env.OPS_SECRET || process.env.CRON_SECRET || '').trim();
   const token = (request.headers.get('x-ops-token') || '').trim();
-
-  if (!auth) {
-    return new Response(JSON.stringify({ error: 'server misconfigured: OPS_SECRET/CRON_SECRET 미설정' }), {
-      status: 503,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-  if (token !== auth) {
-    return new Response(JSON.stringify({ error: 'unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
+  const hasDetailAccess = !!auth && token === auth;
 
   const url = process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
   const kvToken = process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -35,7 +28,6 @@ export default async function handler(request) {
 
   const redis = new Redis({ url, token: kvToken });
 
-  // 5개 크론 × 2 키(failCount + lastError) = 10 키 한 번에 조회
   const keys = CRON_NAMES.flatMap((c) => [`cron:fail:${c}`, `cron:lastError:${c}`]);
   let vals;
   try {
@@ -49,21 +41,34 @@ export default async function handler(request) {
 
   const result = {};
   for (let i = 0; i < CRON_NAMES.length; i++) {
-    const raw = vals[i * 2 + 1];
-    let lastError = null;
-    if (raw) {
-      try {
-        lastError = typeof raw === 'string' ? JSON.parse(raw) : raw;
-      } catch { lastError = { parseError: true, raw: String(raw).slice(0, 200) }; }
-    }
-    result[CRON_NAMES[i]] = {
-      failCount: parseInt(vals[i * 2] || '0', 10),
-      lastError,
+    const failCount = parseInt(vals[i * 2] || '0', 10);
+    const entry = {
+      failCount,
+      healthy: failCount < HEALTHY_THRESHOLD,
     };
+    if (hasDetailAccess) {
+      const raw = vals[i * 2 + 1];
+      let lastError = null;
+      if (raw) {
+        try {
+          lastError = typeof raw === 'string' ? JSON.parse(raw) : raw;
+        } catch { lastError = { parseError: true, raw: String(raw).slice(0, 200) }; }
+      }
+      entry.lastError = lastError;
+    }
+    result[CRON_NAMES[i]] = entry;
   }
 
-  return new Response(JSON.stringify({ ts: new Date().toISOString(), crons: result }), {
+  return new Response(JSON.stringify({
+    ts: new Date().toISOString(),
+    mode: hasDetailAccess ? 'detail' : 'public',
+    crons: result,
+  }), {
     status: 200,
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      // 공개 응답 30초 CDN 캐시 — 같은 상태 브라우저 탭 다수 호출 부하 감소
+      'Cache-Control': 'public, max-age=0, s-maxage=30',
+    },
   });
 }

--- a/api/ops/cron-status.js
+++ b/api/ops/cron-status.js
@@ -67,8 +67,11 @@ export default async function handler(request) {
     status: 200,
     headers: {
       'Content-Type': 'application/json',
-      // 공개 응답 30초 CDN 캐시 — 같은 상태 브라우저 탭 다수 호출 부하 감소
-      'Cache-Control': 'public, max-age=0, s-maxage=30',
+      // 토큰 요청(lastError 포함)은 CDN 캐시 금지 — 공개 응답에 토큰 응답 캐시되어
+      // lastError 유출되는 critical 회피. 공개 모드만 30s s-maxage.
+      'Cache-Control': hasDetailAccess
+        ? 'private, no-store'
+        : 'public, max-age=0, s-maxage=30',
     },
   });
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,7 @@
 // 데스크탑 헤더 — CDS 스타일 탭 + 장 상태 + 환율 + 다크모드
 import { getKoreanMarketStatus, getUsMarketStatus } from '../utils/marketHours';
 import { fmt } from '../utils/format';
+import OpsStatusBadge from './OpsStatusBadge';
 
 function DarkToggleIcon({ dark }) {
   return dark ? (
@@ -111,6 +112,9 @@ export default function Header({
               <span className="text-[12px] text-[#B0B8C1] font-mono">{timeStr}</span>
             </div>
           )}
+
+          {/* #164 Phase B: 크론 상태 뱃지 (localStorage opsMode=true 일 때만 표시) */}
+          <OpsStatusBadge />
 
           {/* 다크모드 토글 */}
           {onDarkToggle && (

--- a/src/components/OpsStatusBadge.jsx
+++ b/src/components/OpsStatusBadge.jsx
@@ -14,7 +14,8 @@ export default function OpsStatusBadge() {
     } catch { /* 무시 */ }
   }, []);
 
-  const { status, unhealthyCount, unhealthyNames } = useCronStatus();
+  // visible 일 때만 폴링 — 일반 사용자는 네트워크 요청 0 (비용/부하 방지)
+  const { status, unhealthyCount, unhealthyNames } = useCronStatus(visible);
 
   if (!visible) return null;
 

--- a/src/components/OpsStatusBadge.jsx
+++ b/src/components/OpsStatusBadge.jsx
@@ -1,0 +1,46 @@
+// OpsStatusBadge.jsx — 헤더 우측 크론 상태 뱃지 (#164 Phase B)
+// 기본 비노출. localStorage opsMode=true 일 때만 표시 — 내부 운영용.
+// 30초마다 /api/ops/cron-status 폴링.
+import { useEffect, useState } from 'react';
+import { useCronStatus } from '../hooks/useCronStatus';
+
+export default function OpsStatusBadge() {
+  const [visible, setVisible] = useState(false);
+
+  // localStorage 읽기 — SSR 안전
+  useEffect(() => {
+    try {
+      setVisible(window.localStorage.getItem('opsMode') === 'true');
+    } catch { /* 무시 */ }
+  }, []);
+
+  const { status, unhealthyCount, unhealthyNames } = useCronStatus();
+
+  if (!visible) return null;
+
+  const dotColor =
+    status === 'ok' ? 'bg-[#2AC769]' :
+    status === 'warn' ? 'bg-[#FF9500]' :
+    'bg-[#C9CDD2]'; // unknown
+
+  const label =
+    status === 'ok' ? '크론 정상' :
+    status === 'warn' ? `실패 ${unhealthyCount}건` :
+    '상태 조회 중';
+
+  const tooltip =
+    status === 'warn'
+      ? `${unhealthyNames.join(', ')} (최근 1h)`
+      : label;
+
+  return (
+    <span
+      className="flex items-center gap-1.5 text-[12px] text-[#8B95A1]"
+      title={tooltip}
+      aria-label={`크론 시스템 상태: ${label}`}
+    >
+      <span className={`w-2 h-2 rounded-full ${dotColor} ${status === 'warn' ? 'animate-pulse' : ''}`} />
+      <span className="hidden lg:inline">{label}</span>
+    </span>
+  );
+}

--- a/src/hooks/useCronStatus.js
+++ b/src/hooks/useCronStatus.js
@@ -13,6 +13,7 @@ async function fetchCronStatus() {
 }
 
 /**
+ * @param {boolean} enabled — false 면 요청 중단 (일반 사용자 폴링 방지)
  * @returns {{
  *   status: 'ok' | 'warn' | 'unknown',
  *   unhealthyCount: number,
@@ -20,15 +21,16 @@ async function fetchCronStatus() {
  *   isLoading: boolean,
  * }}
  */
-export function useCronStatus() {
+export function useCronStatus(enabled = true) {
   const { data, isLoading } = useQuery({
     queryKey: ['ops-cron-status'],
     queryFn: fetchCronStatus,
     staleTime: 30_000,
-    refetchInterval: 30_000,
+    refetchInterval: enabled ? 30_000 : false,
     refetchIntervalInBackground: false,
     retry: 1,
     placeholderData: null,
+    enabled,
   });
 
   if (!data?.crons) {

--- a/src/hooks/useCronStatus.js
+++ b/src/hooks/useCronStatus.js
@@ -1,0 +1,48 @@
+// useCronStatus.js — /api/ops/cron-status 폴링 훅 (#164 Phase B)
+// 30초 폴링, 공개 모드 응답 사용 (failCount + healthy 불린만).
+// 에러 상세는 토큰 필요해서 별도 CLI 에서만 조회.
+import { useQuery } from '@tanstack/react-query';
+
+async function fetchCronStatus() {
+  const res = await fetch('/api/ops/cron-status', {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!res.ok) throw new Error(`ops cron-status HTTP ${res.status}`);
+  return res.json();
+}
+
+/**
+ * @returns {{
+ *   status: 'ok' | 'warn' | 'unknown',
+ *   unhealthyCount: number,
+ *   unhealthyNames: string[],
+ *   isLoading: boolean,
+ * }}
+ */
+export function useCronStatus() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['ops-cron-status'],
+    queryFn: fetchCronStatus,
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+    refetchIntervalInBackground: false,
+    retry: 1,
+    placeholderData: null,
+  });
+
+  if (!data?.crons) {
+    return { status: 'unknown', unhealthyCount: 0, unhealthyNames: [], isLoading };
+  }
+
+  const names = Object.keys(data.crons);
+  const unhealthyNames = names.filter((n) => data.crons[n].healthy === false);
+  const status = unhealthyNames.length > 0 ? 'warn' : 'ok';
+
+  return {
+    status,
+    unhealthyCount: unhealthyNames.length,
+    unhealthyNames,
+    isLoading,
+  };
+}


### PR DESCRIPTION
## Phase B — 대시보드 시스템 상태 뱃지

헤더 우측 "업데이트 시각" 옆에 초록/노랑/회색 점 뱃지. localStorage opsMode=true 일 때만 표시 (내부 운영용). 30초마다 /api/ops/cron-status 폴링.

### 상태 표기
- 🟢 "크론 정상" — 전 크론 failCount < 3
- 🟠 "실패 N건" (pulse) — 하나 이상 unhealthy, 툴팁에 크론 이름
- ⚪ "상태 조회 중" — 로딩/에러

## 공개/토큰 dual-mode 엔드포인트

- 토큰 없음: \`{ failCount, healthy }\` 만 (클라이언트 시크릿 불필요)
- 토큰(OPS_SECRET): \`lastError\` 상세 포함 (CLI 디버깅)

## Codex 리뷰 반영

CRITICAL: CDN 캐시가 토큰/공개 응답 공유 → lastError 유출 가능. 토큰 모드 \`no-store\` 로 캐시 금지 (공개 모드만 30s s-maxage).

HIGH: 일반 사용자 30s 폴링 → \`useCronStatus(enabled)\` + \`visible\` 게이팅. opsMode 미설정 사용자 네트워크 요청 0.

## Opus 리뷰

VERDICT: PASS (CRITICAL/HIGH 0건, 재리뷰 후).

## 활성화

브라우저 콘솔:
\`\`\`js
localStorage.setItem('opsMode', 'true'); location.reload();
\`\`\`

Closes #164

🤖 Generated with Claude Code [claude-opus-4-7]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 헤더에 운영 상태 배지 추가: 시스템 운영 상태를 시각적으로 표시
  * 실시간 상태 모니터링: 30초 주기로 자동 업데이트

* **성능 개선**
  * 상태 조회 응답에 대한 캐싱 최적화로 성능 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->