### PR TITLE
feat: ai-debate Gemini 전환 + 크론 pre-gen + GET 엔드포인트화 (#198)

### DIFF
--- a/api/ai-debate.js
+++ b/api/ai-debate.js
@@ -27,21 +27,16 @@ export default async function handler(request) {
 
   const url = new URL(request.url);
   const symbol = url.searchParams.get('s');
-  const name = url.searchParams.get('n') || symbol;
+  const rawName = url.searchParams.get('n') || symbol;
+  // 프롬프트 인젝션 방지 — 개행 제거 + 50자 제한
+  const name = (rawName || '').replace(/[\r\n]/g, ' ').slice(0, 50);
   const market = url.searchParams.get('m') || 'us';
 
   if (!symbol) {
     return new Response(JSON.stringify({ error: 'symbol required' }), { status: 400 });
   }
 
-  if (!GEMINI_KEY) {
-    return new Response(JSON.stringify({ error: 'GEMINI_API_KEY not configured' }), {
-      status: 503,
-      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': '*' },
-    });
-  }
-
-  // Redis 캐시 조회 — 크론 pre-gen 결과 또는 이전 실시간 생성 결과
+  // Redis 캐시 조회 먼저 — 키 없어도 캐시 hit 가능 (크론 pre-gen 결과)
   const cacheKey = `ai:debate:${symbol}`;
   if (redis) {
     try {
@@ -61,6 +56,14 @@ export default async function handler(request) {
     } catch (e) {
       console.warn('[ai-debate] Redis 조회 실패:', e.message);
     }
+  }
+
+  // 캐시 miss — 실시간 생성 전 키 확인
+  if (!GEMINI_KEY) {
+    return new Response(JSON.stringify({ error: 'GEMINI_API_KEY not configured' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': '*' },
+    });
   }
 
   // 롱테일 종목 실시간 생성 — 크론이 커버 안 한 종목의 첫 클릭

--- a/api/ai-debate.js
+++ b/api/ai-debate.js
@@ -21,6 +21,10 @@ export default async function handler(request) {
     });
   }
 
+  if (request.method !== 'GET') {
+    return new Response(JSON.stringify({ error: 'GET only' }), { status: 405 });
+  }
+
   const url = new URL(request.url);
   const symbol = url.searchParams.get('s');
   const name = url.searchParams.get('n') || symbol;
@@ -89,7 +93,13 @@ export default async function handler(request) {
       });
 
       if (res.status === 429 || res.status >= 500) continue;
-      if (!res.ok) continue;
+      if (!res.ok) {
+        const errText = await res.text().catch(() => '');
+        return new Response(JSON.stringify({ error: `gemini_api: ${res.status}`, detail: errText }), {
+          status: 502,
+          headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': '*' },
+        });
+      }
 
       const data = await res.json();
       const text = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '';

--- a/api/ai-debate.js
+++ b/api/ai-debate.js
@@ -82,9 +82,9 @@ export default async function handler(request) {
 
   for (const modelUrl of GEMINI_MODELS) {
     try {
-      const res = await fetch(`${modelUrl}?key=${GEMINI_KEY}`, {
+      const res = await fetch(modelUrl, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'x-goog-api-key': GEMINI_KEY },
         body: JSON.stringify({
           contents: [{ parts: [{ text: prompt }] }],
           generationConfig: { maxOutputTokens: 256, temperature: 0.7 },
@@ -93,13 +93,14 @@ export default async function handler(request) {
       });
 
       if (res.status === 429 || res.status >= 500) continue;
-      if (!res.ok) {
-        const errText = await res.text().catch(() => '');
-        return new Response(JSON.stringify({ error: `gemini_api: ${res.status}`, detail: errText }), {
+      // 401/403(인증 오류)만 즉시 실패 — 나머지 4xx(404 등 모델 미지원)는 다음 모델 시도
+      if (res.status === 401 || res.status === 403) {
+        return new Response(JSON.stringify({ error: `gemini_auth: ${res.status}` }), {
           status: 502,
           headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': '*' },
         });
       }
+      if (!res.ok) continue;
 
       const data = await res.json();
       const text = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '';

--- a/api/ai-debate.js
+++ b/api/ai-debate.js
@@ -1,51 +1,43 @@
-// AI 종목토론 — Groq API (Edge, 무료 tier, 초고속)
-// primary: llama-3.3-70b-versatile, fallback: llama-3.1-8b-instant
-// Redis 서버 캐시: 동일 종목 토론은 1회만 생성, 전체 사용자 공유 (TTL 30분)
+// AI 종목토론 — Gemini API (Edge)
+// primary: gemini-2.5-flash-lite, fallback: gemini-1.5-flash
+// GET /api/ai-debate?s=AAPL
+// Redis TTL 25h — 크론 pre-gen으로 대부분 cache hit
 export const config = { runtime: 'edge' };
 
 import { redis } from './_price-cache.js';
 
-const GROQ_MODELS = [
-  'llama-3.3-70b-versatile',
-  'llama-3.1-8b-instant',
+const GEMINI_KEY = process.env.GEMINI_API_KEY;
+const GEMINI_MODELS = [
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent',
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent',
 ];
 
-const DEBATE_TTL = 1800; // 30분 — 종목별 캐시
+const DEBATE_TTL = 90000; // 25시간 — 크론 daily 주기 커버
 
 export default async function handler(request) {
   if (request.method === 'OPTIONS') {
     return new Response(null, {
-      headers: { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'POST, OPTIONS', 'Access-Control-Allow-Headers': 'Content-Type' },
+      headers: { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'GET, OPTIONS' },
     });
   }
 
-  if (request.method !== 'POST') {
-    return new Response(JSON.stringify({ error: 'POST only' }), { status: 405 });
-  }
+  const url = new URL(request.url);
+  const symbol = url.searchParams.get('s');
+  const name = url.searchParams.get('n') || symbol;
+  const market = url.searchParams.get('m') || 'us';
 
-  const apiKey = process.env.GROQ_API_KEY;
-  if (!apiKey) {
-    return new Response(JSON.stringify({ error: 'GROQ_API_KEY not configured' }), {
-      status: 503,
-      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache', 'Access-Control-Allow-Origin': '*' },
-    });
-  }
-
-  let body;
-  try {
-    body = await request.json();
-  } catch {
-    return new Response(JSON.stringify({ error: 'invalid json' }), { status: 400 });
-  }
-
-  const { s: symbol, ctx = {} } = body;
   if (!symbol) {
     return new Response(JSON.stringify({ error: 'symbol required' }), { status: 400 });
   }
 
-  // ── Redis 캐시 조회 — 동일 종목은 서버에서 1회만 생성, 전체 사용자 공유 ──
-  // 키에 가격을 포함하지 않음 (의도적): 토론은 정성적 분석이므로 30분 내 가격 변동이
-  // 토론 품질에 실질 영향 없음. 키에 가격대를 넣으면 캐시 히트율이 급락하여 토큰 절감 효과 소실.
+  if (!GEMINI_KEY) {
+    return new Response(JSON.stringify({ error: 'GEMINI_API_KEY not configured' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': '*' },
+    });
+  }
+
+  // Redis 캐시 조회 — 크론 pre-gen 결과 또는 이전 실시간 생성 결과
   const cacheKey = `ai:debate:${symbol}`;
   if (redis) {
     try {
@@ -56,23 +48,20 @@ export default async function handler(request) {
           status: 200,
           headers: {
             'Content-Type': 'application/json',
-            'Cache-Control': 'public, max-age=1800',
+            'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=300',
             'Access-Control-Allow-Origin': '*',
             'X-Cache': 'HIT',
           },
         });
       }
     } catch (e) {
-      console.warn('[ai-debate] Redis 조회 실패, Groq 직접 호출:', e.message);
+      console.warn('[ai-debate] Redis 조회 실패:', e.message);
     }
   }
 
-  const { name = symbol, price, changePct, market = 'us' } = ctx;
-  const priceStr = price ? `현재가 ${market === 'kr' ? price.toLocaleString() + '원' : '$' + price}` : '';
-  const changeStr = changePct != null ? ` (${changePct > 0 ? '+' : ''}${changePct.toFixed(2)}%)` : '';
-
-  // ADR-016: 3라운드 채팅 → "살 이유 vs 조심할 이유" 2줄 요약 (토큰 60% 절감)
-  const prompt = `종목: ${name} (${symbol})${priceStr ? ', ' + priceStr : ''}${changeStr}
+  // 롱테일 종목 실시간 생성 — 크론이 커버 안 한 종목의 첫 클릭
+  const marketLabel = market === 'kr' ? '한국 주식' : market === 'us' ? '미국 주식' : '암호화폐';
+  const prompt = `${marketLabel} 종목: ${name} (${symbol})
 
 이 종목에 대해 "살 이유"(bull) 1~2문장, "조심할 이유"(bear) 1~2문장, 종합 의견 1줄을 작성하세요.
 구체적 수치, 이유, 리스크를 포함하세요. 쉬운 한국어로 작성하세요.
@@ -87,88 +76,40 @@ export default async function handler(request) {
   "confidence": 0.65
 }`;
 
-  for (const model of GROQ_MODELS) {
+  for (const modelUrl of GEMINI_MODELS) {
     try {
-      const res = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+      const res = await fetch(`${modelUrl}?key=${GEMINI_KEY}`, {
         method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          model,
-          messages: [{ role: 'user', content: prompt }],
-          max_tokens: 256,
-          temperature: 0.7,
+          contents: [{ parts: [{ text: prompt }] }],
+          generationConfig: { maxOutputTokens: 256, temperature: 0.7 },
         }),
         signal: AbortSignal.timeout(15000),
       });
 
-      // 429(레이트 리밋)·5xx(서버 일시 오류) → 다음 모델 fallback
       if (res.status === 429 || res.status >= 500) continue;
-
-      // 4xx(인증·요청 오류) → 재시도 무의미, 에러 컨텍스트 보존 후 즉시 반환
-      if (!res.ok) {
-        const errText = await res.text();
-        return new Response(
-          JSON.stringify({ error: `groq_api: ${res.status}`, detail: errText }),
-          { status: 502, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache', 'Access-Control-Allow-Origin': '*' } }
-        );
-      }
+      if (!res.ok) continue;
 
       const data = await res.json();
-      const text = data.choices?.[0]?.message?.content ?? '';
+      const text = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
 
       let parsed;
       try {
         const match = text.match(/\{[\s\S]*\}/);
         parsed = JSON.parse(match?.[0] ?? text);
-        // 구 형식(bull/bear 문자열) → messages 배열로 변환
-        if (!parsed.messages && (parsed.bull || parsed.bear)) {
-          parsed.messages = [
-            ...(parsed.bull ? [{ side: 'bull', text: parsed.bull }] : []),
-            ...(parsed.bear ? [{ side: 'bear', text: parsed.bear }] : []),
-          ];
-        }
-        // LLM이 메시지 text 안에 전체 JSON을 삽입한 경우 감지 → 재파싱 (단일 depth)
-        // inner JSON이 실제 응답이므로 messages/verdict/confidence 모두 복구
-        let innerResult = null;
-        for (const msg of (parsed.messages ?? [])) {
-          const innerText = (msg?.text ?? '').trim();
-          if (!innerText.startsWith('{')) continue;
-          try {
-            let inner;
-            try {
-              inner = JSON.parse(innerText);
-            } catch {
-              const m = innerText.match(/\{[\s\S]*\}/);
-              if (!m) continue;
-              inner = JSON.parse(m[0]);
-            }
-            if (Array.isArray(inner?.messages) && inner.messages.length >= 2) {
-              innerResult = inner;
-              break;
-            }
-          } catch (e) {
-            console.warn('[ai-debate] inner JSON reparse failed:', e?.message);
-          }
-        }
-        if (innerResult) {
-          // 화이트리스트 필드만 병합 — prototype 오염 방지
-          parsed = {
-            ...parsed,
-            messages: innerResult.messages,
-            ...(innerResult.verdict  != null && { verdict:    innerResult.verdict }),
-            ...(innerResult.confidence != null && { confidence: innerResult.confidence }),
-          };
-        }
       } catch {
-        parsed = { messages: [{ side: 'bull', text }], verdict: '', confidence: 0.5 };
+        continue;
       }
 
-      const result = { symbol, model, ...parsed };
+      if (!parsed?.messages) continue;
 
-      // ── Redis 캐시 저장 — 다음 요청부터 Groq 호출 없이 즉시 반환 ──
+      const result = {
+        symbol,
+        model: modelUrl.split('/models/')[1]?.split(':')[0] ?? 'gemini',
+        ...parsed,
+      };
+
       if (redis) {
         try {
           await redis.set(cacheKey, JSON.stringify(result), { ex: DEBATE_TTL });
@@ -181,23 +122,18 @@ export default async function handler(request) {
         status: 200,
         headers: {
           'Content-Type': 'application/json',
-          'Cache-Control': 'public, max-age=1800',
+          'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=300',
           'Access-Control-Allow-Origin': '*',
           'X-Cache': 'MISS',
         },
       });
     } catch (e) {
-      if (model === GROQ_MODELS[GROQ_MODELS.length - 1]) {
-        return new Response(JSON.stringify({ error: e.message }), {
-          status: 502,
-          headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache', 'Access-Control-Allow-Origin': '*' },
-        });
-      }
+      if (e.name !== 'TimeoutError') console.warn('[ai-debate] 모델 실패:', e.message);
     }
   }
 
   return new Response(JSON.stringify({ error: 'all models failed' }), {
     status: 502,
-    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache', 'Access-Control-Allow-Origin': '*' },
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': '*' },
   });
 }

--- a/src/api/_gateway.js
+++ b/src/api/_gateway.js
@@ -183,7 +183,14 @@ export function fetchSocialSentiment(symbol, timeoutMs = 6000) {
   return gwJson({ t: 'sc', s: symbol }, timeoutMs);
 }
 
-// ─── AI 종목토론 ─────────────────────────────────────────────
-export function fetchAiDebate(symbol, ctx = {}, timeoutMs = 25000) {
-  return gwJson({ t: 'db', s: symbol, ctx }, timeoutMs);
+// ─── AI 종목토론 — GET (Edge CDN s-maxage=3600 캐시 가능) ────
+export async function fetchAiDebate(symbol, ctx = {}, timeoutMs = 25000) {
+  const params = new URLSearchParams({ s: symbol });
+  if (ctx.name) params.set('n', ctx.name);
+  if (ctx.market) params.set('m', ctx.market);
+  const res = await fetch(`/api/ai-debate?${params}`, {
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) throw new Error(`ai-debate HTTP ${res.status}`);
+  return res.json();
 }

--- a/src/components/home/AiDebateSection.jsx
+++ b/src/components/home/AiDebateSection.jsx
@@ -86,7 +86,7 @@ export default function AiDebateSection({ watchedItems = [], usStocks = [], allI
       const ctx = { name: item.name, price: stock?.price, changePct: stock?.changePct, market: item.market };
       const data = await fetchAiDebate(item.symbol, ctx);
       if (data?.error) {
-        setError(data.error === 'GROQ_API_KEY not configured' ? 'AI 기능 미설정' : data.error);
+        setError(data.error === 'GEMINI_API_KEY not configured' ? 'AI 기능 미설정' : data.error);
       } else {
         setCached(item.symbol, data);
         setResult(data);

--- a/src/components/home/AiDebateSection.jsx
+++ b/src/components/home/AiDebateSection.jsx
@@ -85,14 +85,10 @@ export default function AiDebateSection({ watchedItems = [], usStocks = [], allI
       const stock = usStocks.find(s => s.symbol === item.symbol);
       const ctx = { name: item.name, price: stock?.price, changePct: stock?.changePct, market: item.market };
       const data = await fetchAiDebate(item.symbol, ctx);
-      if (data?.error) {
-        setError(data.error === 'GEMINI_API_KEY not configured' ? 'AI 기능 미설정' : data.error);
-      } else {
-        setCached(item.symbol, data);
-        setResult(data);
-      }
+      setCached(item.symbol, data);
+      setResult(data);
     } catch (e) {
-      setError(e.message);
+      setError(e.message?.includes('503') ? 'AI 기능 미설정' : e.message);
     } finally {
       setLoading(false);
     }

--- a/workers/cron/src/crons/update-ai-debate.js
+++ b/workers/cron/src/crons/update-ai-debate.js
@@ -1,7 +1,8 @@
 // crons/update-ai-debate.js — AI 종목토론 일일 pre-generation
-// 매일 KST 06:00 (UTC 21:00 전날) — 국장 20 + 미장 20 + 코인 10 = 50종목
+// 매일 KST 06:00 (UTC 21:00 전날) — 국장 10 + 미장 10 + 코인 5 = 25종목
 // Gemini 2.5 Flash Lite → Redis TTL 25h
-// 유저 수 무관 — 하루 50회 고정 (무료 티어 1,500회/일의 3.3%)
+// 25종목 × 2req = 50 subrequests — CF Workers 한계(50/invocation) 내 유지
+// 유저 수 무관 — 하루 25회 고정 (무료 티어 1,500회/일의 1.7%)
 
 import { getRedis, recordCronFailure } from '../price-cache.js';
 
@@ -64,9 +65,9 @@ async function generateOne(symbol, name, market, geminiKey) {
 
   for (const modelUrl of GEMINI_MODELS) {
     try {
-      const res = await fetch(`${modelUrl}?key=${geminiKey}`, {
+      const res = await fetch(modelUrl, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'x-goog-api-key': geminiKey },
         body: JSON.stringify({
           contents: [{ parts: [{ text: prompt }] }],
           generationConfig: { maxOutputTokens: 256, temperature: 0.7 },

--- a/workers/cron/src/crons/update-ai-debate.js
+++ b/workers/cron/src/crons/update-ai-debate.js
@@ -7,8 +7,10 @@ import { getRedis, recordCronFailure } from '../price-cache.js';
 
 const DEBATE_TTL = 90000; // 25시간
 
+// 25종목 — CF Workers subrequest 50/invocation 한계 고려 (종목당 Gemini+Redis = 2req)
+// 25 × 2 = 50 → 한계 내. 롱테일은 유저 first-click 시 실시간 생성 (fallback 유지)
 const TOP_SYMBOLS = [
-  // 국장 상위 20
+  // 국장 상위 10
   { symbol: '005930', name: '삼성전자', market: 'kr' },
   { symbol: '000660', name: 'SK하이닉스', market: 'kr' },
   { symbol: '005380', name: '현대차', market: 'kr' },
@@ -19,17 +21,7 @@ const TOP_SYMBOLS = [
   { symbol: '035720', name: '카카오', market: 'kr' },
   { symbol: '035420', name: 'NAVER', market: 'kr' },
   { symbol: '006400', name: '삼성SDI', market: 'kr' },
-  { symbol: '051910', name: 'LG화학', market: 'kr' },
-  { symbol: '105560', name: 'KB금융', market: 'kr' },
-  { symbol: '055550', name: '신한지주', market: 'kr' },
-  { symbol: '066570', name: 'LG전자', market: 'kr' },
-  { symbol: '003550', name: 'LG', market: 'kr' },
-  { symbol: '028260', name: '삼성물산', market: 'kr' },
-  { symbol: '012330', name: '현대모비스', market: 'kr' },
-  { symbol: '000810', name: '삼성화재', market: 'kr' },
-  { symbol: '032830', name: '삼성생명', market: 'kr' },
-  { symbol: '096770', name: 'SK이노베이션', market: 'kr' },
-  // 미장 상위 20
+  // 미장 상위 10
   { symbol: 'AAPL', name: 'Apple', market: 'us' },
   { symbol: 'MSFT', name: 'Microsoft', market: 'us' },
   { symbol: 'NVDA', name: 'NVIDIA', market: 'us' },
@@ -40,27 +32,12 @@ const TOP_SYMBOLS = [
   { symbol: 'JPM', name: 'JPMorgan', market: 'us' },
   { symbol: 'AVGO', name: 'Broadcom', market: 'us' },
   { symbol: 'TSM', name: 'TSMC', market: 'us' },
-  { symbol: 'AMD', name: 'AMD', market: 'us' },
-  { symbol: 'NFLX', name: 'Netflix', market: 'us' },
-  { symbol: 'V', name: 'Visa', market: 'us' },
-  { symbol: 'UNH', name: 'UnitedHealth', market: 'us' },
-  { symbol: 'XOM', name: 'ExxonMobil', market: 'us' },
-  { symbol: 'ORCL', name: 'Oracle', market: 'us' },
-  { symbol: 'WMT', name: 'Walmart', market: 'us' },
-  { symbol: 'PLTR', name: 'Palantir', market: 'us' },
-  { symbol: 'ARM', name: 'ARM Holdings', market: 'us' },
-  { symbol: 'CRM', name: 'Salesforce', market: 'us' },
-  // 코인 상위 10
+  // 코인 상위 5
   { symbol: 'BTC', name: '비트코인', market: 'crypto' },
   { symbol: 'ETH', name: '이더리움', market: 'crypto' },
   { symbol: 'XRP', name: '리플', market: 'crypto' },
   { symbol: 'SOL', name: '솔라나', market: 'crypto' },
   { symbol: 'BNB', name: '바이낸스코인', market: 'crypto' },
-  { symbol: 'DOGE', name: '도지코인', market: 'crypto' },
-  { symbol: 'ADA', name: '에이다', market: 'crypto' },
-  { symbol: 'AVAX', name: '아발란체', market: 'crypto' },
-  { symbol: 'DOT', name: '폴카닷', market: 'crypto' },
-  { symbol: 'LINK', name: '체인링크', market: 'crypto' },
 ];
 
 const GEMINI_MODELS = [
@@ -151,7 +128,7 @@ export async function updateAiDebate(env) {
   }
 
   if (fail > ok) {
-    await recordCronFailure(env, 'update-ai-debate', `ok=${ok} fail=${fail}`);
+    await recordCronFailure(env, 'ai-debate', `ok=${ok} fail=${fail}`);
   }
 
   return { ok, fail, total: TOP_SYMBOLS.length };

--- a/workers/cron/src/crons/update-ai-debate.js
+++ b/workers/cron/src/crons/update-ai-debate.js
@@ -1,0 +1,158 @@
+// crons/update-ai-debate.js — AI 종목토론 일일 pre-generation
+// 매일 KST 06:00 (UTC 21:00 전날) — 국장 20 + 미장 20 + 코인 10 = 50종목
+// Gemini 2.5 Flash Lite → Redis TTL 25h
+// 유저 수 무관 — 하루 50회 고정 (무료 티어 1,500회/일의 3.3%)
+
+import { getRedis, recordCronFailure } from '../price-cache.js';
+
+const DEBATE_TTL = 90000; // 25시간
+
+const TOP_SYMBOLS = [
+  // 국장 상위 20
+  { symbol: '005930', name: '삼성전자', market: 'kr' },
+  { symbol: '000660', name: 'SK하이닉스', market: 'kr' },
+  { symbol: '005380', name: '현대차', market: 'kr' },
+  { symbol: '000270', name: '기아', market: 'kr' },
+  { symbol: '373220', name: 'LG에너지솔루션', market: 'kr' },
+  { symbol: '207940', name: '삼성바이오로직스', market: 'kr' },
+  { symbol: '068270', name: '셀트리온', market: 'kr' },
+  { symbol: '035720', name: '카카오', market: 'kr' },
+  { symbol: '035420', name: 'NAVER', market: 'kr' },
+  { symbol: '006400', name: '삼성SDI', market: 'kr' },
+  { symbol: '051910', name: 'LG화학', market: 'kr' },
+  { symbol: '105560', name: 'KB금융', market: 'kr' },
+  { symbol: '055550', name: '신한지주', market: 'kr' },
+  { symbol: '066570', name: 'LG전자', market: 'kr' },
+  { symbol: '003550', name: 'LG', market: 'kr' },
+  { symbol: '028260', name: '삼성물산', market: 'kr' },
+  { symbol: '012330', name: '현대모비스', market: 'kr' },
+  { symbol: '000810', name: '삼성화재', market: 'kr' },
+  { symbol: '032830', name: '삼성생명', market: 'kr' },
+  { symbol: '096770', name: 'SK이노베이션', market: 'kr' },
+  // 미장 상위 20
+  { symbol: 'AAPL', name: 'Apple', market: 'us' },
+  { symbol: 'MSFT', name: 'Microsoft', market: 'us' },
+  { symbol: 'NVDA', name: 'NVIDIA', market: 'us' },
+  { symbol: 'GOOGL', name: 'Alphabet', market: 'us' },
+  { symbol: 'AMZN', name: 'Amazon', market: 'us' },
+  { symbol: 'META', name: 'Meta', market: 'us' },
+  { symbol: 'TSLA', name: 'Tesla', market: 'us' },
+  { symbol: 'JPM', name: 'JPMorgan', market: 'us' },
+  { symbol: 'AVGO', name: 'Broadcom', market: 'us' },
+  { symbol: 'TSM', name: 'TSMC', market: 'us' },
+  { symbol: 'AMD', name: 'AMD', market: 'us' },
+  { symbol: 'NFLX', name: 'Netflix', market: 'us' },
+  { symbol: 'V', name: 'Visa', market: 'us' },
+  { symbol: 'UNH', name: 'UnitedHealth', market: 'us' },
+  { symbol: 'XOM', name: 'ExxonMobil', market: 'us' },
+  { symbol: 'ORCL', name: 'Oracle', market: 'us' },
+  { symbol: 'WMT', name: 'Walmart', market: 'us' },
+  { symbol: 'PLTR', name: 'Palantir', market: 'us' },
+  { symbol: 'ARM', name: 'ARM Holdings', market: 'us' },
+  { symbol: 'CRM', name: 'Salesforce', market: 'us' },
+  // 코인 상위 10
+  { symbol: 'BTC', name: '비트코인', market: 'crypto' },
+  { symbol: 'ETH', name: '이더리움', market: 'crypto' },
+  { symbol: 'XRP', name: '리플', market: 'crypto' },
+  { symbol: 'SOL', name: '솔라나', market: 'crypto' },
+  { symbol: 'BNB', name: '바이낸스코인', market: 'crypto' },
+  { symbol: 'DOGE', name: '도지코인', market: 'crypto' },
+  { symbol: 'ADA', name: '에이다', market: 'crypto' },
+  { symbol: 'AVAX', name: '아발란체', market: 'crypto' },
+  { symbol: 'DOT', name: '폴카닷', market: 'crypto' },
+  { symbol: 'LINK', name: '체인링크', market: 'crypto' },
+];
+
+const GEMINI_MODELS = [
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent',
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent',
+];
+
+async function generateOne(symbol, name, market, geminiKey) {
+  const marketLabel = market === 'kr' ? '한국 주식' : market === 'us' ? '미국 주식' : '암호화폐';
+  const prompt = `${marketLabel} 종목: ${name} (${symbol})
+
+이 종목에 대해 "살 이유"(bull) 1~2문장, "조심할 이유"(bear) 1~2문장, 종합 의견 1줄을 작성하세요.
+구체적 수치, 이유, 리스크를 포함하세요. 쉬운 한국어로 작성하세요.
+
+반드시 아래 JSON만 반환하세요 (다른 텍스트 절대 없이):
+{
+  "messages": [
+    {"side": "bull", "text": "살 이유 1~2문장"},
+    {"side": "bear", "text": "조심할 이유 1~2문장"}
+  ],
+  "verdict": "한국어 종합 의견 1줄",
+  "confidence": 0.65
+}`;
+
+  for (const modelUrl of GEMINI_MODELS) {
+    try {
+      const res = await fetch(`${modelUrl}?key=${geminiKey}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: prompt }] }],
+          generationConfig: { maxOutputTokens: 256, temperature: 0.7 },
+        }),
+        signal: AbortSignal.timeout(20000),
+      });
+
+      if (res.status === 429) {
+        await new Promise(r => setTimeout(r, 5000));
+        continue;
+      }
+      if (!res.ok) continue;
+
+      const data = await res.json();
+      const text = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+      const match = text.match(/\{[\s\S]*\}/);
+      if (!match) continue;
+
+      const parsed = JSON.parse(match[0]);
+      if (!Array.isArray(parsed?.messages) || parsed.messages.length < 2) continue;
+
+      return {
+        symbol, name,
+        model: modelUrl.split('/models/')[1]?.split(':')[0] ?? 'gemini',
+        ...parsed,
+        _generatedAt: new Date().toISOString(),
+      };
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+export async function updateAiDebate(env) {
+  const geminiKey = env.GEMINI_API_KEY;
+  if (!geminiKey) return { skipped: true, reason: 'GEMINI_API_KEY not set' };
+
+  const redis = getRedis();
+  if (!redis) return { skipped: true, reason: 'Redis not initialized' };
+
+  let ok = 0, fail = 0;
+
+  for (const { symbol, name, market } of TOP_SYMBOLS) {
+    try {
+      const result = await generateOne(symbol, name, market, geminiKey);
+      if (result) {
+        await redis.set(`ai:debate:${symbol}`, JSON.stringify(result), { ex: DEBATE_TTL });
+        ok++;
+      } else {
+        fail++;
+      }
+    } catch (e) {
+      console.warn(`[ai-debate-cron] ${symbol} 실패:`, e.message);
+      fail++;
+    }
+    // 15 RPM 안전 — 4초 간격 (15회/분 = 4초/회)
+    await new Promise(r => setTimeout(r, 4000));
+  }
+
+  if (fail > ok) {
+    await recordCronFailure(env, 'update-ai-debate', `ok=${ok} fail=${fail}`);
+  }
+
+  return { ok, fail, total: TOP_SYMBOLS.length };
+}

--- a/workers/cron/src/crons/update-ai-debate.js
+++ b/workers/cron/src/crons/update-ai-debate.js
@@ -1,17 +1,16 @@
 // crons/update-ai-debate.js — AI 종목토론 일일 pre-generation
-// 매일 KST 06:00 (UTC 21:00 전날) — 국장 10 + 미장 10 + 코인 5 = 25종목
-// Gemini 2.5 Flash Lite → Redis TTL 25h
-// 25종목 × 2req = 50 subrequests — CF Workers 한계(50/invocation) 내 유지
-// 유저 수 무관 — 하루 25회 고정 (무료 티어 1,500회/일의 1.7%)
+// 매일 KST 06:00 (UTC 21:00 전날) — 국장 8 + 미장 9 + 코인 5 = 22종목
+// Gemini 2.5 Flash Lite 단일 모델 (fallback 없음 — subrequest 예산 보존)
+// 22종목 × 2req(Gemini+Redis) = 44 subrequests — CF Workers 50/invocation 한계 내 여유 유지
+// 유저 수 무관 — 하루 22회 고정 (무료 티어 1,500회/일의 1.5%)
 
 import { getRedis, recordCronFailure } from '../price-cache.js';
 
 const DEBATE_TTL = 90000; // 25시간
 
-// 25종목 — CF Workers subrequest 50/invocation 한계 고려 (종목당 Gemini+Redis = 2req)
-// 25 × 2 = 50 → 한계 내. 롱테일은 유저 first-click 시 실시간 생성 (fallback 유지)
+// 22종목 — 국장 8 + 미장 9 + 코인 5. 롱테일은 유저 first-click 시 실시간 생성
 const TOP_SYMBOLS = [
-  // 국장 상위 10
+  // 국장 상위 8
   { symbol: '005930', name: '삼성전자', market: 'kr' },
   { symbol: '000660', name: 'SK하이닉스', market: 'kr' },
   { symbol: '005380', name: '현대차', market: 'kr' },
@@ -19,10 +18,8 @@ const TOP_SYMBOLS = [
   { symbol: '373220', name: 'LG에너지솔루션', market: 'kr' },
   { symbol: '207940', name: '삼성바이오로직스', market: 'kr' },
   { symbol: '068270', name: '셀트리온', market: 'kr' },
-  { symbol: '035720', name: '카카오', market: 'kr' },
   { symbol: '035420', name: 'NAVER', market: 'kr' },
-  { symbol: '006400', name: '삼성SDI', market: 'kr' },
-  // 미장 상위 10
+  // 미장 상위 9
   { symbol: 'AAPL', name: 'Apple', market: 'us' },
   { symbol: 'MSFT', name: 'Microsoft', market: 'us' },
   { symbol: 'NVDA', name: 'NVIDIA', market: 'us' },
@@ -32,7 +29,6 @@ const TOP_SYMBOLS = [
   { symbol: 'TSLA', name: 'Tesla', market: 'us' },
   { symbol: 'JPM', name: 'JPMorgan', market: 'us' },
   { symbol: 'AVGO', name: 'Broadcom', market: 'us' },
-  { symbol: 'TSM', name: 'TSMC', market: 'us' },
   // 코인 상위 5
   { symbol: 'BTC', name: '비트코인', market: 'crypto' },
   { symbol: 'ETH', name: '이더리움', market: 'crypto' },
@@ -41,10 +37,8 @@ const TOP_SYMBOLS = [
   { symbol: 'BNB', name: '바이낸스코인', market: 'crypto' },
 ];
 
-const GEMINI_MODELS = [
-  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent',
-  'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent',
-];
+// fallback 없음 — subrequest 예산 보존 (22×2=44, 한계 50 내 여유 6)
+const GEMINI_MODEL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent';
 
 async function generateOne(symbol, name, market, geminiKey) {
   const marketLabel = market === 'kr' ? '한국 주식' : market === 'us' ? '미국 주식' : '암호화폐';
@@ -63,43 +57,36 @@ async function generateOne(symbol, name, market, geminiKey) {
   "confidence": 0.65
 }`;
 
-  for (const modelUrl of GEMINI_MODELS) {
-    try {
-      const res = await fetch(modelUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'x-goog-api-key': geminiKey },
-        body: JSON.stringify({
-          contents: [{ parts: [{ text: prompt }] }],
-          generationConfig: { maxOutputTokens: 256, temperature: 0.7 },
-        }),
-        signal: AbortSignal.timeout(20000),
-      });
+  try {
+    const res = await fetch(GEMINI_MODEL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-goog-api-key': geminiKey },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: { maxOutputTokens: 256, temperature: 0.7 },
+      }),
+      signal: AbortSignal.timeout(20000),
+    });
 
-      if (res.status === 429) {
-        await new Promise(r => setTimeout(r, 5000));
-        continue;
-      }
-      if (!res.ok) continue;
+    if (!res.ok) return null;
 
-      const data = await res.json();
-      const text = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
-      const match = text.match(/\{[\s\S]*\}/);
-      if (!match) continue;
+    const data = await res.json();
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) return null;
 
-      const parsed = JSON.parse(match[0]);
-      if (!Array.isArray(parsed?.messages) || parsed.messages.length < 2) continue;
+    const parsed = JSON.parse(match[0]);
+    if (!Array.isArray(parsed?.messages) || parsed.messages.length < 2) return null;
 
-      return {
-        symbol, name,
-        model: modelUrl.split('/models/')[1]?.split(':')[0] ?? 'gemini',
-        ...parsed,
-        _generatedAt: new Date().toISOString(),
-      };
-    } catch {
-      continue;
-    }
+    return {
+      symbol, name,
+      model: 'gemini-2.5-flash-lite',
+      ...parsed,
+      _generatedAt: new Date().toISOString(),
+    };
+  } catch {
+    return null;
   }
-  return null;
 }
 
 export async function updateAiDebate(env) {

--- a/workers/cron/src/crons/update-ai-debate.js
+++ b/workers/cron/src/crons/update-ai-debate.js
@@ -116,7 +116,7 @@ export async function updateAiDebate(env) {
   }
 
   if (fail > ok) {
-    await recordCronFailure(env, 'ai-debate', `ok=${ok} fail=${fail}`);
+    await recordCronFailure('ai-debate', `ok=${ok} fail=${fail}`);
   }
 
   return { ok, fail, total: TOP_SYMBOLS.length };

--- a/workers/cron/src/index.js
+++ b/workers/cron/src/index.js
@@ -5,6 +5,7 @@ import { updateUs } from './crons/update-us.js';
 import { checkSignalAccuracy } from './crons/check-signal-accuracy.js';
 import { morningBriefing } from './crons/morning-briefing.js';
 import { watchdog } from './crons/watchdog.js';
+import { updateAiDebate } from './crons/update-ai-debate.js';
 
 export default {
   async scheduled(event, env, ctx) {
@@ -53,6 +54,9 @@ export default {
       ctx.waitUntil(checkSignalAccuracy(env));
     } else if (cron === '50 23 * * *') {
       ctx.waitUntil(morningBriefing(env));
+    } else if (cron === '0 21 * * *') {
+      // AI 종목토론 daily pre-gen — UTC 21:00 = KST 06:00
+      ctx.waitUntil(updateAiDebate(env));
     } else if (cron === '*/10 * * * *') {
       // #164 Phase C: 크론 실패 조기 경보. cron:fail:* >= 3 시 Discord 알림.
       ctx.waitUntil(watchdog(env));
@@ -75,6 +79,7 @@ export default {
       if (path === '/check-signal') return Response.json(await checkSignalAccuracy(env));
       if (path === '/briefing') return Response.json(await morningBriefing(env));
       if (path === '/watchdog') return Response.json(await watchdog(env));
+      if (path === '/ai-debate') return Response.json(await updateAiDebate(env));
       return new Response('mdv5-cron worker', { status: 200 });
     } catch (e) {
       return Response.json({ error: e.message }, { status: 500 });

--- a/workers/cron/wrangler.toml
+++ b/workers/cron/wrangler.toml
@@ -14,5 +14,6 @@ crons = [
   "4-59/5 * * * *",    # us shard 2  — 04, 09, 14, 19, ...
   "*/30 * * * *",
   "50 23 * * *",
+  "0 21 * * *",        # ai-debate pre-gen — UTC 21:00 = KST 06:00 (50종목 daily)
   "*/10 * * * *"       # #164 Phase C: watchdog — cron:fail:* >= 3 시 Discord 알림
 ]

--- a/workers/cron/wrangler.toml
+++ b/workers/cron/wrangler.toml
@@ -14,6 +14,6 @@ crons = [
   "4-59/5 * * * *",    # us shard 2  — 04, 09, 14, 19, ...
   "*/30 * * * *",
   "50 23 * * *",
-  "0 21 * * *",        # ai-debate pre-gen — UTC 21:00 = KST 06:00 (50종목 daily)
+  "0 21 * * *",        # ai-debate pre-gen — UTC 21:00 = KST 06:00 (25종목 daily)
   "*/10 * * * *"       # #164 Phase C: watchdog — cron:fail:* >= 3 시 Discord 알림
 ]


### PR DESCRIPTION
## 변경 사항

Closes #198

### 목표
유저 수 증가에 LLM 비용이 비례하지 않는 구조. 1명이건 10만명이건 하루 22회 고정.

### 핵심 변경
- **api/ai-debate.js**: POST→GET, Groq(llama)→Gemini 2.5 Flash Lite, s-maxage=3600, TTL 25h
  - Redis 캐시 조회 먼저 → GEMINI_KEY 체크 후순위 (cache-first 설계)
  - n 파라미터 sanitize (개행 제거 + 50자 제한, 프롬프트 인젝션 방지)
  - API 키 URL 파라미터 → x-goog-api-key 헤더 (보안)
  - 401/403만 즉시 반환, 나머지 4xx는 다음 모델 fallback
- **workers/cron/src/crons/update-ai-debate.js**: 신규 — 국장 8 + 미장 9 + 코인 5 = 22종목 daily pre-gen
  - 단일 모델 (fallback 없음) → 22×2=44 subreq, CF Workers 50/invocation 한계 내 여유 확보
  - x-goog-api-key 헤더 방식
- **workers/cron/src/index.js**: 크론 핸들러 + HTTP 테스트 핸들러 추가
- **workers/cron/wrangler.toml**: "0 21 * * *" 스케줄 추가 (UTC 21:00 = KST 06:00)
- **src/api/_gateway.js**: fetchAiDebate gwJson POST → GET fetch 직접 호출로 전환
- **src/components/home/AiDebateSection.jsx**: 에러 처리 catch 통합 (dead code 제거)

### Codex P2 지적 처리
| 지적 | 판단 | 처리 |
|------|------|------|
| recordCronFailure 인자 오류 (env 불필요) | 채택 | 수정 완료 |
| /api/d db 호환 유지 | 기각 | _gateway.js에서 직접 GET 호출로 전환했으므로 /api/d 경로 미사용 |

### 효과
- Groq LLM 비용 → 0 (Gemini 무료 22회/일, 1,500회/일 한도의 1.5%)
- Edge CDN s-maxage=3600 → 대부분 유저 캐시 hit
- 한국 종목 분석 품질 향상 (Gemini > llama)

## 리뷰 결과
- code-reviewer (Opus): PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 매일 자동으로 생성되는 AI 토론 콘텐츠 사전 로드로 응답 속도 향상

* **Improvements**
  * AI 토론 콘텐츠 캐시 관리 방식 개선으로 더욱 안정적인 성능 제공
  * AI 서비스 사용 불가 상황에서 사용자 안내 메시지 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->