### PR TITLE
fix: US 로고 clearbit fallback 제거 — 잘못된 로고 방지 (#182)

### DIFF
--- a/src/components/home/utils.js
+++ b/src/components/home/utils.js
@@ -1,4 +1,5 @@
 import { buildStockKeywords, matchesKeywords } from '../../utils/newsAlias';
+import { US_LOGO_DOMAIN } from '../../data/usLogoOverrides';
 
 // 종목 → 검색 키워드 배열 반환
 export function buildKeywords(item) {
@@ -127,10 +128,13 @@ export function getLogoUrls(item) {
     return urls;
   }
   if (market === 'US') {
-    return [
-      `https://assets.parqet.com/logos/symbol/${sym}?format=png`,
-      `https://logo.clearbit.com/${sym.toLowerCase()}.com`,
-    ];
+    // parqet 단일 소스 + 화이트리스트 기반 수동 도메인 매핑 보조
+    // clearbit `${sym}.com` 추측 fallback은 오매칭(F.com≠Ford 등)을 일으키므로 제거 (#182)
+    // BRK.B 등 점(.) 포함 심볼은 encodeURIComponent로 안전 처리
+    const urls = [`https://assets.parqet.com/logos/symbol/${encodeURIComponent(sym)}?format=png`];
+    const domain = US_LOGO_DOMAIN[sym.toUpperCase()];
+    if (domain) urls.push(`https://logo.clearbit.com/${domain}`);
+    return urls;
   }
   if (market === 'KR') {
     return [

--- a/src/components/home/utils.js
+++ b/src/components/home/utils.js
@@ -130,10 +130,14 @@ export function getLogoUrls(item) {
   if (market === 'US') {
     // parqet 단일 소스 + 화이트리스트 기반 수동 도메인 매핑 보조
     // clearbit `${sym}.com` 추측 fallback은 오매칭(F.com≠Ford 등)을 일으키므로 제거 (#182)
-    // BRK.B 등 점(.) 포함 심볼은 encodeURIComponent로 안전 처리
+    // 빈 심볼 가드 — 무효 URL 호출 방지 (Gemini 리뷰)
+    if (!sym) return [];
+    // 예비 공백·특수문자 방어 — encodeURIComponent는 공백/&/? 등에 효과
     const urls = [`https://assets.parqet.com/logos/symbol/${encodeURIComponent(sym)}?format=png`];
     const domain = US_LOGO_DOMAIN[sym.toUpperCase()];
-    if (domain) urls.push(`https://logo.clearbit.com/${domain}`);
+    if (typeof domain === 'string' && domain) {
+      urls.push(`https://logo.clearbit.com/${domain}`);
+    }
     return urls;
   }
   if (market === 'KR') {

--- a/src/data/usLogoOverrides.js
+++ b/src/data/usLogoOverrides.js
@@ -1,0 +1,12 @@
+// US 종목 로고 도메인 화이트리스트 — parqet 실패 케이스 전용 clearbit 보조
+// 심볼.com 도메인 추측이 오매칭을 일으키므로(F.com≠Ford 등) 화이트리스트 방식으로만 clearbit 사용.
+// QA 피드백 기반 확장 — 초기엔 명백한 케이스만, 잘못된 로고 확인 시 추가.
+export const US_LOGO_DOMAIN = Object.freeze({
+  // 버크셔 해서웨이 — parqet에 BRK/BRK.A/BRK.B 모두 실패
+  BRK: 'berkshirehathaway.com',
+  'BRK.A': 'berkshirehathaway.com',
+  'BRK.B': 'berkshirehathaway.com',
+  // 알파벳 (구글 모회사) — parqet GOOG/GOOGL 실패
+  GOOG: 'abc.xyz',
+  GOOGL: 'abc.xyz',
+});

--- a/src/data/usLogoOverrides.js
+++ b/src/data/usLogoOverrides.js
@@ -1,11 +1,16 @@
 // US 종목 로고 도메인 화이트리스트 — parqet 실패 케이스 전용 clearbit 보조
 // 심볼.com 도메인 추측이 오매칭을 일으키므로(F.com≠Ford 등) 화이트리스트 방식으로만 clearbit 사용.
 // QA 피드백 기반 확장 — 초기엔 명백한 케이스만, 잘못된 로고 확인 시 추가.
+//
+// 앱 내부 US 심볼 포맷: 점(.) 대신 하이픈(-) 사용 (usStockList.js 예: BRK-B).
+// 외부 소스/캐시 복원 변동 대비해 두 포맷 모두 등록.
 export const US_LOGO_DOMAIN = Object.freeze({
-  // 버크셔 해서웨이 — parqet에 BRK/BRK.A/BRK.B 모두 실패
-  BRK: 'berkshirehathaway.com',
+  // 버크셔 해서웨이 — 앱 기본 심볼은 BRK-B/BRK-A
+  'BRK-A': 'berkshirehathaway.com',
+  'BRK-B': 'berkshirehathaway.com',
   'BRK.A': 'berkshirehathaway.com',
   'BRK.B': 'berkshirehathaway.com',
+  BRK: 'berkshirehathaway.com',
   // 알파벳 (구글 모회사) — parqet GOOG/GOOGL 실패
   GOOG: 'abc.xyz',
   GOOGL: 'abc.xyz',


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
- [SEC] 이슈 없음. 화이트리스트 기반이라 clearbit URL은 내부 통제됨. XSS 벡터 없음 (URL 속성 바인딩).
- [PERF] 이슈 없음. O(1) lookup, 렌더 경로에 영향 無.

### Codex gate (OpenAI)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #182

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 미국 주식 로고 표시 안정성 개선. Berkshire Hathaway(BRK), Alphabet(GOOG/GOOGL) 등 특정 종목의 로고 표시가 더욱 안정적으로 작동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->