### PR TITLE
fix: 뉴스 클러스터 방향성 계산 — 중립 기사 분모 포함 (#234)

### DIFF
--- a/src/constants/signalThresholds.js
+++ b/src/constants/signalThresholds.js
@@ -110,6 +110,6 @@ export const THRESHOLDS = {
   NEWS_CLUSTER: {
     WINDOW_MS: 4 * 3600000,      // 4시간 (원본 유지 — 8h는 집중 아님)
     MIN_CLUSTER: 3,              // P1 강화: 2→3 (#221 시그널 품질 개선)
-    DOMINANCE_RATIO: 0.6,        // 방향 판정 최소 도미넌스 60%
+    DOMINANCE_RATIO: 0.5,        // 방향 판정 최소 도미넌스 50% (분모: newsCount, neutral 포함 — #234)
   },
 };

--- a/src/constants/signalThresholds.js
+++ b/src/constants/signalThresholds.js
@@ -110,6 +110,6 @@ export const THRESHOLDS = {
   NEWS_CLUSTER: {
     WINDOW_MS: 4 * 3600000,      // 4시간 (원본 유지 — 8h는 집중 아님)
     MIN_CLUSTER: 3,              // P1 강화: 2→3 (#221 시그널 품질 개선)
-    DOMINANCE_RATIO: 0.5,        // 방향 판정 최소 도미넌스 50% (분모: newsCount, neutral 포함 — #234)
+    DOMINANCE_RATIO: 0.55,       // 방향 판정 최소 도미넌스 55% (분모: newsCount, neutral 포함 — #234)
   },
 };

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -870,9 +870,10 @@ export function createNewsClusterSignal(symbol, name, market, newsCount, bullCou
   if (newsCount < THRESHOLDS.NEWS_CLUSTER.MIN_CLUSTER) return null;
   let direction = DIRECTIONS.NEUTRAL;
   const dominance = THRESHOLDS.NEWS_CLUSTER.DOMINANCE_RATIO;
-  const directional = bullCount + bearCount; // neutral 제외 — 방향성 있는 뉴스만 분모
-  if (directional > 0 && bullCount > bearCount && bullCount / directional >= dominance) direction = DIRECTIONS.BULLISH;
-  else if (directional > 0 && bearCount > bullCount && bearCount / directional >= dominance) direction = DIRECTIONS.BEARISH;
+  const directional = bullCount + bearCount;
+  // 분모: newsCount (전체 기준) — directional만 분모로 쓰면 중립 기사 다수 시 소수 bull/bear가 방향성 과장 (#234)
+  if (directional > 0 && bullCount > bearCount && bullCount / newsCount >= dominance) direction = DIRECTIONS.BULLISH;
+  else if (directional > 0 && bearCount > bullCount && bearCount / newsCount >= dominance) direction = DIRECTIONS.BEARISH;
   const strength = newsCount >= 8 ? 4 : newsCount >= 5 ? 3 : 2;
   const sentimentLabel = direction === DIRECTIONS.BULLISH ? '호재 위주' : direction === DIRECTIONS.BEARISH ? '악재 위주' : '혼재';
   const title = `${name} 관련 뉴스 ${newsCount}건 집중 — ${sentimentLabel}`;


### PR DESCRIPTION
## Summary

- `signalEngine.js` `createNewsClusterSignal` 분모를 `directional(bull+bear)` → `newsCount(전체)`로 교체
- `signalThresholds.js` DOMINANCE_RATIO: 0.6 → 0.55 (분모 교체 후 너무 엄격해지는 것 방지)

**버그 시나리오:** newsCount=14, bull=3, bear=1, neutral=10 → directional 분모 시 75%로 BULLISH 오판정 (실제 21%)

## Review artifacts

- ✅ code-reviewer (Opus): PASS
- ✅ architect (Opus): PASS — newsCount 분모 + 0.55 절충안 승인
- ✅ Codex gate: PASS — 내부 일관성 확인, 블로킹 없음

## Codex P2 처리

Codex: "0.5 너무 느슨" → 0.55로 조정 수용 (Architect 0.5 권고 vs Codex 우려 절충)

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정 및 개선**
  * 뉴스 클러스터 방향성 분석 알고리즘을 개선하여 중립 항목이 신호 강도에 미치는 영향을 최소화했습니다.
  * 방향성 지배력 임계값을 0.60에서 0.55로 조정하여 신호 감지 정확도를 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->