### PR TITLE
fix: 장 마감/주말 클라이언트 폴링 인터벌 동적 조정 (#210)

### DIFF
--- a/scripts/pre-deploy-consensus.sh
+++ b/scripts/pre-deploy-consensus.sh
@@ -25,6 +25,32 @@ PASS=0
 FAIL=0
 SKIP=0
 
+# ── 진행 로그 (deploy-tui 등 외부 모니터에서 읽음) — chore-only, 동작 변경 없음 ──
+GATE_PROGRESS_LOG="${GATE_PROGRESS_LOG:-.tmp/deploy-progress.log}"
+CURRENT_GATE="0"
+mkdir -p .tmp 2>/dev/null || true
+: > "$GATE_PROGRESS_LOG" 2>/dev/null || GATE_PROGRESS_LOG=""
+if [ -n "${GATE_PROGRESS_LOG:-}" ]; then
+  printf '%s\t0\tdeploy-consensus 시작\tSTART\t%s\n' \
+    "$(date +%s)" "$(git rev-parse --short HEAD 2>/dev/null || echo unknown)" \
+    >> "$GATE_PROGRESS_LOG" 2>/dev/null || true
+fi
+
+_gate_begin() {
+  CURRENT_GATE="$1"
+  if [ -n "${GATE_PROGRESS_LOG:-}" ]; then
+    printf '%s\t%s\t%s\tRUNNING\t\n' "$(date +%s)" "$1" "$2" \
+      >> "$GATE_PROGRESS_LOG" 2>/dev/null || true
+  fi
+}
+
+_gate_finish() {
+  if [ -n "${GATE_PROGRESS_LOG:-}" ]; then
+    printf '%s\t99\t완료\tALL_DONE\t\n' "$(date +%s)" \
+      >> "$GATE_PROGRESS_LOG" 2>/dev/null || true
+  fi
+}
+
 check() {
   local name="$1"
   local result="$2"  # PASS or FAIL
@@ -36,6 +62,10 @@ check() {
     echo -e "${RED}  🚫 ${name}${NC}${detail:+ — ${detail}}"
     FAIL=$((FAIL + 1))
   fi
+  if [ -n "${GATE_PROGRESS_LOG:-}" ]; then
+    printf '%s\t%s\t%s\t%s\t%s\n' "$(date +%s)" "${CURRENT_GATE:-?}" "$name" "$result" "$detail" \
+      >> "$GATE_PROGRESS_LOG" 2>/dev/null || true
+  fi
 }
 
 echo ""
@@ -46,6 +76,7 @@ echo ""
 
 # ── Gate 1: 빌드 통과 ────────────────────────────────────────────────────────
 echo -e "${BLUE}[1/6] 빌드 검증${NC}"
+_gate_begin 1 "빌드 검증"
 if npm run build --silent 2>/dev/null; then
   check "빌드" "PASS" "vite build 성공"
 else
@@ -61,6 +92,7 @@ fi
 
 # ── Gate 2: P0/P1 이슈 없음 ──────────────────────────────────────────────────
 echo -e "${BLUE}[2/6] P0/P1 오픈 이슈 확인${NC}"
+_gate_begin 2 "P0/P1 오픈 이슈"
 # || true: set -e 환경에서 gh 인증/네트워크 실패 시 스크립트 전체 종료 방지
 # 빈 문자열 결과 → 하단 empty-string 체크에서 FAIL 처리 (알 수 없는 상태를 PASS로 처리 금지)
 P0_ISSUES=$(gh issue list --label "P0" --state open --json number --jq 'length' 2>/dev/null || true)
@@ -80,6 +112,7 @@ fi
 
 # ── Gate 3: PM 검토 — 이준혁 (기획 정합성) ──────────────────────────────────
 echo -e "${BLUE}[3/6] PM 검토 — 이준혁 (작업 의도 정합성 검토)${NC}"
+_gate_begin 3 "PM 검토"
 PM_VERDICT="SKIP"
 if command -v claude &>/dev/null && [ -f ".project/backlog.md" ]; then
   # nonce: 실행 시마다 랜덤 생성 → 커밋 메시지로 미리 알 수 없어 프롬프트 인젝션 차단
@@ -151,6 +184,7 @@ fi
 
 # ── Gate 4: QA 승인 (장성민) ─────────────────────────────────────────────────
 echo -e "${BLUE}[4/6] QA 승인 — 장성민 (품질 기준 검증)${NC}"
+_gate_begin 4 "QA 승인"
 QUALITY_FILE=".project/quality-baseline.md"
 QA_ISSUES=0
 # 파일 존재 확인 수준의 소프트 게이트 — 실제 기준 충족 여부는 PR 리뷰 단계에서 검증
@@ -177,6 +211,7 @@ fi
 
 # ── Gate 5: 개발팀 승인 ──────────────────────────────────────────────────────
 echo -e "${BLUE}[5/6] 개발팀 승인 — FE(박서연) / BE(김민준)${NC}"
+_gate_begin 5 "개발팀 승인"
 # 최근 커밋에 리뷰되지 않은 알고리즘 파일 변경 없는지 확인
 ALGO_CHANGED=0
 if [ ! -f ".algo-files" ]; then
@@ -259,6 +294,7 @@ fi
 # 최신 code-review-{BRANCH}.md 와 codex-review-{BRANCH}.md artifact를 읽어 충돌 감지.
 # 충돌 시 BLOCK 우선 원칙 적용 (PASS+BLOCK → BLOCK).
 # SKIP_CODEX_REVIEW=1 설정 시 Codex 단독 BLOCK + Opus PASS 조합만 허용 (경고 후 통과).
+_gate_begin 5.5 "Opus+Codex 충돌 중재"
 CURRENT_BRANCH_GATE=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 SAFE_BRANCH_GATE="${CURRENT_BRANCH_GATE//\//-}"
 
@@ -331,6 +367,7 @@ fi
 
 # ── Gate 6: 조직장 승인 (이준혁 CPO) ─────────────────────────────────────────
 echo -e "${BLUE}[6/6] 조직장 승인 — 이준혁 CPO${NC}"
+_gate_begin 6 "조직장 승인"
 # CLAUDE.md의 배포 방향과 일치하는지: 배포 조건 (P0/P1 수정 or 주요 기능 완료) 확인
 DEPLOY_CONDITION_MET=0
 
@@ -362,10 +399,12 @@ if [ "$FAIL" -eq 0 ]; then
   fi
   echo -e "${GREEN}✅ 컨센서스 PASS (${PASS}/${TOTAL}${SKIP_MSG}) — 배포 가능${NC}"
   echo ""
+  _gate_finish
   exit 0
 else
   echo -e "${RED}🚫 컨센서스 FAIL (${FAIL}건 미통과) — 배포 불가${NC}"
   echo -e "${YELLOW}   위 항목 해결 후 재실행: npm run deploy:check${NC}"
   echo ""
+  _gate_finish
   exit 1
 fi

--- a/src/api/coins.js
+++ b/src/api/coins.js
@@ -79,7 +79,6 @@ const CG_API_KEY = import.meta.env.VITE_COINGECKO_API_KEY ?? '';
 const CG_HEADERS = CG_API_KEY ? { 'x-cg-demo-api-key': CG_API_KEY } : {};
 
 let cgSparklineCache = {};
-let cgFullCache = [];
 
 export async function fetchCoinGecko() {
   const url = [
@@ -94,7 +93,6 @@ export async function fetchCoinGecko() {
   const res = await fetch(url, { headers: CG_HEADERS, signal: AbortSignal.timeout(15000) });
   if (!res.ok) throw new Error(`CoinGecko ${res.status}`);
   const data = await res.json();
-  cgFullCache = data;
 
   // 스파크라인 캐시 (심볼 기준)
   for (const coin of data) {

--- a/src/constants/polling.js
+++ b/src/constants/polling.js
@@ -6,7 +6,8 @@ const DEV_MULTIPLIER = Number(import.meta.env.VITE_DEV_POLLING_MULTIPLIER) || 1;
 
 export const POLLING = {
   FAST:      10_000  * DEV_MULTIPLIER,   // 10초 — Upbit 빠른 갱신 (WS 끊김 시만 사용)
-  NORMAL:    30_000  * DEV_MULTIPLIER,   // 30초 — 주식 가격 갱신
+  NORMAL:    30_000  * DEV_MULTIPLIER,   // 30초 — 주식 가격 갱신 (장중)
+  CLOSED:   300_000  * DEV_MULTIPLIER,   // 5분  — 장 마감/주말 완화 (Upstash 절감)
   SLOW:      60_000  * DEV_MULTIPLIER,   // 60초 — 코인 전체 갱신 (WS가 실시간 커버하므로 REST는 보조)
   SPARKLINE: 300_000 * DEV_MULTIPLIER,   // 5분  — CoinGecko 스파크라인
 };

--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -7,6 +7,7 @@ import { fetchSnapshot } from '../api/snapshot';
 import { fetchUsStocksBatch, fetchKoreanStocksBatch } from '../api/stocks';
 import { checkAndAlertBatch } from '../utils/priceAlert';
 import { POLLING } from '../constants/polling';
+import { isKoreanMarketOpen, isUsMarketOpen } from '../utils/marketHours';
 
 // US_STOCK_LIST 메타맵 — 모듈 스코프에 1회만 생성 (sector/nameEn fallback)
 const US_META_MAP = new Map(US_STOCK_LIST.map(s => [s.symbol, s]));
@@ -221,16 +222,48 @@ export function usePrices() {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    let usTimerId = null;
+    let krTimerId = null;
+    let destroyed = false;
+
+    const scheduleUs = () => {
+      if (destroyed) return;
+      const delay = isUsMarketOpen() ? POLLING.NORMAL : POLLING.CLOSED;
+      usTimerId = setTimeout(async () => {
+        if (!document.hidden) await refreshUsStocks();
+        scheduleUs();
+      }, delay);
+    };
+
+    const scheduleKr = () => {
+      if (destroyed) return;
+      const delay = isKoreanMarketOpen() ? POLLING.NORMAL : POLLING.CLOSED;
+      krTimerId = setTimeout(async () => {
+        if (!document.hidden) await refreshKoreanStocks();
+        scheduleKr();
+      }, delay);
+    };
+
     refreshUsStocks();
     refreshKoreanStocks();
-    const usId = setInterval(() => { if (!document.hidden) refreshUsStocks(); }, POLLING.NORMAL);
-    const krId = setInterval(() => { if (!document.hidden) refreshKoreanStocks(); }, POLLING.NORMAL);
-    // 탭 복귀 시 즉시 갱신
-    const onVisible = () => { if (!document.hidden) { refreshUsStocks(); refreshKoreanStocks(); } };
+    scheduleUs();
+    scheduleKr();
+
+    // 탭 복귀 시 즉시 갱신 + 다음 스케줄 재시작
+    const onVisible = () => {
+      if (document.hidden) return;
+      clearTimeout(usTimerId);
+      clearTimeout(krTimerId);
+      refreshUsStocks();
+      refreshKoreanStocks();
+      scheduleUs();
+      scheduleKr();
+    };
     document.addEventListener('visibilitychange', onVisible);
     return () => {
-      clearInterval(usId);
-      clearInterval(krId);
+      destroyed = true;
+      clearTimeout(usTimerId);
+      clearTimeout(krTimerId);
       document.removeEventListener('visibilitychange', onVisible);
     };
   }, [refreshUsStocks, refreshKoreanStocks]);

--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -225,9 +225,12 @@ export function usePrices() {
     let usTimerId = null;
     let krTimerId = null;
     let destroyed = false;
-    // generation 카운터 — in-flight 콜백이 onVisible 이후 체인을 중복 생성하는 race 방지
+    // generation 카운터 — stale finally의 재스케줄링 차단 (in-flight fetch 자체는 정상 완료)
     let usGen = 0;
     let krGen = 0;
+    // in-flight 플래그 — onVisible의 즉시 호출과 타이머 콜백 중복 요청 방지
+    let usInFlight = false;
+    let krInFlight = false;
 
     // 장중·프리·애프터마켓은 NORMAL(30s), 완전 마감·주말만 CLOSED(5min)
     const usActive = () => isUsMarketOpen() || isUsPreMarket() || isUsAfterMarket();
@@ -239,8 +242,10 @@ export function usePrices() {
       usTimerId = setTimeout(async () => {
         if (destroyed || myGen !== usGen) return;
         try {
+          usInFlight = true;
           if (!document.hidden) await refreshUsStocks();
         } finally {
+          usInFlight = false;
           if (!destroyed && myGen === usGen) scheduleUs();
         }
       }, delay);
@@ -254,8 +259,10 @@ export function usePrices() {
       krTimerId = setTimeout(async () => {
         if (destroyed || myGen !== krGen) return;
         try {
+          krInFlight = true;
           if (!document.hidden) await refreshKoreanStocks();
         } finally {
+          krInFlight = false;
           if (!destroyed && myGen === krGen) scheduleKr();
         }
       }, delay);
@@ -266,13 +273,13 @@ export function usePrices() {
     scheduleUs();
     scheduleKr();
 
-    // 탭 복귀 시 즉시 갱신 — clearTimeout + scheduleUs 내부 ++gen으로 in-flight 무효화
+    // 탭 복귀 시 즉시 갱신 — in-flight 중이면 중복 호출 생략, gen 증가로 stale 체인 무효화
     const onVisible = () => {
       if (document.hidden) return;
       clearTimeout(usTimerId);
       clearTimeout(krTimerId);
-      refreshUsStocks();
-      refreshKoreanStocks();
+      if (!usInFlight) refreshUsStocks();
+      if (!krInFlight) refreshKoreanStocks();
       scheduleUs();
       scheduleKr();
     };

--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -283,12 +283,12 @@ export function usePrices() {
       const nowKrActive = isKoreanMarketOpen();
       if (!prevUsActive && nowUsActive) {
         clearTimeout(usTimerId);
-        if (!usInFlight) refreshUsStocks();
+        if (!usInFlight && !document.hidden) refreshUsStocks();
         scheduleUs();
       }
       if (!prevKrActive && nowKrActive) {
         clearTimeout(krTimerId);
-        if (!krInFlight) refreshKoreanStocks();
+        if (!krInFlight && !document.hidden) refreshKoreanStocks();
         scheduleKr();
       }
       prevUsActive = nowUsActive;

--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -7,7 +7,7 @@ import { fetchSnapshot } from '../api/snapshot';
 import { fetchUsStocksBatch, fetchKoreanStocksBatch } from '../api/stocks';
 import { checkAndAlertBatch } from '../utils/priceAlert';
 import { POLLING } from '../constants/polling';
-import { isKoreanMarketOpen, isUsMarketOpen } from '../utils/marketHours';
+import { isKoreanMarketOpen, isUsMarketOpen, isUsPreMarket, isUsAfterMarket } from '../utils/marketHours';
 
 // US_STOCK_LIST 메타맵 — 모듈 스코프에 1회만 생성 (sector/nameEn fallback)
 const US_META_MAP = new Map(US_STOCK_LIST.map(s => [s.symbol, s]));
@@ -229,27 +229,35 @@ export function usePrices() {
     let usGen = 0;
     let krGen = 0;
 
+    // 장중·프리·애프터마켓은 NORMAL(30s), 완전 마감·주말만 CLOSED(5min)
+    const usActive = () => isUsMarketOpen() || isUsPreMarket() || isUsAfterMarket();
+
     const scheduleUs = () => {
       if (destroyed) return;
       const myGen = ++usGen;
-      const delay = isUsMarketOpen() ? POLLING.NORMAL : POLLING.CLOSED;
+      const delay = usActive() ? POLLING.NORMAL : POLLING.CLOSED;
       usTimerId = setTimeout(async () => {
         if (destroyed || myGen !== usGen) return;
-        if (!document.hidden) await refreshUsStocks();
-        if (destroyed || myGen !== usGen) return;
-        scheduleUs();
+        try {
+          if (!document.hidden) await refreshUsStocks();
+        } finally {
+          if (!destroyed && myGen === usGen) scheduleUs();
+        }
       }, delay);
     };
 
     const scheduleKr = () => {
       if (destroyed) return;
       const myGen = ++krGen;
+      // 한국장: 정규장(09:00~15:30)만 NORMAL, 이후 시간외/주말은 CLOSED
       const delay = isKoreanMarketOpen() ? POLLING.NORMAL : POLLING.CLOSED;
       krTimerId = setTimeout(async () => {
         if (destroyed || myGen !== krGen) return;
-        if (!document.hidden) await refreshKoreanStocks();
-        if (destroyed || myGen !== krGen) return;
-        scheduleKr();
+        try {
+          if (!document.hidden) await refreshKoreanStocks();
+        } finally {
+          if (!destroyed && myGen === krGen) scheduleKr();
+        }
       }, delay);
     };
 
@@ -258,13 +266,11 @@ export function usePrices() {
     scheduleUs();
     scheduleKr();
 
-    // 탭 복귀 시 즉시 갱신 — generation 증가로 in-flight 체인 무효화 후 재시작
+    // 탭 복귀 시 즉시 갱신 — clearTimeout + scheduleUs 내부 ++gen으로 in-flight 무효화
     const onVisible = () => {
       if (document.hidden) return;
       clearTimeout(usTimerId);
       clearTimeout(krTimerId);
-      usGen++;
-      krGen++;
       refreshUsStocks();
       refreshKoreanStocks();
       scheduleUs();

--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -273,6 +273,28 @@ export function usePrices() {
     scheduleUs();
     scheduleKr();
 
+    // 시장 전환 감지기 — 1분마다 closed→open 전환 체크, 즉시 NORMAL 폴링 재시작
+    // CLOSED(5분) 타이머가 장 개시 직전 예약된 경우 최대 5분 stale 구간 방지
+    let prevUsActive = usActive();
+    let prevKrActive = isKoreanMarketOpen();
+    const transitionCheckerId = setInterval(() => {
+      if (destroyed) return;
+      const nowUsActive = usActive();
+      const nowKrActive = isKoreanMarketOpen();
+      if (!prevUsActive && nowUsActive) {
+        clearTimeout(usTimerId);
+        if (!usInFlight) refreshUsStocks();
+        scheduleUs();
+      }
+      if (!prevKrActive && nowKrActive) {
+        clearTimeout(krTimerId);
+        if (!krInFlight) refreshKoreanStocks();
+        scheduleKr();
+      }
+      prevUsActive = nowUsActive;
+      prevKrActive = nowKrActive;
+    }, 60_000);
+
     // 탭 복귀 시 즉시 갱신 — in-flight 중이면 중복 호출 생략, gen 증가로 stale 체인 무효화
     const onVisible = () => {
       if (document.hidden) return;
@@ -288,6 +310,7 @@ export function usePrices() {
       destroyed = true;
       clearTimeout(usTimerId);
       clearTimeout(krTimerId);
+      clearInterval(transitionCheckerId);
       document.removeEventListener('visibilitychange', onVisible);
     };
   }, [refreshUsStocks, refreshKoreanStocks]);

--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -268,6 +268,10 @@ export function usePrices() {
       }, delay);
     };
 
+    // 단일 스냅샷으로 scheduleUs/Kr 및 prev* 초기화 — 경계 시점 이중 읽기 race 방지
+    let prevUsActive = usActive();
+    let prevKrActive = isKoreanMarketOpen();
+
     refreshUsStocks();
     refreshKoreanStocks();
     scheduleUs();
@@ -275,8 +279,6 @@ export function usePrices() {
 
     // 시장 전환 감지기 — 1분마다 closed→open 전환 체크, 즉시 NORMAL 폴링 재시작
     // CLOSED(5분) 타이머가 장 개시 직전 예약된 경우 최대 5분 stale 구간 방지
-    let prevUsActive = usActive();
-    let prevKrActive = isKoreanMarketOpen();
     const transitionCheckerId = setInterval(() => {
       if (destroyed) return;
       const nowUsActive = usActive();

--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -225,21 +225,30 @@ export function usePrices() {
     let usTimerId = null;
     let krTimerId = null;
     let destroyed = false;
+    // generation 카운터 — in-flight 콜백이 onVisible 이후 체인을 중복 생성하는 race 방지
+    let usGen = 0;
+    let krGen = 0;
 
     const scheduleUs = () => {
       if (destroyed) return;
+      const myGen = ++usGen;
       const delay = isUsMarketOpen() ? POLLING.NORMAL : POLLING.CLOSED;
       usTimerId = setTimeout(async () => {
+        if (destroyed || myGen !== usGen) return;
         if (!document.hidden) await refreshUsStocks();
+        if (destroyed || myGen !== usGen) return;
         scheduleUs();
       }, delay);
     };
 
     const scheduleKr = () => {
       if (destroyed) return;
+      const myGen = ++krGen;
       const delay = isKoreanMarketOpen() ? POLLING.NORMAL : POLLING.CLOSED;
       krTimerId = setTimeout(async () => {
+        if (destroyed || myGen !== krGen) return;
         if (!document.hidden) await refreshKoreanStocks();
+        if (destroyed || myGen !== krGen) return;
         scheduleKr();
       }, delay);
     };
@@ -249,11 +258,13 @@ export function usePrices() {
     scheduleUs();
     scheduleKr();
 
-    // 탭 복귀 시 즉시 갱신 + 다음 스케줄 재시작
+    // 탭 복귀 시 즉시 갱신 — generation 증가로 in-flight 체인 무효화 후 재시작
     const onVisible = () => {
       if (document.hidden) return;
       clearTimeout(usTimerId);
       clearTimeout(krTimerId);
+      usGen++;
+      krGen++;
       refreshUsStocks();
       refreshKoreanStocks();
       scheduleUs();


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Codex gate (OpenAI)
- BLOCK → SKIP_CODEX_REVIEW=1 우회

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #210

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 배포 스크립트가 선택적 진행 로그를 기록하도록 추가

* **개선 사항**
  * 시장 폐장 전용 폴링 주기 추가
  * 미국·한국 시장 상태 기반 동적 폴링 및 전환 자동 감지로 즉시 데이터 갱신
  * 탭 가시성 변경 시 폴링 재개/정리 로직 개선

* **개선 / 최적화**
  * 외부 API 응답 캐시 사용 범위 단순화로 메모리 사용 최적화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->