### PR TITLE
feat: 데이터 소스 헬스 모니터 cron — 일별 자동 감시 + Issue 생성 (P2-23, #238)

### DIFF
--- a/api/cron/health-check.js
+++ b/api/cron/health-check.js
@@ -1,0 +1,109 @@
+// 데이터 소스 헬스 모니터 cron
+// 매일 UTC 00:00 (KST 09:00) 실행 — Yahoo/Stooq/Alpaca/네이버/RSS 연결 상태 점검
+import { timingSafeEqual } from 'crypto';
+
+export const config = { runtime: 'nodejs', maxDuration: 60 };
+
+// ─── 인증 ────────────────────────────────────────────────
+function authorize(req) {
+  if (req.headers['x-vercel-cron']) return true;
+  const authHeader = req.headers['authorization'] || '';
+  if (!process.env.CRON_SECRET) return false;
+  const expected = Buffer.from(`Bearer ${process.env.CRON_SECRET}`);
+  const incoming = Buffer.from(authHeader);
+  return incoming.length === expected.length && timingSafeEqual(incoming, expected);
+}
+
+// ─── 단일 소스 헬스 체크 ────────────────────────────────
+async function checkSource(name, url, options = {}) {
+  const { timeoutMs = 10000, allow401 = false } = options;
+  const start = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: controller.signal, redirect: 'follow' });
+    const latencyMs = Date.now() - start;
+    if (res.ok || (allow401 && res.status === 401)) {
+      return { status: latencyMs < 5000 ? 'ok' : 'slow', latencyMs };
+    }
+    return { status: 'fail', error: `HTTP ${res.status}`, latencyMs };
+  } catch (err) {
+    const latencyMs = Date.now() - start;
+    const error = err.name === 'AbortError' ? 'timeout' : (err.message || 'unknown');
+    return { status: 'fail', error, latencyMs };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ─── 전체 헬스 체크 실행 ────────────────────────────────
+async function runHealthChecks() {
+  const sources = [
+    // 미장 체인 (10초 타임아웃)
+    { key: 'yahoo_v8',  url: 'https://query1.finance.yahoo.com/v8/finance/chart/AAPL?interval=1d&range=1d', opts: { timeoutMs: 10000 } },
+    { key: 'stooq',     url: 'https://stooq.com/q/d/l/?s=aapl.us&i=d',                                     opts: { timeoutMs: 10000 } },
+    { key: 'alpaca',    url: 'https://data.alpaca.markets/v2/stocks/AAPL/bars?timeframe=1Day&limit=1',      opts: { timeoutMs: 10000, allow401: true } },
+    // 국내 소스
+    { key: 'naver_world', url: 'https://finance.naver.com/world/sise.naver?symbol=NASDAQ%3AAAPL',           opts: { timeoutMs: 10000 } },
+    // RSS (5초 타임아웃)
+    { key: 'rss_hankyung', url: 'https://feeds.hankyung.com/economy',        opts: { timeoutMs: 5000 } },
+    { key: 'rss_yonhap',   url: 'https://www.yna.co.kr/rss/economy.xml',    opts: { timeoutMs: 5000 } },
+    { key: 'rss_mk',       url: 'https://www.mk.co.kr/rss/40300001/',        opts: { timeoutMs: 5000 } },
+  ];
+
+  // 병렬 실행
+  const entries = await Promise.all(
+    sources.map(({ key, url, opts }) =>
+      checkSource(key, url, opts).then((result) => [key, result])
+    )
+  );
+  return Object.fromEntries(entries);
+}
+
+// ─── GitHub Issue 자동 생성 ──────────────────────────────
+async function createGithubIssue(failedSources, date) {
+  const token = process.env.GITHUB_TOKEN;
+  const repo  = process.env.GITHUB_REPO;
+  if (!token || !repo) return false;
+
+  // 소스명 목록
+  const nameList = failedSources.join(', ');
+  const title = `[헬스체크] ${nameList} 연결 실패 — ${date}`;
+  const body  = `## 데이터 소스 헬스체크 실패\n\n**날짜:** ${date}\n**실패 소스:** ${nameList}\n\n> 자동 생성된 이슈입니다.`;
+
+  const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+    method: 'POST',
+    headers: {
+      Authorization: `token ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'market-dashboard-health-cron',
+    },
+    body: JSON.stringify({ title, body, labels: ['bug', 'ai-generated'] }),
+  });
+  return res.ok;
+}
+
+// ─── 메인 핸들러 ────────────────────────────────────────
+export default async function handler(req, res) {
+  if (!authorize(req)) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+
+  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+
+  const results = await runHealthChecks();
+
+  // fail 소스 목록 추출
+  const failedSources = Object.entries(results)
+    .filter(([, v]) => v.status === 'fail')
+    .map(([k]) => k);
+  const failCount = failedSources.length;
+
+  // GitHub Issue 생성 (fail이 있을 때만)
+  let issueCreated = false;
+  if (failCount > 0) {
+    issueCreated = await createGithubIssue(failedSources, date).catch(() => false);
+  }
+
+  return res.status(200).json({ date, results, failCount, issueCreated });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,7 @@
   "regions": ["icn1"],
   "ignoreCommand": "exit 0",
   "crons": [
-    { "path": "/api/cron/compute-signals", "schedule": "*/10 * * * *" }
+    { "path": "/api/cron/compute-signals", "schedule": "*/10 * * * *" },
+    { "path": "/api/cron/health-check", "schedule": "0 0 * * *" }
   ]
 }


### PR DESCRIPTION
## Summary

- `/api/cron/health-check.js` 신규 — 매일 UTC 00:00 실행
- Yahoo v8 / Stooq / Alpaca / 네이버 해외시세 / RSS 3개(한경·연합·매경) 병렬 헬스 체크
- fail 소스 발생 시 GitHub Issue 자동 생성 (`bug + ai-generated`)
- `GITHUB_TOKEN`/`GITHUB_REPO` 미설정 시 graceful 스킵
- `vercel.json` crons 배열에 daily 스케줄 추가

## 배경

Yahoo v8 비공식 엔드포인트 차단 이력(2026-03-29 강제 교체), RSS 간헐적 실패 누적에도 자동 알림 없음. 다음 장애를 미리 감지하기 위한 방어선.

## Review artifacts

- ✅ code-reviewer (Opus): PASS
- ✅ 88 테스트 전체 PASS

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 외부 데이터 및 RSS 소스를 매일 자동으로 모니터링하는 상태 확인 시스템이 추가되었습니다.
* 응답 속도를 추적하고, 서비스 장애 또는 느린 응답을 감지합니다.
* 문제 발생 시 자동으로 저장소에 이슈를 생성하여 빠른 대응을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->