### PR TITLE
feat: US 우선주 필터 + 복합키 dedup (#183)

### DIFF
--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -9,6 +9,7 @@ function fmt(n, d = 0) {
 }
 
 import { isCoinItem } from './home/utils';
+import { itemKey, isPreferredOrSpecial } from '../utils/symbolKey';
 
 function getPct(item) {
   return isCoinItem(item) ? (item.change24h ?? 0) : (item.changePct ?? 0);
@@ -118,10 +119,10 @@ export default function GlobalSearch({ krStocks = [], usStocks = [], coins = [],
     return () => document.removeEventListener('keydown', onKey);
   }, [onClose]);
 
-  // 전체 종목 합치기 (market 태그 포함)
+  // 전체 종목 합치기 (market 태그 포함) — US 우선주 2차 방어 (#183)
   const allItems = useMemo(() => [
     ...krStocks.map(s => ({ ...s, _market: 'kr' })),
-    ...usStocks.map(s => ({ ...s, _market: 'us' })),
+    ...usStocks.filter(s => !isPreferredOrSpecial(s.symbol)).map(s => ({ ...s, _market: 'us' })),
     ...coins.map(c    => ({ ...c, _market: 'coin' })),
     ...etfs.map(e     => ({ ...e, _market: 'etf' })),
   ], [krStocks, usStocks, coins, etfs]);
@@ -149,12 +150,12 @@ export default function GlobalSearch({ krStocks = [], usStocks = [], coins = [],
         return 0;
       });
 
-    // 로컬 결과의 code/symbol 집합 (중복 제거용)
-    const localCodes = new Set(local.map(i => (i.symbol || i.id || '').toUpperCase()));
+    // 로컬 결과의 복합키 집합 (크로스마켓 충돌 방지 — META 등)
+    const localKeys = new Set(local.map(itemKey));
 
-    // 네이버 검색 결과 정규화 — 중복 제거 후 추가
+    // 네이버 검색 결과 정규화 — KR 전용이므로 KR 키로 중복 체크
     const naverNormalized = naverItems
-      .filter(item => !localCodes.has((item.code || '').toUpperCase()))
+      .filter(item => !localKeys.has(`KR:${(item.code || '').toUpperCase()}`))
       .map(item => ({
         id:       item.code,
         code:     item.code,
@@ -168,10 +169,11 @@ export default function GlobalSearch({ krStocks = [], usStocks = [], coins = [],
         _naverOnly: true,
       }));
 
-    // 미장 검색 결과 정규화 — 로컬에 없는 종목만 추가
-    const allCodes = new Set([...localCodes, ...naverNormalized.map(i => i.symbol.toUpperCase())]);
+    // 미장 검색 결과 정규화 — US 키로만 중복 체크 (우선주도 필터)
+    const allKeys = new Set([...localKeys, ...naverNormalized.map(itemKey)]);
     const usNormalized = usSearchItems
-      .filter(item => !allCodes.has((item.symbol || '').toUpperCase()))
+      .filter(item => !isPreferredOrSpecial(item.symbol))
+      .filter(item => !allKeys.has(`US:${(item.symbol || '').toUpperCase()}`))
       .map(item => ({
         symbol:   item.symbol,
         name:     item.name,

--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -124,7 +124,8 @@ export default function GlobalSearch({ krStocks = [], usStocks = [], coins = [],
     ...krStocks.map(s => ({ ...s, _market: 'kr' })),
     ...usStocks.filter(s => !isPreferredOrSpecial(s.symbol)).map(s => ({ ...s, _market: 'us' })),
     ...coins.map(c    => ({ ...c, _market: 'coin' })),
-    ...etfs.map(e     => ({ ...e, _market: 'etf' })),
+    // ETF는 실제 거래 시장(kr/us)에 태그 — HomeDashboard와 동일 규약으로 관심종목 키 일치
+    ...etfs.map(e     => ({ ...e, _market: (e.market || 'us').toLowerCase() })),
   ], [krStocks, usStocks, coins, etfs]);
 
   const results = useMemo(() => {

--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -307,13 +307,13 @@ export default function GlobalSearch({ krStocks = [], usStocks = [], coins = [],
 
                   {/* 관심종목 ★ */}
                   <button
-                    onClick={(e) => { e.stopPropagation(); toggle(item.id || item.symbol); }}
+                    onClick={(e) => { e.stopPropagation(); toggle(item.id || item.symbol, item._market || item.market); }}
                     className={`flex-shrink-0 w-8 h-8 flex items-center justify-center rounded-lg transition-colors text-[16px] mr-2 ${
-                      isWatched(item.id || item.symbol) ? 'text-[#FF9500] hover:bg-[#FFF4E6]' : 'text-[#D5D8DC] hover:bg-[#F2F4F6]'
+                      isWatched(item.id || item.symbol, item._market || item.market) ? 'text-[#FF9500] hover:bg-[#FFF4E6]' : 'text-[#D5D8DC] hover:bg-[#F2F4F6]'
                     }`}
-                    title={isWatched(item.id || item.symbol) ? '관심종목 해제' : '관심종목 추가'}
+                    title={isWatched(item.id || item.symbol, item._market || item.market) ? '관심종목 해제' : '관심종목 추가'}
                   >
-                    {isWatched(item.id || item.symbol) ? '★' : '☆'}
+                    {isWatched(item.id || item.symbol, item._market || item.market) ? '★' : '☆'}
                   </button>
                 </button>
               );

--- a/src/components/HomeDashboard.jsx
+++ b/src/components/HomeDashboard.jsx
@@ -555,7 +555,7 @@ export default function HomeDashboard({
 
   // ─── 관심종목 필터링 ────────────────────────────────────────
   const watchedItems = useMemo(
-    () => allItems.filter(i => isWatched(i.id || i.symbol)),
+    () => allItems.filter(i => isWatched(i.id || i.symbol, i._market || i.market)),
     [allItems, watchlist] // watchlist dep: Set 변경 시 재계산
   );
 
@@ -673,7 +673,7 @@ export default function HomeDashboard({
                 >
                   <div className="flex items-center gap-3 min-w-0">
                     <button
-                      onClick={e => { e.stopPropagation(); toggle(item.id || item.symbol); }}
+                      onClick={e => { e.stopPropagation(); toggle(item.id || item.symbol, item._market || item.market); }}
                       className="text-[14px] text-yellow-400 flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center"
                     >★</button>
                     <div className="min-w-0">

--- a/src/components/WatchlistTable.jsx
+++ b/src/components/WatchlistTable.jsx
@@ -351,10 +351,10 @@ const FlashRow = React.memo(function FlashRow({ item, rank, krwRate, onClick, se
       {/* 관심종목 별 버튼 */}
       <TableCell className="pl-2 pr-0 py-3 w-7">
         <button
-          onClick={e => { e.stopPropagation(); toggle(item.id || item.symbol, item._market || item.market); }}
+          onClick={e => { e.stopPropagation(); toggle(item.id || item.symbol, item._market || item.market || type); }}
           className="flex-shrink-0 w-6 h-6 flex items-center justify-center text-[14px] hover:scale-110 transition-transform"
         >
-          {isWatched(item.id || item.symbol, item._market || item.market) ? '★' : '☆'}
+          {isWatched(item.id || item.symbol, item._market || item.market || type) ? '★' : '☆'}
         </button>
       </TableCell>
 
@@ -613,9 +613,9 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = DEFA
       const avg = items.length ? items.reduce((s, i) => s + getVol(i), 0) / items.length : 0;
       if (avg > 0) list = list.filter(i => getVol(i) >= avg * 2);
     }
-    if (filter === 'watchlist') list = list.filter(i => isWatched(i.id || i.symbol, i._market || i.market));
+    if (filter === 'watchlist') list = list.filter(i => isWatched(i.id || i.symbol, i._market || i.market || type));
     // ★ 관심종목만 보기 토글
-    if (showWatchlistOnly)      list = list.filter(i => isWatched(i.id || i.symbol, i._market || i.market));
+    if (showWatchlistOnly)      list = list.filter(i => isWatched(i.id || i.symbol, i._market || i.market || type));
     return list;
   }, [items, debouncedSearch, filter, sector, showWatchlistOnly, isWatched]);
 

--- a/src/components/WatchlistTable.jsx
+++ b/src/components/WatchlistTable.jsx
@@ -351,10 +351,10 @@ const FlashRow = React.memo(function FlashRow({ item, rank, krwRate, onClick, se
       {/* 관심종목 별 버튼 */}
       <TableCell className="pl-2 pr-0 py-3 w-7">
         <button
-          onClick={e => { e.stopPropagation(); toggle(item.id || item.symbol); }}
+          onClick={e => { e.stopPropagation(); toggle(item.id || item.symbol, item._market || item.market); }}
           className="flex-shrink-0 w-6 h-6 flex items-center justify-center text-[14px] hover:scale-110 transition-transform"
         >
-          {isWatched(item.id || item.symbol) ? '★' : '☆'}
+          {isWatched(item.id || item.symbol, item._market || item.market) ? '★' : '☆'}
         </button>
       </TableCell>
 
@@ -613,9 +613,9 @@ export default function WatchlistTable({ items = [], type = 'kr', krwRate = DEFA
       const avg = items.length ? items.reduce((s, i) => s + getVol(i), 0) / items.length : 0;
       if (avg > 0) list = list.filter(i => getVol(i) >= avg * 2);
     }
-    if (filter === 'watchlist') list = list.filter(i => isWatched(i.id || i.symbol));
+    if (filter === 'watchlist') list = list.filter(i => isWatched(i.id || i.symbol, i._market || i.market));
     // ★ 관심종목만 보기 토글
-    if (showWatchlistOnly)      list = list.filter(i => isWatched(i.id || i.symbol));
+    if (showWatchlistOnly)      list = list.filter(i => isWatched(i.id || i.symbol, i._market || i.market));
     return list;
   }, [items, debouncedSearch, filter, sector, showWatchlistOnly, isWatched]);
 

--- a/src/components/home/HotListSection.jsx
+++ b/src/components/home/HotListSection.jsx
@@ -1,6 +1,7 @@
 import { memo, useState } from 'react';
 import { getPct, fmt, getAvatarBg, getLogoUrls } from './utils';
 import { getKoreanMarketStatus, getUsMarketStatus } from '../../utils/marketHours';
+import { itemKey } from '../../utils/symbolKey';
 
 // ─── SECTION 3: HOT 리스트 행 (3열 공통) ─────────────────────
 const HotRow = memo(function HotRow({ item, rank, krwRate, onClick }) {
@@ -116,7 +117,7 @@ export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop,
               : krHot.length > 0
                 ? krHot.map((item, i) => (
                     <HotRow
-                      key={`kr-hot-${item.symbol}`}
+                      key={`hot-${itemKey(item)}`}
                       item={item}
                       rank={i + 1}
                       krwRate={krwRate}
@@ -145,7 +146,7 @@ export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop,
               : usHot.length > 0
                 ? usHot.map((item, i) => (
                     <HotRow
-                      key={`us-hot-${item.symbol}`}
+                      key={`hot-${itemKey(item)}`}
                       item={item}
                       rank={i + 1}
                       krwRate={krwRate}
@@ -172,7 +173,7 @@ export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop,
               : coinHot.length > 0
                 ? coinHot.map((item, i) => (
                     <HotRow
-                      key={`coin-hot-${item.symbol}`}
+                      key={`hot-${itemKey(item)}`}
                       item={item}
                       rank={i + 1}
                       krwRate={krwRate}
@@ -203,7 +204,7 @@ export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop,
               ? <SkeletonHotRow count={5} />
               : krDrop.map((item, i) => (
                   <HotRow
-                    key={`kr-drop-${item.symbol}`}
+                    key={`drop-${itemKey(item)}`}
                     item={item}
                     rank={i + 1}
                     krwRate={krwRate}
@@ -230,7 +231,7 @@ export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop,
               ? <SkeletonHotRow count={5} />
               : usDrop.map((item, i) => (
                   <HotRow
-                    key={`us-drop-${item.symbol}`}
+                    key={`drop-${itemKey(item)}`}
                     item={item}
                     rank={i + 1}
                     krwRate={krwRate}
@@ -255,7 +256,7 @@ export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop,
               ? <SkeletonHotRow count={5} />
               : coinDrop.map((item, i) => (
                   <HotRow
-                    key={`coin-drop-${item.symbol}`}
+                    key={`drop-${itemKey(item)}`}
                     item={item}
                     rank={i + 1}
                     krwRate={krwRate}

--- a/src/components/home/NotableMoversSection.jsx
+++ b/src/components/home/NotableMoversSection.jsx
@@ -5,6 +5,7 @@ import { useMemo, useState, useEffect } from 'react';
 import { getPct, fmt, getAvatarBg, getLogoUrls, findRelatedNews, DERIVATIVE_RE } from './utils';
 import { buildStockKeywords, matchesKeywords } from '../../utils/newsAlias';
 import { getKoreanMarketStatus, getUsMarketStatus } from '../../utils/marketHours';
+import { itemKey } from '../../utils/symbolKey';
 
 const MKT_BADGE = {
   KR:         { label: '국내',      bg: '#FFF0F0', color: '#F04452' },
@@ -316,7 +317,7 @@ export default function NotableMoversSection({ allItems = [], recentNews = [], k
           <div className="flex gap-3 pb-2" style={{ minWidth: 'max-content' }}>
             {displayed.map(item => (
               <NotableCard
-                key={item.id || item.symbol}
+                key={itemKey(item)}
                 item={item}
                 newsCount={item._newsCount}
                 volumeRank={item._volRank}

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useAllNewsQuery } from '../../hooks/useNewsQuery';
 import { useWatchlist } from '../../hooks/useWatchlist';
 import { getPct } from './utils';
+import { itemKey, isPreferredOrSpecial } from '../../utils/symbolKey';
 import NewsFeedWidget from './widgets/NewsFeedWidget';
 import NotableMoversSection from './NotableMoversSection';
 import { useInvestorSignals } from '../../hooks/useInvestorSignals';
@@ -29,12 +30,27 @@ export default function HomeDashboard({
     ...krStocks.map(s => ({ ...s, _market: 'KR' })),
     ...etfs.filter(e => e.market === 'kr').map(e => ({ ...e, _market: 'KR', _isEtf: true })),
   ], [krStocks, etfs]);
+  // US 우선주/워런트/시리즈 주 2차 방어 — 서버 필터 실패 대비 (#183)
   const usItems   = useMemo(() => [
-    ...usStocks.map(s => ({ ...s, _market: 'US' })),
+    ...usStocks.filter(s => !isPreferredOrSpecial(s.symbol)).map(s => ({ ...s, _market: 'US' })),
     ...etfs.filter(e => e.market === 'us').map(e => ({ ...e, _market: 'US', _isEtf: true })),
   ], [usStocks, etfs]);
   const coinItems = useMemo(() => coins.map(c => ({ ...c, _market: 'COIN' })), [coins]);
-  const allItems  = useMemo(() => [...krItems, ...usItems, ...coinItems], [krItems, usItems, coinItems]);
+
+  // 크로스마켓 심볼 충돌(META=Meta/메타디움 등) 해소 — 복합키 기반 dedup (#183)
+  // 동일 키에 중복 발생 시 거래량이 큰 쪽을 유지
+  const allItems  = useMemo(() => {
+    const seen = new Map();
+    const source = [...krItems, ...usItems, ...coinItems];
+    for (const it of source) {
+      const k = itemKey(it);
+      const prev = seen.get(k);
+      const curVol = it._market === 'COIN' ? (it.volume24h ?? 0) : (it.volume ?? 0);
+      const prevVol = prev ? (prev._market === 'COIN' ? (prev.volume24h ?? 0) : (prev.volume ?? 0)) : -1;
+      if (!prev || curVol > prevVol) seen.set(k, it);
+    }
+    return [...seen.values()];
+  }, [krItems, usItems, coinItems]);
 
   // 레버리지·인버스·미분류 ETF 제외 — 시그널 엔진 오발화 방지
   // _isEtf 플래그는 krItems/usItems spread 시 항상 true로 세팅됨 (보장)

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -37,17 +37,19 @@ export default function HomeDashboard({
   ], [usStocks, etfs]);
   const coinItems = useMemo(() => coins.map(c => ({ ...c, _market: 'COIN' })), [coins]);
 
-  // 크로스마켓 심볼 충돌(META=Meta/메타디움 등) 해소 — 복합키 기반 dedup (#183)
-  // 동일 키에 중복 발생 시 거래량이 큰 쪽을 유지
+  // 복합키 `${_market}:${symbol}` 기반 dedup — 서버 중복 공급(동일 market 내 중복 행) 방어 (#183)
+  // 크로스마켓 충돌(US:META vs COIN:META)은 키가 달라 자연히 분리됨
+  // 동일 market 내 중복 시에만 거래량 큰 쪽 유지 (단위가 같아 비교 유효)
   const allItems  = useMemo(() => {
     const seen = new Map();
     const source = [...krItems, ...usItems, ...coinItems];
     for (const it of source) {
       const k = itemKey(it);
       const prev = seen.get(k);
+      if (!prev) { seen.set(k, it); continue; }
       const curVol = it._market === 'COIN' ? (it.volume24h ?? 0) : (it.volume ?? 0);
-      const prevVol = prev ? (prev._market === 'COIN' ? (prev.volume24h ?? 0) : (prev.volume ?? 0)) : -1;
-      if (!prev || curVol > prevVol) seen.set(k, it);
+      const prevVol = prev._market === 'COIN' ? (prev.volume24h ?? 0) : (prev.volume ?? 0);
+      if (curVol > prevVol) seen.set(k, it);
     }
     return [...seen.values()];
   }, [krItems, usItems, coinItems]);

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -75,7 +75,7 @@ export default function HomeDashboard({
 
   // 관심종목
   const watchedItems = useMemo(
-    () => allItems.filter(i => isWatched(i.id || i.symbol)),
+    () => allItems.filter(i => isWatched(i.id || i.symbol, i._market || i.market)),
     [allItems, watchlist] // eslint-disable-line react-hooks/exhaustive-deps
   );
 

--- a/src/data/usDualClass.js
+++ b/src/data/usDualClass.js
@@ -1,0 +1,22 @@
+// US 듀얼클래스 보통주 — 우선주 패턴 판별 예외 목록 (#183)
+// `symbolKey.isPreferredOrSpecial`이 `BRK.B`, `GOOGL` 등 보통주도
+// 접미사 규칙(L/M/N/O/P/Q 3~4글자)에 걸리므로 화이트리스트로 제외한다.
+// KR 심볼은 숫자 6자리라 충돌 없음 — US 전용.
+export const US_DUAL_CLASS_WHITELIST = new Set([
+  // 버크셔 해서웨이 — 앱 내부 포맷은 하이픈, 외부 소스 점 포맷도 방어
+  'BRK-A', 'BRK-B', 'BRK.A', 'BRK.B',
+  // 브라운포먼
+  'BF-A', 'BF-B', 'BF.A', 'BF.B',
+  // 알파벳
+  'GOOG', 'GOOGL',
+  // 폭스
+  'FOX', 'FOXA',
+  // 레나
+  'LEN-B', 'LEN.B',
+  // HEICO
+  'HEI-A', 'HEI.A',
+  // 뉴스코프
+  'NWS', 'NWSA',
+  // 언더아머
+  'UA', 'UAA',
+]);

--- a/src/data/usDualClass.js
+++ b/src/data/usDualClass.js
@@ -1,6 +1,6 @@
 // US 듀얼클래스 보통주 — 우선주 패턴 판별 예외 목록 (#183)
-// `symbolKey.isPreferredOrSpecial`이 `BRK.B`, `GOOGL` 등 보통주도
-// 접미사 규칙(L/M/N/O/P/Q 3~4글자)에 걸리므로 화이트리스트로 제외한다.
+// 현재 `symbolKey.isPreferredOrSpecial`은 `WS`/`WT` 워런트와 `^`/`.PR.`/`-PR.` 명시 토큰만 잡으므로
+// 여기 등재된 대부분은 실제 필터 대상이 아니다. 보수적 안전망 + 추후 규칙 강화 대비.
 // KR 심볼은 숫자 6자리라 충돌 없음 — US 전용.
 export const US_DUAL_CLASS_WHITELIST = new Set([
   // 버크셔 해서웨이 — 앱 내부 포맷은 하이픈, 외부 소스 점 포맷도 방어

--- a/src/hooks/useWatchlist.js
+++ b/src/hooks/useWatchlist.js
@@ -30,17 +30,19 @@ function toCompositeKey(id, market) {
 }
 
 // v1 → v2 1회성 마이그레이션 — raw 심볼 → 복합키
+// 실패 시에도 v1 제거: 손상된 JSON이 로드마다 재시도되는 것 방지
 function migrate() {
+  const rawV1 = localStorage.getItem(KEY_V1);
+  if (!rawV1) return null;
   try {
-    const rawV1 = localStorage.getItem(KEY_V1);
-    if (!rawV1) return null;
     const arr = JSON.parse(rawV1) ?? [];
-    const migrated = new Set(arr.map(toCompositeKey).filter(Boolean));
+    const migrated = new Set(arr.map(id => toCompositeKey(id)).filter(Boolean));
     localStorage.setItem(KEY_V2, JSON.stringify([...migrated]));
-    localStorage.removeItem(KEY_V1);
     return migrated;
   } catch {
     return null;
+  } finally {
+    try { localStorage.removeItem(KEY_V1); } catch {}
   }
 }
 

--- a/src/hooks/useWatchlist.js
+++ b/src/hooks/useWatchlist.js
@@ -8,10 +8,10 @@ const KEY_V2 = 'watchlist_v2';
 
 // 6자리 숫자 = 한국 주식 심볼 패턴
 const KR_SYMBOL_RE = /^\d{6}$/;
-// 코인 id 패턴 — CoinGecko(bitcoin, kaspa) 소문자, CoinPaprika(btc-bitcoin) 하이픈 포함
-const COIN_ID_RE = /^[a-z][a-z0-9-]*$/;
+// 코인 id 패턴 — CoinGecko/Paprika (bitcoin, btc-bitcoin, 1inch, 0x, 0chain 등 digit-prefix 포함)
+const COIN_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
-// raw id에서 market 추정 — 1회성 마이그레이션 + toggle 호환용
+// raw id에서 market 추정 — 마이그레이션 fallback 전용. 호출부는 가능하면 market 명시 권장.
 function inferMarket(id) {
   if (!id) return 'US';
   if (KR_SYMBOL_RE.test(id)) return 'KR';
@@ -19,13 +19,14 @@ function inferMarket(id) {
   return 'US';
 }
 
-function toCompositeKey(id) {
+// toggle/isWatched 호환 — market 힌트 우선, 없으면 추론
+function toCompositeKey(id, market) {
   if (typeof id !== 'string' || !id) return '';
   if (id.includes(':')) return id;
-  const market = inferMarket(id);
-  // 코인 id는 CoinGecko/Paprika API 소문자 요구 — 원본 유지
-  const body = market === 'COIN' ? id : id.toUpperCase();
-  return `${market}:${body}`;
+  const mkt = (market || inferMarket(id)).toUpperCase();
+  // 코인 id는 외부 API 소문자 요구 — 원본 유지. 그 외 대문자 정규화.
+  const body = mkt === 'COIN' ? id : id.toUpperCase();
+  return `${mkt}:${body}`;
 }
 
 // v1 → v2 1회성 마이그레이션 — raw 심볼 → 복합키
@@ -46,7 +47,11 @@ function migrate() {
 function load() {
   try {
     const rawV2 = localStorage.getItem(KEY_V2);
-    if (rawV2) return new Set(JSON.parse(rawV2) ?? []);
+    if (rawV2) {
+      // v2 있는데 v1 잔존 시 1회성 청소 (마이그레이션 중 예외로 남은 고아)
+      if (localStorage.getItem(KEY_V1)) localStorage.removeItem(KEY_V1);
+      return new Set(JSON.parse(rawV2) ?? []);
+    }
     const migrated = migrate();
     return migrated ?? new Set();
   } catch {
@@ -61,8 +66,9 @@ function save(set) {
 export function useWatchlist() {
   const [watchlist, setWatchlist] = useState(() => load());
 
-  const toggle = useCallback((id) => {
-    const key = toCompositeKey(id);
+  // toggle(id, market?) — market 명시 권장 (호출부가 item._market 또는 item.market 보유 시 전달)
+  const toggle = useCallback((id, market) => {
+    const key = toCompositeKey(id, market);
     if (!key) return;
     setWatchlist(prev => {
       const next = new Set(prev);
@@ -73,7 +79,10 @@ export function useWatchlist() {
     });
   }, []);
 
-  const isWatched = useCallback((id) => watchlist.has(toCompositeKey(id)), [watchlist]);
+  const isWatched = useCallback(
+    (id, market) => watchlist.has(toCompositeKey(id, market)),
+    [watchlist],
+  );
 
   // 관심종목 중 한국 주식 심볼만 추출 (외부 API 호환 — raw 심볼 반환)
   const krSymbols = useMemo(

--- a/src/hooks/useWatchlist.js
+++ b/src/hooks/useWatchlist.js
@@ -22,7 +22,10 @@ function inferMarket(id) {
 function toCompositeKey(id) {
   if (typeof id !== 'string' || !id) return '';
   if (id.includes(':')) return id;
-  return `${inferMarket(id)}:${id.toUpperCase()}`;
+  const market = inferMarket(id);
+  // 코인 id는 CoinGecko/Paprika API 소문자 요구 — 원본 유지
+  const body = market === 'COIN' ? id : id.toUpperCase();
+  return `${market}:${body}`;
 }
 
 // v1 → v2 1회성 마이그레이션 — raw 심볼 → 복합키

--- a/src/hooks/useWatchlist.js
+++ b/src/hooks/useWatchlist.js
@@ -1,42 +1,86 @@
-// 관심종목 훅 — localStorage 기반 영구 저장
+// 관심종목 훅 — localStorage 기반 영구 저장 (#183 복합키 마이그레이션)
+// v2: `${market}:${symbol}` 형식 ('KR:005930', 'US:AAPL', 'COIN:bitcoin')
+// 외부 API는 기존 호환 — `toggle`/`isWatched`에 raw symbol 전달 시 market 추론해 복합키로 변환
 import { useState, useCallback, useMemo } from 'react';
 
-const KEY = 'watchlist_v1';
+const KEY_V1 = 'watchlist_v1';
+const KEY_V2 = 'watchlist_v2';
 
 // 6자리 숫자 = 한국 주식 심볼 패턴
 const KR_SYMBOL_RE = /^\d{6}$/;
+// 코인 id 패턴 — CoinGecko(bitcoin, kaspa) 소문자, CoinPaprika(btc-bitcoin) 하이픈 포함
+const COIN_ID_RE = /^[a-z][a-z0-9-]*$/;
+
+// raw id에서 market 추정 — 1회성 마이그레이션 + toggle 호환용
+function inferMarket(id) {
+  if (!id) return 'US';
+  if (KR_SYMBOL_RE.test(id)) return 'KR';
+  if (COIN_ID_RE.test(id)) return 'COIN';
+  return 'US';
+}
+
+function toCompositeKey(id) {
+  if (typeof id !== 'string' || !id) return '';
+  if (id.includes(':')) return id;
+  return `${inferMarket(id)}:${id.toUpperCase()}`;
+}
+
+// v1 → v2 1회성 마이그레이션 — raw 심볼 → 복합키
+function migrate() {
+  try {
+    const rawV1 = localStorage.getItem(KEY_V1);
+    if (!rawV1) return null;
+    const arr = JSON.parse(rawV1) ?? [];
+    const migrated = new Set(arr.map(toCompositeKey).filter(Boolean));
+    localStorage.setItem(KEY_V2, JSON.stringify([...migrated]));
+    localStorage.removeItem(KEY_V1);
+    return migrated;
+  } catch {
+    return null;
+  }
+}
 
 function load() {
-  try { return new Set(JSON.parse(localStorage.getItem(KEY)) ?? []); } catch { return new Set(); }
+  try {
+    const rawV2 = localStorage.getItem(KEY_V2);
+    if (rawV2) return new Set(JSON.parse(rawV2) ?? []);
+    const migrated = migrate();
+    return migrated ?? new Set();
+  } catch {
+    return new Set();
+  }
 }
+
 function save(set) {
-  try { localStorage.setItem(KEY, JSON.stringify([...set])); } catch {}
+  try { localStorage.setItem(KEY_V2, JSON.stringify([...set])); } catch {}
 }
 
 export function useWatchlist() {
   const [watchlist, setWatchlist] = useState(() => load());
 
   const toggle = useCallback((id) => {
+    const key = toCompositeKey(id);
+    if (!key) return;
     setWatchlist(prev => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
       save(next);
       return next;
     });
   }, []);
 
-  const isWatched = useCallback((id) => watchlist.has(id), [watchlist]);
+  const isWatched = useCallback((id) => watchlist.has(toCompositeKey(id)), [watchlist]);
 
-  // 관심종목 중 한국 주식 심볼만 추출 (6자리 숫자)
+  // 관심종목 중 한국 주식 심볼만 추출 (외부 API 호환 — raw 심볼 반환)
   const krSymbols = useMemo(
-    () => [...watchlist].filter(id => KR_SYMBOL_RE.test(id)),
+    () => [...watchlist].filter(k => k.startsWith('KR:')).map(k => k.slice(3)),
     [watchlist]
   );
 
-  // 관심종목 중 미국 주식 심볼만 추출 (영문자 포함, 6자리 숫자 아닌 것)
+  // 관심종목 중 미국 주식 심볼만 추출
   const usSymbols = useMemo(
-    () => [...watchlist].filter(id => !KR_SYMBOL_RE.test(id) && /^[A-Z]/.test(id)),
+    () => [...watchlist].filter(k => k.startsWith('US:')).map(k => k.slice(3)),
     [watchlist]
   );
 

--- a/src/utils/symbolKey.js
+++ b/src/utils/symbolKey.js
@@ -11,23 +11,19 @@ export const itemKey = (i) => {
   return `${mkt}:${sym}`;
 };
 
-// 워런트/특수단위 — 하이픈/점 접미사 + WS/WT 꼬리
-// 예: DAL.W, XYZ-WS, FUND.UN (접미사 W, L, P, U, T 단일자)
-const WARRANT_RE = /[-.][WLPUT]$|W[ST]$/;
-// 시리즈/우선주 표기 — 캐럿(^), `.PR.`, `-PR.`, `PRA~PRZ` 명시 접미사
+// 워런트/권리 — `WS`/`WT` 꼬리만 확정 매치 (e.g., XYZWS, ABCWT)
+const WARRANT_RE = /W[ST]$/;
+// 시리즈/우선주 — 캐럿(`^`) 또는 `.PR.`/`-PR.` 명시 토큰
 const SERIES_RE = /\^|[-.]PR\./;
-// 명시적 우선주 클래스 — `-A~-Z`, `.A~.Z` 구분자 포함된 단일 알파벳 접미사
-// (듀얼클래스 보통주 BRK-B, BRK.B, FOXA 등은 화이트리스트로 예외 처리)
-const CLASS_SUFFIX_RE = /[-.][A-Z]$/;
 
-// 우선주/특수클래스 식별 — 보통주 복귀 위해 화이트리스트 선행
-// 정책: 구분자(`-`/`.`) 없는 3~6글자 티커(AAPL/ORCL/META 등)는 절대 필터 안 함
+// 우선주/워런트 식별 — 클라이언트는 명시 토큰만 잡음.
+// 정책: 듀얼클래스 `-A`/`-B`/`.A`/`.B` 패턴은 서버 `update-us` 크론이 1차 책임.
+// 클라이언트가 일반 구분자 접미사를 필터하면 CWEN-A, MOG-A, LGF-B 등 보통주 오탐 발생.
 export function isPreferredOrSpecial(sym) {
   if (!sym || typeof sym !== 'string') return false;
   const up = sym.toUpperCase();
   if (US_DUAL_CLASS_WHITELIST.has(up)) return false;
   if (WARRANT_RE.test(up)) return true;
   if (SERIES_RE.test(up)) return true;
-  if (CLASS_SUFFIX_RE.test(up)) return true;
   return false;
 }

--- a/src/utils/symbolKey.js
+++ b/src/utils/symbolKey.js
@@ -1,0 +1,27 @@
+// 크로스마켓 심볼 충돌 해소 + US 우선주/특수클래스 식별 (#183)
+// - META: US(Meta Platforms) vs COIN(Metadium) 등 심볼 충돌 → `${market}:${symbol}` 복합키로 구분
+// - US 우선주/워런트/시리즈 주: 클라이언트에서 2차 방어 필터 (서버 필터 실패 대비)
+import { US_DUAL_CLASS_WHITELIST } from '../data/usDualClass';
+
+// 마켓:심볼 복합키 — allItems dedup/React key 공통
+export const itemKey = (i) =>
+  `${i._market || 'US'}:${(i.symbol || i.id || '').toUpperCase()}`;
+
+// 우선주 접미사 패턴 — 3~4글자 + [LMNOPQ] (예: AGNCM, HBANP)
+// AGNC(보통주)는 4글자+C라 미매치. 보통주는 대부분 접미사 규칙에 안 걸림.
+const PREFERRED_SUFFIX_RE = /^[A-Z]{3,4}[LMNOPQ]$/;
+// 워런트 패턴 — `-W`, `.W`, `-L`, `.L`, `-P`, `.P`, `WS`
+const WARRANT_RE = /[-.][WLP]$|WS$/;
+// 시리즈 주 — 캐럿(^), `.PR.`, `PRA~PRZ` 접미사
+const SERIES_RE = /\^|\.PR\.|PR[A-Z]$/;
+
+// 우선주/특수클래스 식별 — 보통주 복귀 위해 화이트리스트 선행
+export function isPreferredOrSpecial(sym) {
+  if (!sym) return false;
+  const up = sym.toUpperCase();
+  if (US_DUAL_CLASS_WHITELIST.has(up)) return false;
+  if (WARRANT_RE.test(up)) return true;
+  if (SERIES_RE.test(up)) return true;
+  if (PREFERRED_SUFFIX_RE.test(up)) return true;
+  return false;
+}

--- a/src/utils/symbolKey.js
+++ b/src/utils/symbolKey.js
@@ -3,16 +3,19 @@
 // - 우선주/워런트 필터는 서버 `update-us` 크론이 1차 책임. 클라이언트는 명시적 패턴만 방어.
 import { US_DUAL_CLASS_WHITELIST } from '../data/usDualClass';
 
-// 마켓:심볼 복합키 — allItems dedup/React key 공통
-// `_market`은 대문자로 정규화 (home/index.jsx 'US' vs GlobalSearch.jsx 'us' 불일치 흡수)
+// 마켓:심볼 복합키 — allItems dedup/React key + useWatchlist 조회 공통
+// `_market`은 대문자 정규화. COIN body는 원본 유지(외부 API 소문자 id 요구) → toCompositeKey와 규약 일치.
 export const itemKey = (i) => {
   const mkt = (i._market || 'US').toString().toUpperCase();
-  const sym = (i.symbol || i.id || '').toString().toUpperCase();
+  const raw = (i.symbol || i.id || '').toString();
+  if (!raw) return '';
+  const sym = mkt === 'COIN' ? raw : raw.toUpperCase();
   return `${mkt}:${sym}`;
 };
 
-// 워런트/권리 — `WS`/`WT` 꼬리만 확정 매치 (e.g., XYZWS, ABCWT)
-const WARRANT_RE = /W[ST]$/;
+// 워런트/권리 — 하이픈/점 구분자 + `WS`/`WT` 꼬리만 매치 (e.g., XYZ-WS, ABC.WT)
+// 구분자 없이 WS/WT 끝나는 보통주(NEWS, JEWELS)는 제외.
+const WARRANT_RE = /[-.]W[ST]$/;
 // 시리즈/우선주 — 캐럿(`^`) 또는 `.PR.`/`-PR.` 명시 토큰
 const SERIES_RE = /\^|[-.]PR\./;
 

--- a/src/utils/symbolKey.js
+++ b/src/utils/symbolKey.js
@@ -1,27 +1,33 @@
 // 크로스마켓 심볼 충돌 해소 + US 우선주/특수클래스 식별 (#183)
-// - META: US(Meta Platforms) vs COIN(Metadium) 등 심볼 충돌 → `${market}:${symbol}` 복합키로 구분
-// - US 우선주/워런트/시리즈 주: 클라이언트에서 2차 방어 필터 (서버 필터 실패 대비)
+// - 주 목적: META(Meta Platforms) vs META(Metadium) 등 크로스마켓 심볼 충돌 해소
+// - 우선주/워런트 필터는 서버 `update-us` 크론이 1차 책임. 클라이언트는 명시적 패턴만 방어.
 import { US_DUAL_CLASS_WHITELIST } from '../data/usDualClass';
 
 // 마켓:심볼 복합키 — allItems dedup/React key 공통
-export const itemKey = (i) =>
-  `${i._market || 'US'}:${(i.symbol || i.id || '').toUpperCase()}`;
+// `_market`은 대문자로 정규화 (home/index.jsx 'US' vs GlobalSearch.jsx 'us' 불일치 흡수)
+export const itemKey = (i) => {
+  const mkt = (i._market || 'US').toString().toUpperCase();
+  const sym = (i.symbol || i.id || '').toString().toUpperCase();
+  return `${mkt}:${sym}`;
+};
 
-// 우선주 접미사 패턴 — 3~4글자 + [LMNOPQ] (예: AGNCM, HBANP)
-// AGNC(보통주)는 4글자+C라 미매치. 보통주는 대부분 접미사 규칙에 안 걸림.
-const PREFERRED_SUFFIX_RE = /^[A-Z]{3,4}[LMNOPQ]$/;
-// 워런트 패턴 — `-W`, `.W`, `-L`, `.L`, `-P`, `.P`, `WS`
-const WARRANT_RE = /[-.][WLP]$|WS$/;
-// 시리즈 주 — 캐럿(^), `.PR.`, `PRA~PRZ` 접미사
-const SERIES_RE = /\^|\.PR\.|PR[A-Z]$/;
+// 워런트/특수단위 — 하이픈/점 접미사 + WS/WT 꼬리
+// 예: DAL.W, XYZ-WS, FUND.UN (접미사 W, L, P, U, T 단일자)
+const WARRANT_RE = /[-.][WLPUT]$|W[ST]$/;
+// 시리즈/우선주 표기 — 캐럿(^), `.PR.`, `-PR.`, `PRA~PRZ` 명시 접미사
+const SERIES_RE = /\^|[-.]PR\./;
+// 명시적 우선주 클래스 — `-A~-Z`, `.A~.Z` 구분자 포함된 단일 알파벳 접미사
+// (듀얼클래스 보통주 BRK-B, BRK.B, FOXA 등은 화이트리스트로 예외 처리)
+const CLASS_SUFFIX_RE = /[-.][A-Z]$/;
 
 // 우선주/특수클래스 식별 — 보통주 복귀 위해 화이트리스트 선행
+// 정책: 구분자(`-`/`.`) 없는 3~6글자 티커(AAPL/ORCL/META 등)는 절대 필터 안 함
 export function isPreferredOrSpecial(sym) {
-  if (!sym) return false;
+  if (!sym || typeof sym !== 'string') return false;
   const up = sym.toUpperCase();
   if (US_DUAL_CLASS_WHITELIST.has(up)) return false;
   if (WARRANT_RE.test(up)) return true;
   if (SERIES_RE.test(up)) return true;
-  if (PREFERRED_SUFFIX_RE.test(up)) return true;
+  if (CLASS_SUFFIX_RE.test(up)) return true;
   return false;
 }


### PR DESCRIPTION
## 개요
크로스마켓 심볼 충돌(META=Meta/메타디움) 해소 + US 우선주/워런트 보수적 필터.

Closes #183

## 변경 내용
- `src/utils/symbolKey.js` 신규 — `itemKey(item)` 복합키 `${_market}:${symbol}`
  - COIN body는 원본 유지(소문자 id 외부 API 요구 준수)
  - 빈 symbol 방어
- `src/data/usDualClass.js` 신규 — 듀얼클래스 보통주 화이트리스트 (NWS 등)
- `isPreferredOrSpecial(sym)` — `[-.]W[ST]$`/`\^`/`[-.]PR\.` 명시 토큰만 매치
  - **보수적 정책**: 구분자 없는 3~6글자 보통주(AAPL/AMZN/ORCL) 절대 필터 안 함
  - 서버 `update-us` 크론이 1차 책임, 클라이언트는 2차 방어
- `src/hooks/useWatchlist.js` v2 마이그레이션
  - `watchlist_v1` (raw symbol) → `watchlist_v2` (복합키) 1회성 전환
  - `toggle(id, market?)` / `isWatched(id, market?)` — market 힌트 API 확장
  - `migrate()` finally에서 v1 제거 — 손상 JSON 재시도 방지
- `HomeDashboard/home/index.jsx` — allItems 병합 시 `_market` 태그 + itemKey dedup
- `HotListSection`, `NotableMoversSection`, `GlobalSearch`, `WatchlistTable` React key/toggle에 복합키 적용
- `WatchlistTable` `type` prop을 market fallback 최종 기본값으로 사용

## code-reviewer (Opus) 반영
4차 반복 리뷰 수행. 지적사항 전량 반영:
- CRITICAL: `migrate()` map 콜백에 arrow로 id만 전달 (index 오염 차단)
- HIGH: `CLASS_SUFFIX_RE` 제거 (CWEN-A/MOG-A 듀얼클래스 보통주 오탐 방지)
- HIGH: `COIN_ID_RE` digit-prefix 허용 (1inch/0x)
- HIGH: `WARRANT_RE` 구분자 강제 `/[-.]W[ST]$/` (NEWS/JEWELS 오탐 방지)
- HIGH: `itemKey` COIN body 원본 유지 → `toCompositeKey`와 규약 통일
- HIGH: ETF `_market` 태그 실제 시장별 분리 (GlobalSearch ↔ HomeDashboard 키 일관성)
- HIGH: WatchlistTable `type` prop을 market fallback으로 사용
- HIGH: migrate v1 finally 제거
- STYLE: itemKey 빈 symbol 방어

## Test plan
- [ ] 기존 v1 watchlist 있는 브라우저 → 새로고침 → v2 자동 마이그레이션 + v1 제거
- [ ] META 검색 시 US Meta Platforms와 COIN 메타디움 각각 노출
- [ ] SPY 관심종목 HomeDashboard에서 추가 → GlobalSearch에서도 ★ 표시
- [ ] AAPL/NEWS/ORCL 등 보통주 필터 안 됨 확인
- [ ] AGNCM/XYZ-WS 등 워런트 심볼 필터 확인 (서버에서 차단된 상태 가정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)