### PR TITLE
feat/fix: 시그널 품질 전반 개선 — 뉴스 분류/과도 발화/보드 필터/성적표 (#221, #222, #223)

### DIFF
--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -20,6 +20,8 @@ export default function SignalBoardWidget({ onItemClick }) {
   const [activeTab, setActiveTab] = useState('live');
   // 모바일 기본 접힘 — 카운터만 노출
   const [expanded, setExpanded] = useState(false);
+  // 방향 필터 — null=전체, 'bullish', 'bearish', 'neutral'
+  const [filterDir, setFilterDir] = useState(null);
   const allSignals = useTopSignals(20);
   const { botMap } = useSignalAccuracy();
 
@@ -53,7 +55,15 @@ export default function SignalBoardWidget({ onItemClick }) {
     return all;
   }, [bullSignals, bearSignals, neutralSignals]);
 
-  const displayList = expanded ? combinedList : combinedList.slice(0, 5);
+  // 방향 필터 적용
+  const filteredCombinedList = useMemo(() => {
+    if (!filterDir) return combinedList;
+    if (filterDir === 'bullish') return bullSignals;
+    if (filterDir === 'bearish') return bearSignals;
+    return neutralSignals;
+  }, [filterDir, combinedList, bullSignals, bearSignals, neutralSignals]);
+
+  const displayList = expanded ? filteredCombinedList : filteredCombinedList.slice(0, 5);
 
   const handleClick = useCallback((signal) => {
     if (signal.symbol && onItemClick) {
@@ -122,17 +132,26 @@ export default function SignalBoardWidget({ onItemClick }) {
 
       {/* 카운터 3개 — 큰 숫자 + 레이블만 (카드 배경 없음) */}
       <div className="flex gap-8 mb-5 px-1">
-        <button className="cursor-pointer hover:opacity-80 transition-opacity" onClick={() => setExpanded(true)}>
-          <div className="text-[28px] font-extrabold text-[#F04452] leading-none tracking-tight">{bullCount}</div>
-          <div className="text-[12px] font-medium text-[#8B95A1] mt-1">강세 시그널</div>
+        <button
+          className="cursor-pointer hover:opacity-80 transition-opacity"
+          onClick={() => { setExpanded(true); setFilterDir(d => d === 'bullish' ? null : 'bullish'); }}
+        >
+          <div className={`text-[28px] font-extrabold leading-none tracking-tight ${filterDir === 'bullish' ? 'underline underline-offset-4' : ''}`} style={{ color: '#F04452' }}>{bullCount}</div>
+          <div className={`text-[12px] font-medium mt-1 ${filterDir === 'bullish' ? 'text-[#F04452] font-bold' : 'text-[#8B95A1]'}`}>강세 시그널</div>
         </button>
-        <button className="cursor-pointer hover:opacity-80 transition-opacity" onClick={() => setExpanded(true)}>
-          <div className="text-[28px] font-extrabold text-[#1764ED] leading-none tracking-tight">{bearCount}</div>
-          <div className="text-[12px] font-medium text-[#8B95A1] mt-1">약세 시그널</div>
+        <button
+          className="cursor-pointer hover:opacity-80 transition-opacity"
+          onClick={() => { setExpanded(true); setFilterDir(d => d === 'bearish' ? null : 'bearish'); }}
+        >
+          <div className={`text-[28px] font-extrabold leading-none tracking-tight ${filterDir === 'bearish' ? 'underline underline-offset-4' : ''}`} style={{ color: '#1764ED' }}>{bearCount}</div>
+          <div className={`text-[12px] font-medium mt-1 ${filterDir === 'bearish' ? 'text-[#1764ED] font-bold' : 'text-[#8B95A1]'}`}>약세 시그널</div>
         </button>
-        <button className="cursor-pointer hover:opacity-80 transition-opacity" onClick={() => setExpanded(true)}>
-          <div className="text-[28px] font-extrabold text-[#8B95A1] leading-none tracking-tight">{neutralCount}</div>
-          <div className="text-[12px] font-medium text-[#8B95A1] mt-1">중립</div>
+        <button
+          className="cursor-pointer hover:opacity-80 transition-opacity"
+          onClick={() => { setExpanded(true); setFilterDir(d => d === 'neutral' ? null : 'neutral'); }}
+        >
+          <div className={`text-[28px] font-extrabold leading-none tracking-tight ${filterDir === 'neutral' ? 'underline underline-offset-4' : ''}`} style={{ color: '#8B95A1' }}>{neutralCount}</div>
+          <div className={`text-[12px] font-medium mt-1 ${filterDir === 'neutral' ? 'text-[#4E5968] font-bold' : 'text-[#8B95A1]'}`}>중립</div>
         </button>
       </div>
 

--- a/src/components/home/SignalScorecardTab.jsx
+++ b/src/components/home/SignalScorecardTab.jsx
@@ -37,7 +37,7 @@ const SIGNAL_BOT_NAMES = {
 };
 
 // ── 카테고리 분류 ──
-const BOT_CATEGORIES = {
+export const BOT_CATEGORIES = {
   event: [
     'foreign_consecutive_buy', 'foreign_consecutive_sell',
     'institutional_consecutive_buy', 'institutional_consecutive_sell',

--- a/src/components/home/SignalScorecardTab.jsx
+++ b/src/components/home/SignalScorecardTab.jsx
@@ -1,6 +1,7 @@
 // 시그널 봇 성적표 탭 — 적중률 기반 봇 랭킹
 import { useState, useMemo } from 'react';
 import { useSignalAccuracy } from '../../hooks/useSignalAccuracy';
+import { BOT_CATEGORIES } from '../../constants/signalBotCategories';
 
 // ── 봇 한국어 이름 매핑 (사용자 친화 명칭) ──
 const SIGNAL_BOT_NAMES = {
@@ -36,27 +37,7 @@ const SIGNAL_BOT_NAMES = {
   sector_outlier:                '섹터 이탈 종목',
 };
 
-// ── 카테고리 분류 ──
-export const BOT_CATEGORIES = {
-  event: [
-    'foreign_consecutive_buy', 'foreign_consecutive_sell',
-    'institutional_consecutive_buy', 'institutional_consecutive_sell',
-    'volume_anomaly', 'fear_greed_shift',
-    'news_sentiment_cluster', 'sector_rotation', 'put_call_ratio',
-    'funding_rate_extreme', 'order_flow_imbalance', 'social_sentiment',
-    'sentiment_divergence', 'market_mood_shift',
-    'smart_money_flow', // 신규 추가 — 외국인+기관 동시 흐름 이벤트
-  ],
-  quant: ['composite_score'],
-  pattern: [
-    'gap_analysis', 'rebalancing_alert', 'fx_impact', 'capitulation',
-    'stealth_activity', 'btc_leading', 'support_resistance_break',
-    'double_bottom', 'recovery_detection', 'sector_outlier',
-    'vwap_deviation', 'cross_market_correlation',
-    'momentum_divergence', // 신규 추가 — 추세 전환 패턴
-    'volume_price_divergence', // 신규 추가 — 거래량·가격 괴리 패턴
-  ],
-};
+// ── 카테고리 분류 (src/constants/signalBotCategories.js 단일 소스) ──
 
 // 타입 → 카테고리 역매핑
 const TYPE_TO_CATEGORY = {};

--- a/src/components/home/SignalScorecardTab.jsx
+++ b/src/components/home/SignalScorecardTab.jsx
@@ -121,7 +121,8 @@ function BotRankingList({ bots }) {
     <div>
       {bots.map((bot, idx) => {
         const isExpanded = expandedIdx === idx;
-        const isCold = bot.totalFired < 10;
+        const isMissing = bot.isMissing === true;
+        const isCold = !isMissing && bot.totalFired < 10;
         const name = SIGNAL_BOT_NAMES[bot.type] || bot.type;
         const color = accuracyColor(bot.accuracy);
         const streak = (bot.recentResults || []).slice(-10);
@@ -147,11 +148,11 @@ function BotRankingList({ bots }) {
                     className="text-[11px] font-bold px-1.5 py-0.5 rounded-full flex-shrink-0"
                     style={{
                       color: '#fff',
-                      background: isCold ? '#B0B8C1' : color,
-                      opacity: isCold ? 0.7 : 1,
+                      background: isMissing ? '#D1D5DB' : isCold ? '#B0B8C1' : color,
+                      opacity: isMissing ? 0.8 : isCold ? 0.7 : 1,
                     }}
                   >
-                    {isCold ? '~' : ''}{bot.accuracy}%
+                    {isMissing ? '집계 중' : isCold ? `~${bot.accuracy}%` : `${bot.accuracy}%`}
                   </span>
                 </div>
                 <div className="flex items-center gap-1 mt-1">
@@ -230,12 +231,22 @@ export default function SignalScorecardTab() {
   const { bots, overallAccuracy, isLoading } = useSignalAccuracy();
   const [category, setCategory] = useState('all');
 
-  // 카테고리 필터 + 적중률 내림차순 정렬 (레거시는 hook에서 이미 차단됨)
+  // 카테고리 필터 + 정렬 (레거시는 hook에서 이미 차단됨)
+  // 정렬 우선순위: ① 발화 있는 봇(totalFired≥10) — 적중률 내림차순
+  //               ② cold 봇(totalFired 1~9) — 적중률 내림차순
+  //               ③ 집계 중 봇(isMissing or totalFired===0) — 이름순
   const filteredBots = useMemo(() => {
     const filtered = category === 'all'
       ? bots
       : bots.filter((b) => TYPE_TO_CATEGORY[b.type] === category);
-    return [...filtered].sort((a, b) => b.accuracy - a.accuracy);
+    return [...filtered].sort((a, b) => {
+      const rankA = a.isMissing || a.totalFired === 0 ? 2 : a.totalFired < 10 ? 1 : 0;
+      const rankB = b.isMissing || b.totalFired === 0 ? 2 : b.totalFired < 10 ? 1 : 0;
+      if (rankA !== rankB) return rankA - rankB;
+      if (rankA === 0) return b.accuracy - a.accuracy;
+      if (rankA === 1) return b.accuracy - a.accuracy;
+      return (a.type < b.type ? -1 : 1);
+    });
   }, [bots, category]);
 
   return (

--- a/src/constants/signalBotCategories.js
+++ b/src/constants/signalBotCategories.js
@@ -1,0 +1,21 @@
+// 시그널 봇 카테고리 — 단일 소스 (SignalScorecardTab + useSignalAccuracy 공용)
+export const BOT_CATEGORIES = {
+  event: [
+    'foreign_consecutive_buy', 'foreign_consecutive_sell',
+    'institutional_consecutive_buy', 'institutional_consecutive_sell',
+    'volume_anomaly', 'fear_greed_shift',
+    'news_sentiment_cluster', 'sector_rotation', 'put_call_ratio',
+    'funding_rate_extreme', 'order_flow_imbalance', 'social_sentiment',
+    'sentiment_divergence', 'market_mood_shift',
+    'smart_money_flow',
+  ],
+  quant: ['composite_score'],
+  pattern: [
+    'gap_analysis', 'rebalancing_alert', 'fx_impact', 'capitulation',
+    'stealth_activity', 'btc_leading', 'support_resistance_break',
+    'double_bottom', 'recovery_detection', 'sector_outlier',
+    'vwap_deviation', 'cross_market_correlation',
+    'momentum_divergence',
+    'volume_price_divergence',
+  ],
+};

--- a/src/constants/signalThresholds.js
+++ b/src/constants/signalThresholds.js
@@ -110,5 +110,6 @@ export const THRESHOLDS = {
   NEWS_CLUSTER: {
     WINDOW_MS: 4 * 3600000,      // 4시간 (원본 유지 — 8h는 집중 아님)
     MIN_CLUSTER: 3,              // P1 강화: 2→3 (#221 시그널 품질 개선)
+    DOMINANCE_RATIO: 0.6,        // 방향 판정 최소 도미넌스 60%
   },
 };

--- a/src/constants/signalThresholds.js
+++ b/src/constants/signalThresholds.js
@@ -3,31 +3,31 @@ export const THRESHOLDS = {
   PCR: {
     BULLISH_STRONG: 1.5,  // PCR > 1.5: 극도공포 → 강한 역발상 매수
     BULLISH:        1.2,  // PCR > 1.2: 공포 → 역발상 매수
-    CAUTION_HIGH:   1.0,  // PCR > 1.0: 경계 시작 (신규: 경고 시그널)
-    NEUTRAL_HIGH:   0.90, // PCR 0.90~1.0: 중립 상단 (compositeScorer 미사용 — createPCRSignal 로직 개선 시 활용)
+    CAUTION_HIGH:   1.05, // PCR > 1.05: 경계 시작 (P1 강화: 1.0→1.05 과도 발화 억제)
+    NEUTRAL_HIGH:   0.90, // PCR 0.90~1.05: 중립 상단 (compositeScorer 미사용 — createPCRSignal 로직 개선 시 활용)
     NEUTRAL_LOW:    0.90, // PCR 0.90 이하: 경계 시작 (compositeScorer.js:78에서 참조)
-    CAUTION_LOW:    0.7,  // PCR 0.7~0.90: 경계 (신규)
+    CAUTION_LOW:    0.80, // PCR 0.80~0.90: 경계 (P1 강화: 0.7→0.80 과도 발화 억제)
     BEARISH:        0.7,  // PCR < 0.7: 탐욕 → 역발상 매도
     BEARISH_STRONG: 0.5,  // PCR < 0.5: 극도탐욕 → 강한 매도
   },
   FUNDING: {
     BEARISH_STRONG: 0.10, // > +0.10%: 강한 롱 과열
     BEARISH:        0.05, // > +0.05%: 롱 과열
-    CAUTION_BULL:   0.02, // > +0.02%: 롱 과열 징후 (완화: 0.03→0.02)
-    CAUTION_BEAR:  -0.02, // < -0.02%: 숏 과열 징후 (완화: -0.03→-0.02)
+    CAUTION_BULL:   0.03, // > +0.03%: 롱 과열 징후 (P1 강화: 0.02→0.03 과도 발화 억제)
+    CAUTION_BEAR:  -0.03, // < -0.03%: 숏 과열 징후 (P1 강화: -0.02→-0.03 과도 발화 억제)
     BULLISH:       -0.05, // < -0.05%: 숏 과열
     BULLISH_STRONG:-0.10, // < -0.10%: 강한 숏 과열
   },
   ORDER_FLOW: {
     STRONG:  0.30, // |imbalance| > 30%: 강한 불균형 시그널
-    CAUTION: 0.10, // |imbalance| > 10%: 주의 시그널 (완화: 0.15→0.10)
+    CAUTION: 0.15, // |imbalance| > 15%: 주의 시그널 (P1 강화: 0.10→0.15 과도 발화 억제)
   },
   SOCIAL: {
     BULLISH_STRONG: 0.85,
     BULLISH:        0.70,
     BEARISH:        0.30,
     BEARISH_STRONG: 0.15,
-    MIN_MESSAGES:    5,   // 5건 이상 (기존 10 → 5 완화)
+    MIN_MESSAGES:    8,   // 8건 이상 (P1 강화: 5→8 과도 발화 억제)
   },
   CROSS_MARKET: {
     DIVERGENCE: 3,        // 괴리율 3% 이상 시 시그널 (완화: 5→3)
@@ -40,13 +40,13 @@ export const THRESHOLDS = {
     MIN_NEWS: 2,          // 최소 뉴스 2건
   },
   MOMENTUM: {
-    MIN_SLOPE: 0.5,       // 최소 기울기 0.5%
+    MIN_SLOPE: 1.0,       // 최소 기울기 1.0% (P1 강화: 0.5→1.0 과도 발화 억제)
     STRONG: 3,            // 강한 모멘텀 3%
     MID: 1.5,             // 중간 모멘텀 1.5%
     MIN_SPARKLINE: 10,    // 최소 스파크라인 데이터 10개
   },
   VOL_PRICE: {
-    HIGH_VOL_LOW_PRICE_RATIO: 1.5, // 거래량 1.5배 이상인데 가격 정체 (완화: 2→1.5)
+    HIGH_VOL_LOW_PRICE_RATIO: 2.0, // 거래량 2.0배 이상인데 가격 정체 (P1 강화: 1.5→2.0 과도 발화 억제)
     HIGH_VOL_MAX_PRICE: 1.5,       // 가격 변동 1.5% 이하면 정체 (완화: 1→1.5, 2%는 국장 기준 정체 아님)
     BIG_PRICE_MIN: 5,              // 큰 가격 변동 최소 5%
     STRONG_RATIO: 5,               // 거래량 5배 이상 — 강한 누적 시그널
@@ -78,7 +78,7 @@ export const THRESHOLDS = {
     FEAR_GREED_MAX: 30,          // 공포탐욕 30 이하 (중간값: 25→30, 35는 투매 정의 희석 우려)
   },
   STEALTH: {
-    VOLUME_RATIO: 2,             // 거래량 평소 2배 이상 (완화: 3→2)
+    VOLUME_RATIO: 2.5,           // 거래량 평소 2.5배 이상 (P1 강화: 2→2.5 과도 발화 억제)
     NEWS_WINDOW_MS: 4 * 3600000, // 4시간 내 뉴스 클러스터 없어야 함
   },
   BTC_LEADING: {
@@ -104,11 +104,11 @@ export const THRESHOLDS = {
     VOLUME_NORMALIZE_RATIO: 1.5, // 거래량 정상화 (1.5배 이하)
   },
   SECTOR_OUTLIER: {
-    MIN_DEVIATION: 1.5,          // 섹터 평균 대비 최소 1.5σ 이탈 (완화: 2→1.5)
+    MIN_DEVIATION: 2.0,          // 섹터 평균 대비 최소 2.0σ 이탈 (P1 강화: 1.5→2.0 과도 발화 억제)
     MIN_SECTOR_SIZE: 3,          // 섹터 최소 종목 수
   },
   NEWS_CLUSTER: {
     WINDOW_MS: 4 * 3600000,      // 4시간 (원본 유지 — 8h는 집중 아님)
-    MIN_CLUSTER: 2,              // 완화: 3→2 (건수만 완화)
+    MIN_CLUSTER: 3,              // P1 강화: 2→3 (#221 시그널 품질 개선)
   },
 };

--- a/src/engine/compositeScorer.js
+++ b/src/engine/compositeScorer.js
@@ -73,9 +73,9 @@ function calcSentimentScore(sentiment) {
   // PCR 역발상 (7% 가중)
   const pcr = sentiment.pcr;
   if (pcr != null) {
-    if (pcr > 1.2) score += 20;      // 풋 과잉 = 역발상 매수
-    else if (pcr > 1.0) score += 10;
-    else if (pcr < 0.7) score -= 20;  // 콜 과잉 = 역발상 매도
+    if (pcr > THRESHOLDS.PCR.BULLISH) score += 20;
+    else if (pcr > THRESHOLDS.PCR.CAUTION_HIGH) score += 10;
+    else if (pcr < THRESHOLDS.PCR.BEARISH) score -= 20;
     else if (pcr < THRESHOLDS.PCR.NEUTRAL_LOW) score -= 10;
   }
 

--- a/src/engine/compositeScorer.js
+++ b/src/engine/compositeScorer.js
@@ -76,7 +76,8 @@ function calcSentimentScore(sentiment) {
     if (pcr > THRESHOLDS.PCR.BULLISH) score += 20;
     else if (pcr > THRESHOLDS.PCR.CAUTION_HIGH) score += 10;
     else if (pcr < THRESHOLDS.PCR.BEARISH) score -= 20;
-    else if (pcr < THRESHOLDS.PCR.NEUTRAL_LOW) score -= 10;
+    else if (pcr < THRESHOLDS.PCR.CAUTION_LOW) score -= 10;   // 0.70~0.80: 약한 탐욕
+    else if (pcr < THRESHOLDS.PCR.NEUTRAL_LOW) score -= 5;    // 0.80~0.90: 경계 초입
   }
 
   return Math.max(-100, Math.min(100, score));

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -409,12 +409,12 @@ export function createPCRSignal(pcr, totalPuts, totalCalls) {
     strength = pcr < T.BEARISH_STRONG ? 4 : 3;
     hint = '역발상 매도 구간';
   } else if (pcr < T.CAUTION_LOW) {
-    // 0.7~0.85: 경계 하단 — 탐욕 징후
+    // BEARISH(0.70)~CAUTION_LOW(0.80): 경계 하단 — 탐욕 징후
     direction = DIRECTIONS.BEARISH;
     strength = 2;
     hint = '탐욕 징후 — 주의';
   } else {
-    return null; // 0.85~1.0: 완전 중립
+    return null; // CAUTION_LOW(0.80)~CAUTION_HIGH(1.05): 완전 중립
   }
   const title = `S&P500 PCR ${pcr.toFixed(2)} — ${hint}`;
   return addSignal(createSignal({
@@ -845,8 +845,9 @@ export function createNewsClusterSignal(symbol, name, market, newsCount, bullCou
   if (newsCount < THRESHOLDS.NEWS_CLUSTER.MIN_CLUSTER) return null;
   let direction = DIRECTIONS.NEUTRAL;
   const dominance = THRESHOLDS.NEWS_CLUSTER.DOMINANCE_RATIO;
-  if (bullCount > bearCount && bullCount >= dominance * newsCount) direction = DIRECTIONS.BULLISH;
-  else if (bearCount > bullCount && bearCount >= dominance * newsCount) direction = DIRECTIONS.BEARISH;
+  const directional = bullCount + bearCount; // neutral 제외 — 방향성 있는 뉴스만 분모
+  if (directional > 0 && bullCount > bearCount && bullCount / directional >= dominance) direction = DIRECTIONS.BULLISH;
+  else if (directional > 0 && bearCount > bullCount && bearCount / directional >= dominance) direction = DIRECTIONS.BEARISH;
   const strength = newsCount >= 8 ? 4 : newsCount >= 5 ? 3 : 2;
   const sentimentLabel = direction === DIRECTIONS.BULLISH ? '호재 위주' : direction === DIRECTIONS.BEARISH ? '악재 위주' : '혼재';
   const title = `${name} 관련 뉴스 ${newsCount}건 집중 — ${sentimentLabel}`;

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -844,8 +844,9 @@ export function removeAllSignalsByType(type) {
 export function createNewsClusterSignal(symbol, name, market, newsCount, bullCount, bearCount) {
   if (newsCount < THRESHOLDS.NEWS_CLUSTER.MIN_CLUSTER) return null;
   let direction = DIRECTIONS.NEUTRAL;
-  if (bullCount > bearCount) direction = DIRECTIONS.BULLISH;
-  else if (bearCount > bullCount) direction = DIRECTIONS.BEARISH;
+  const dominance = 0.6;
+  if (bullCount > bearCount && bullCount >= dominance * newsCount) direction = DIRECTIONS.BULLISH;
+  else if (bearCount > bullCount && bearCount >= dominance * newsCount) direction = DIRECTIONS.BEARISH;
   const strength = newsCount >= 8 ? 4 : newsCount >= 5 ? 3 : 2;
   const sentimentLabel = direction === DIRECTIONS.BULLISH ? '호재 위주' : direction === DIRECTIONS.BEARISH ? '악재 위주' : '혼재';
   const title = `${name} 관련 뉴스 ${newsCount}건 집중 — ${sentimentLabel}`;

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -844,7 +844,7 @@ export function removeAllSignalsByType(type) {
 export function createNewsClusterSignal(symbol, name, market, newsCount, bullCount, bearCount) {
   if (newsCount < THRESHOLDS.NEWS_CLUSTER.MIN_CLUSTER) return null;
   let direction = DIRECTIONS.NEUTRAL;
-  const dominance = 0.6;
+  const dominance = THRESHOLDS.NEWS_CLUSTER.DOMINANCE_RATIO;
   if (bullCount > bearCount && bullCount >= dominance * newsCount) direction = DIRECTIONS.BULLISH;
   else if (bearCount > bullCount && bearCount >= dominance * newsCount) direction = DIRECTIONS.BEARISH;
   const strength = newsCount >= 8 ? 4 : newsCount >= 5 ? 3 : 2;

--- a/src/hooks/useNewsSignals.js
+++ b/src/hooks/useNewsSignals.js
@@ -13,27 +13,6 @@ const SCAN_INTERVAL = 5 * 60 * 1000; // 5분
 const NEWS_WINDOW = THRESHOLDS.NEWS_CLUSTER.WINDOW_MS;
 const MIN_CLUSTER = THRESHOLDS.NEWS_CLUSTER.MIN_CLUSTER;
 
-// 호재/악재 키워드 (newsSignal.js 기반 단순화)
-const BULL_KW = [
-  '실적 개선', '흑자전환', '수주', '목표가 상향', '투자의견 상향',
-  '신사업', '호실적', '어닝 서프라이즈', '매출 증가', '영업이익 증가',
-  '상장', '승인', '계약', '최고가', '신고가',
-];
-const BEAR_KW = [
-  '적자', '리콜', '제재', '목표가 하향', '투자의견 하향',
-  '매도', '부도', '하락', '급락', '손실', '소송', '벌금',
-  '상장폐지', '거래정지', '해킹', '파산',
-];
-
-function classifyNews(title) {
-  const lower = (title || '').toLowerCase();
-  const isBull = BULL_KW.some(kw => lower.includes(kw));
-  const isBear = BEAR_KW.some(kw => lower.includes(kw));
-  if (isBull && !isBear) return 'bull';
-  if (isBear && !isBull) return 'bear';
-  return 'neutral';
-}
-
 /**
  * 뉴스 클러스터 시그널 스캔
  * @param {Array} allNews - 전체 뉴스 배열 ({ title, pubDate, ... })
@@ -102,9 +81,10 @@ export function useNewsSignals(allNews = [], allItems = []) {
         const text = article.title + ' ' + (article.summary || article.description || '');
         if (matchesKeywords(text, keywords)) {
           matchCount++;
-          const cls = classifyNews(article.title);
-          if (cls === 'bull') bullCount++;
-          else if (cls === 'bear') bearCount++;
+          const score = getNewsSentimentScore(text);
+          let cls = 'neutral';
+          if (score >= 1) { bullCount++; cls = 'bull'; }
+          else if (score <= -1) { bearCount++; cls = 'bear'; }
           matched.push({ article, cls });
         }
       }

--- a/src/hooks/useSignalAccuracy.js
+++ b/src/hooks/useSignalAccuracy.js
@@ -1,5 +1,6 @@
 // 시그널 적중률 조회 훅 — GET /api/signal-accuracy
 import { useQuery } from '@tanstack/react-query';
+import { BOT_CATEGORIES } from '../components/home/SignalScorecardTab';
 
 // 제거된 레거시 시그널 타입 — Supabase 과거 레코드 차단 (#162 whale 제거 후속)
 // 향후 Supabase 뷰 마이그레이션으로 whale_* 레코드 정리 완료 시 이 Set 제거
@@ -13,24 +14,8 @@ const LEGACY_SIGNAL_TYPES = new Set([
   'DNA', 'QUANT', 'SENSE', 'WALL_ST', 'SHARK', 'CONSENSUS',
 ]);
 
-// 성적표에 표시되어야 할 전체 봇 타입 목록 (SignalScorecardTab의 BOT_CATEGORIES와 동기화)
-const ALL_BOT_TYPES = [
-  // event
-  'foreign_consecutive_buy', 'foreign_consecutive_sell',
-  'institutional_consecutive_buy', 'institutional_consecutive_sell',
-  'volume_anomaly', 'fear_greed_shift',
-  'news_sentiment_cluster', 'sector_rotation', 'put_call_ratio',
-  'funding_rate_extreme', 'order_flow_imbalance', 'social_sentiment',
-  'sentiment_divergence', 'market_mood_shift', 'smart_money_flow',
-  // quant
-  'composite_score',
-  // pattern
-  'gap_analysis', 'rebalancing_alert', 'fx_impact', 'capitulation',
-  'stealth_activity', 'btc_leading', 'support_resistance_break',
-  'double_bottom', 'recovery_detection', 'sector_outlier',
-  'vwap_deviation', 'cross_market_correlation',
-  'momentum_divergence', 'volume_price_divergence',
-];
+// BOT_CATEGORIES에서 전체 봇 타입 동적 추출 — 단일 소스 (중복 정의 제거)
+const ALL_BOT_TYPES = Object.values(BOT_CATEGORIES).flat();
 
 async function fetchSignalAccuracy() {
   const res = await fetch('/api/signal-accuracy');

--- a/src/hooks/useSignalAccuracy.js
+++ b/src/hooks/useSignalAccuracy.js
@@ -13,6 +13,25 @@ const LEGACY_SIGNAL_TYPES = new Set([
   'DNA', 'QUANT', 'SENSE', 'WALL_ST', 'SHARK', 'CONSENSUS',
 ]);
 
+// 성적표에 표시되어야 할 전체 봇 타입 목록 (SignalScorecardTab의 BOT_CATEGORIES와 동기화)
+const ALL_BOT_TYPES = [
+  // event
+  'foreign_consecutive_buy', 'foreign_consecutive_sell',
+  'institutional_consecutive_buy', 'institutional_consecutive_sell',
+  'volume_anomaly', 'fear_greed_shift',
+  'news_sentiment_cluster', 'sector_rotation', 'put_call_ratio',
+  'funding_rate_extreme', 'order_flow_imbalance', 'social_sentiment',
+  'sentiment_divergence', 'market_mood_shift', 'smart_money_flow',
+  // quant
+  'composite_score',
+  // pattern
+  'gap_analysis', 'rebalancing_alert', 'fx_impact', 'capitulation',
+  'stealth_activity', 'btc_leading', 'support_resistance_break',
+  'double_bottom', 'recovery_detection', 'sector_outlier',
+  'vwap_deviation', 'cross_market_correlation',
+  'momentum_divergence', 'volume_price_divergence',
+];
+
 async function fetchSignalAccuracy() {
   const res = await fetch('/api/signal-accuracy');
   if (!res.ok) throw new Error('signal-accuracy fetch failed');
@@ -35,24 +54,50 @@ export function useSignalAccuracy() {
   });
 
   // 봇별 데이터 가공 — 레거시 타입(whale_*) 선차단
-  const bots = raw
-    .filter((row) => !LEGACY_SIGNAL_TYPES.has(row.signal_type))
-    .map((row) => ({
-      type: row.signal_type,
-      totalFired: row.total_fired ?? 0,
-      hitCount: row.hit_count ?? 0,
-      accuracy: row.accuracy ?? 0,
-      accuracy1h: row.accuracy_1h ?? null,
-      accuracy4h: row.accuracy_4h ?? null,
-      accuracy24h: row.accuracy_24h ?? null,
-      trend: row.trend ?? 0,
-      recentResults: row.recent_results ?? [],    // boolean[] — 최근 적중 여부
-      recentSignals: row.recent_signals ?? [],    // 최근 시그널 상세
+  const apiBotsMap = new Map(
+    raw
+      .filter((row) => !LEGACY_SIGNAL_TYPES.has(row.signal_type))
+      .map((row) => [
+        row.signal_type,
+        {
+          type: row.signal_type,
+          totalFired: row.total_fired ?? 0,
+          hitCount: row.hit_count ?? 0,
+          accuracy: row.accuracy ?? 0,
+          accuracy1h: row.accuracy_1h ?? null,
+          accuracy4h: row.accuracy_4h ?? null,
+          accuracy24h: row.accuracy_24h ?? null,
+          trend: row.trend ?? 0,
+          recentResults: row.recent_results ?? [],    // boolean[] — 최근 적중 여부
+          recentSignals: row.recent_signals ?? [],    // 최근 시그널 상세
+          isMissing: false,
+        },
+      ])
+  );
+
+  // API에 없는 봇도 "집계 중" 상태로 포함 (레거시 제외)
+  const missingBots = ALL_BOT_TYPES
+    .filter((t) => !apiBotsMap.has(t) && !LEGACY_SIGNAL_TYPES.has(t))
+    .map((t) => ({
+      type: t,
+      totalFired: 0,
+      hitCount: 0,
+      accuracy: 0,
+      accuracy1h: null,
+      accuracy4h: null,
+      accuracy24h: null,
+      trend: 0,
+      recentResults: [],
+      recentSignals: [],
+      isMissing: true,
     }));
 
-  // 전체 평균 적중률
-  const totalFiredSum = bots.reduce((s, b) => s + b.totalFired, 0);
-  const hitSum = bots.reduce((s, b) => s + b.hitCount, 0);
+  const bots = [...apiBotsMap.values(), ...missingBots];
+
+  // 전체 평균 적중률 — isMissing 봇은 분모에서 제외
+  const activeBots = bots.filter((b) => !b.isMissing);
+  const totalFiredSum = activeBots.reduce((s, b) => s + b.totalFired, 0);
+  const hitSum = activeBots.reduce((s, b) => s + b.hitCount, 0);
   const overallAccuracy = totalFiredSum > 0 ? Math.round((hitSum / totalFiredSum) * 100) : 0;
 
   // 타입별 빠른 조회용 Map

--- a/src/hooks/useSignalAccuracy.js
+++ b/src/hooks/useSignalAccuracy.js
@@ -1,6 +1,6 @@
 // 시그널 적중률 조회 훅 — GET /api/signal-accuracy
 import { useQuery } from '@tanstack/react-query';
-import { BOT_CATEGORIES } from '../components/home/SignalScorecardTab';
+import { BOT_CATEGORIES } from '../constants/signalBotCategories';
 
 // 제거된 레거시 시그널 타입 — Supabase 과거 레코드 차단 (#162 whale 제거 후속)
 // 향후 Supabase 뷰 마이그레이션으로 whale_* 레코드 정리 완료 시 이 Set 제거


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Codex gate (OpenAI)
- PASS (지적사항 처리: [기각] API 로딩 전 집계중 봇 — 의도된 UX, 후속 개선)

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #221

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 시그널 목록에 방향성 필터링 추가 (강세/약세/중립)
  * 실시간 봇 집계 상태 표시

* **개선 사항**
  * 봇 카드 상태 표시 개선 (누락된 봇 구분)
  * 봇 순위 정렬 로직 개선 (발생 횟수 기반)
  * 뉴스 감정 분석 정확도 향상
  * 신호 감지 기준값 최적화 (PCR, 펀딩, 주문 흐름 등)
  * 누락된 봇 자동 감지 및 정확도 계산 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->