### PR TITLE
chore: pre-deploy 게이트 단계 진행 로그 기록 (#208)

### DIFF
--- a/scripts/pre-deploy-consensus.sh
+++ b/scripts/pre-deploy-consensus.sh
@@ -25,6 +25,32 @@ PASS=0
 FAIL=0
 SKIP=0
 
+# ── 진행 로그 (deploy-tui 등 외부 모니터에서 읽음) — chore-only, 동작 변경 없음 ──
+GATE_PROGRESS_LOG="${GATE_PROGRESS_LOG:-.tmp/deploy-progress.log}"
+CURRENT_GATE="0"
+mkdir -p .tmp 2>/dev/null || true
+: > "$GATE_PROGRESS_LOG" 2>/dev/null || GATE_PROGRESS_LOG=""
+if [ -n "${GATE_PROGRESS_LOG:-}" ]; then
+  printf '%s\t0\tdeploy-consensus 시작\tSTART\t%s\n' \
+    "$(date +%s)" "$(git rev-parse --short HEAD 2>/dev/null || echo unknown)" \
+    >> "$GATE_PROGRESS_LOG" 2>/dev/null || true
+fi
+
+_gate_begin() {
+  CURRENT_GATE="$1"
+  if [ -n "${GATE_PROGRESS_LOG:-}" ]; then
+    printf '%s\t%s\t%s\tRUNNING\t\n' "$(date +%s)" "$1" "$2" \
+      >> "$GATE_PROGRESS_LOG" 2>/dev/null || true
+  fi
+}
+
+_gate_finish() {
+  if [ -n "${GATE_PROGRESS_LOG:-}" ]; then
+    printf '%s\t99\t완료\tALL_DONE\t\n' "$(date +%s)" \
+      >> "$GATE_PROGRESS_LOG" 2>/dev/null || true
+  fi
+}
+
 check() {
   local name="$1"
   local result="$2"  # PASS or FAIL
@@ -36,6 +62,10 @@ check() {
     echo -e "${RED}  🚫 ${name}${NC}${detail:+ — ${detail}}"
     FAIL=$((FAIL + 1))
   fi
+  if [ -n "${GATE_PROGRESS_LOG:-}" ]; then
+    printf '%s\t%s\t%s\t%s\t%s\n' "$(date +%s)" "${CURRENT_GATE:-?}" "$name" "$result" "$detail" \
+      >> "$GATE_PROGRESS_LOG" 2>/dev/null || true
+  fi
 }
 
 echo ""
@@ -46,6 +76,7 @@ echo ""
 
 # ── Gate 1: 빌드 통과 ────────────────────────────────────────────────────────
 echo -e "${BLUE}[1/6] 빌드 검증${NC}"
+_gate_begin 1 "빌드 검증"
 if npm run build --silent 2>/dev/null; then
   check "빌드" "PASS" "vite build 성공"
 else
@@ -61,6 +92,7 @@ fi
 
 # ── Gate 2: P0/P1 이슈 없음 ──────────────────────────────────────────────────
 echo -e "${BLUE}[2/6] P0/P1 오픈 이슈 확인${NC}"
+_gate_begin 2 "P0/P1 오픈 이슈"
 # || true: set -e 환경에서 gh 인증/네트워크 실패 시 스크립트 전체 종료 방지
 # 빈 문자열 결과 → 하단 empty-string 체크에서 FAIL 처리 (알 수 없는 상태를 PASS로 처리 금지)
 P0_ISSUES=$(gh issue list --label "P0" --state open --json number --jq 'length' 2>/dev/null || true)
@@ -80,6 +112,7 @@ fi
 
 # ── Gate 3: PM 검토 — 이준혁 (기획 정합성) ──────────────────────────────────
 echo -e "${BLUE}[3/6] PM 검토 — 이준혁 (작업 의도 정합성 검토)${NC}"
+_gate_begin 3 "PM 검토"
 PM_VERDICT="SKIP"
 if command -v claude &>/dev/null && [ -f ".project/backlog.md" ]; then
   # nonce: 실행 시마다 랜덤 생성 → 커밋 메시지로 미리 알 수 없어 프롬프트 인젝션 차단
@@ -151,6 +184,7 @@ fi
 
 # ── Gate 4: QA 승인 (장성민) ─────────────────────────────────────────────────
 echo -e "${BLUE}[4/6] QA 승인 — 장성민 (품질 기준 검증)${NC}"
+_gate_begin 4 "QA 승인"
 QUALITY_FILE=".project/quality-baseline.md"
 QA_ISSUES=0
 # 파일 존재 확인 수준의 소프트 게이트 — 실제 기준 충족 여부는 PR 리뷰 단계에서 검증
@@ -177,6 +211,7 @@ fi
 
 # ── Gate 5: 개발팀 승인 ──────────────────────────────────────────────────────
 echo -e "${BLUE}[5/6] 개발팀 승인 — FE(박서연) / BE(김민준)${NC}"
+_gate_begin 5 "개발팀 승인"
 # 최근 커밋에 리뷰되지 않은 알고리즘 파일 변경 없는지 확인
 ALGO_CHANGED=0
 if [ ! -f ".algo-files" ]; then
@@ -259,6 +294,7 @@ fi
 # 최신 code-review-{BRANCH}.md 와 codex-review-{BRANCH}.md artifact를 읽어 충돌 감지.
 # 충돌 시 BLOCK 우선 원칙 적용 (PASS+BLOCK → BLOCK).
 # SKIP_CODEX_REVIEW=1 설정 시 Codex 단독 BLOCK + Opus PASS 조합만 허용 (경고 후 통과).
+_gate_begin 5.5 "Opus+Codex 충돌 중재"
 CURRENT_BRANCH_GATE=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 SAFE_BRANCH_GATE="${CURRENT_BRANCH_GATE//\//-}"
 
@@ -331,6 +367,7 @@ fi
 
 # ── Gate 6: 조직장 승인 (이준혁 CPO) ─────────────────────────────────────────
 echo -e "${BLUE}[6/6] 조직장 승인 — 이준혁 CPO${NC}"
+_gate_begin 6 "조직장 승인"
 # CLAUDE.md의 배포 방향과 일치하는지: 배포 조건 (P0/P1 수정 or 주요 기능 완료) 확인
 DEPLOY_CONDITION_MET=0
 
@@ -362,10 +399,12 @@ if [ "$FAIL" -eq 0 ]; then
   fi
   echo -e "${GREEN}✅ 컨센서스 PASS (${PASS}/${TOTAL}${SKIP_MSG}) — 배포 가능${NC}"
   echo ""
+  _gate_finish
   exit 0
 else
   echo -e "${RED}🚫 컨센서스 FAIL (${FAIL}건 미통과) — 배포 불가${NC}"
   echo -e "${YELLOW}   위 항목 해결 후 재실행: npm run deploy:check${NC}"
   echo ""
+  _gate_finish
   exit 1
 fi


### PR DESCRIPTION
## 변경 요약

\`scripts/pre-deploy-consensus.sh\`에 진행 로그 기록 한 줄씩 추가. 외부 모니터(\`/Users/bong/deploy-tui\`)가 \`npm run deploy\` 실행 시 6-Gate 어디까지 갔는지 실시간으로 보여주기 위함.

## 추가된 것

- \`_gate_begin\` / \`_gate_finish\` helper (스크립트 상단)
- \`check()\` 함수에 한 줄 — PASS/FAIL을 \`.tmp/deploy-progress.log\`에도 기록
- 각 게이트 \`echo "[N/6]…"\` 직후 \`_gate_begin N "이름"\` 호출 (Gate 1~6 + 5.5)
- 정상/실패 종료 직전 \`_gate_finish\` 호출

## 동작

- \`.tmp/deploy-progress.log\` (TAB-delimited) — 매 실행 시 truncate, append-only
- 형식: \`ts<TAB>gate<TAB>label<TAB>state<TAB>detail\`, state: \`START\` / \`RUNNING\` / \`PASS\` / \`FAIL\` / \`ALL_DONE\`
- 외부 모니터 없으면 (= 파일 쓰기 권한 없거나 mkdir 실패 시) 변수가 비워져 모든 호출이 no-op으로 수렴 (set -e 안전)

## 영향 범위

- 알고리즘 파일 변경 없음 → architect 게이트 스킵 정상
- stdout 출력은 그대로 (사용자 경험 변경 0)
- 실패 시 set -e가 \`|| true\`로 흡수돼 게이트 자체에는 영향 없음

## 봇 리뷰 / Opus / Codex gate

- chore 분류, 알고리즘/보호파일 변경 없음 → architect 자동 스킵
- 의미적으로는 npm run pr (Opus + Codex 게이트)이 chore-only 단순 셸 추가에는 과한 절차이지만, CodeRabbit / Copilot / Gemini 자동 리뷰는 정상 트리거됨
- PR 머지 전 봇 리뷰 답변은 정책대로 처리 예정

Closes #208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 배포 프로세스 중 진행 상황을 추적할 수 있는 로깅 기능이 추가되었습니다. 시작, 실행 중, 완료 단계별로 타임스탐프와 상세 정보(성공/실패 여부 포함)가 기록되어 배포 과정을 더 효과적으로 모니터링할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->