### PR TITLE
feat: 내러티브 시그널 — 시그널/뉴스/섹터 자동 연결 컨텍스트 (P2-22, #241)

### DIFF
--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -5,6 +5,9 @@ import { useTopSignals } from '../../hooks/useSignals';
 import { extractName, getEasyLabel } from '../../utils/signalLabel';
 import { SIGNAL_TYPES } from '../../engine/signalTypes';
 import { useSignalAccuracy } from '../../hooks/useSignalAccuracy';
+import { buildNarrative } from '../../utils/narrativeBuilder';
+import { matchesKeywords, buildStockKeywords } from '../../utils/newsAlias';
+import { KR_SECTOR_MAP } from '../../data/krStockList';
 import TickerLogo from './TickerLogo';
 import SignalScorecardTab from './SignalScorecardTab';
 
@@ -15,7 +18,7 @@ const FORCE_TYPES = [
   SIGNAL_TYPES.INSTITUTIONAL_CONSECUTIVE_SELL,
 ];
 
-export default function SignalBoardWidget({ onItemClick }) {
+export default function SignalBoardWidget({ onItemClick, allItems = [], allNews = [] }) {
   // 탭 상태: 'live' | 'scorecard'
   const [activeTab, setActiveTab] = useState('live');
   // 모바일 기본 접힘 — 카운터만 노출
@@ -24,6 +27,42 @@ export default function SignalBoardWidget({ onItemClick }) {
   const [filterDir, setFilterDir] = useState(null);
   const allSignals = useTopSignals(20);
   const { botMap } = useSignalAccuracy();
+
+  // 시그널별 내러티브 사전 계산 — symbol 기준 캐싱
+  // sector 보강(KR), ±2시간 뉴스 매칭, 섹터 동조 종목 수 집계
+  const narrativeMap = useMemo(() => {
+    const map = new Map();
+    if (!allSignals.length) return map;
+    for (const sig of allSignals) {
+      if (!sig.symbol) continue;
+      // sector 보강 — meta.sector 없으면 KR 매핑 시도
+      const sector = sig.meta?.sector
+        || (sig.market === 'kr' ? KR_SECTOR_MAP.get(sig.symbol) : null);
+      // 관련 뉴스 (±2시간 + 키워드 매칭)
+      const ts = sig.timestamp || sig.createdAt || Date.now();
+      const market = sig.market === 'crypto' ? 'COIN' : sig.market?.toUpperCase();
+      const keywords = buildStockKeywords(sig.symbol, sig.name, market);
+      const relatedNews = (keywords.length && allNews.length)
+        ? allNews.filter(item => {
+            const pubMs = item.pubDate ? new Date(item.pubDate).getTime() : 0;
+            if (!pubMs || Math.abs(ts - pubMs) > 2 * 60 * 60 * 1000) return false;
+            const text = item.title + ' ' + (item.summary || item.description || '');
+            return matchesKeywords(text, keywords);
+          })
+        : [];
+      // 섹터 동조 — ±3% 이상 동반 변동 종목 수 (자기 자신 제외)
+      const sectorPeers = (sector && allItems.length)
+        ? allItems.filter(it =>
+            it.symbol !== sig.symbol
+            && it.sector === sector
+            && Math.abs(it.changePct ?? 0) >= 3,
+          ).length
+        : 0;
+      const enriched = sector ? { ...sig, meta: { ...sig.meta, sector } } : sig;
+      map.set(sig.id, buildNarrative({ signal: enriched, relatedNews, sectorPeers }));
+    }
+    return map;
+  }, [allSignals, allItems, allNews]);
 
   const { bullSignals, bearSignals, neutralSignals, bullCount, bearCount, neutralCount } = useMemo(() => {
     const bull = [], bear = [], neutral = [];
@@ -199,51 +238,58 @@ export default function SignalBoardWidget({ onItemClick }) {
             const isBear = signal.direction === 'bearish';
             const nameColor = isBull ? '#F04452' : isBear ? '#1764ED' : '#191F28';
             const dotColor = isBull ? '#F04452' : isBear ? '#1764ED' : '#8B95A1';
+            const narrative = narrativeMap.get(signal.id);
             return (
-              <button
-                key={signal.id}
-                onClick={() => handleClick(signal)}
-                className={`w-full text-left flex items-center gap-3 py-[11px] px-2 rounded-[10px] transition-colors ${
-                  signal.symbol ? 'cursor-pointer hover:bg-[#F2F3F5]' : ''
-                } ${idx > 0 ? 'border-t border-[#F2F3F5]' : ''}`}
-                style={idx > 0 ? {} : {}}
-              >
-                {signal.symbol && (
-                  <TickerLogo item={{ symbol: signal.symbol, name: signal.name, _market: signal.market === 'kr' ? 'KR' : signal.market === 'us' ? 'US' : signal.market === 'crypto' ? 'COIN' : '', id: signal.market === 'crypto' ? signal.symbol : undefined }} size={24} />
-                )}
-                <span className="text-[14px] font-semibold flex-shrink-0" style={{ color: nameColor }}>
-                  {extractName(signal)}
-                </span>
-                <span className="text-[13px] text-[#8B95A1] truncate flex-1 min-w-0">
-                  {getEasyLabel(signal)}
-                  {/* 적중률 배지 */}
-                  {botMap.get(signal.type)?.totalFired > 0 && (
-                    <span
-                      className="ml-1 text-[10px] font-bold px-1 py-[1px] rounded-full"
-                      style={{
-                        color: '#fff',
-                        background: (botMap.get(signal.type)?.accuracy ?? 0) >= 70 ? '#2AC769'
-                          : (botMap.get(signal.type)?.accuracy ?? 0) >= 50 ? '#FF9500' : '#F04452',
-                      }}
-                    >
-                      {botMap.get(signal.type)?.accuracy ?? 0}%
-                    </span>
+              <div key={signal.id} className={idx > 0 ? 'border-t border-[#F2F3F5]' : ''}>
+                <button
+                  onClick={() => handleClick(signal)}
+                  className={`w-full text-left flex items-center gap-3 py-[11px] px-2 rounded-[10px] transition-colors ${
+                    signal.symbol ? 'cursor-pointer hover:bg-[#F2F3F5]' : ''
+                  }`}
+                >
+                  {signal.symbol && (
+                    <TickerLogo item={{ symbol: signal.symbol, name: signal.name, _market: signal.market === 'kr' ? 'KR' : signal.market === 'us' ? 'US' : signal.market === 'crypto' ? 'COIN' : '', id: signal.market === 'crypto' ? signal.symbol : undefined }} size={24} />
                   )}
-                </span>
-                {/* 강도 도트 (원형) */}
-                <div className="flex gap-[3px] flex-shrink-0">
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <div
-                      key={i}
-                      className="w-[5px] h-[5px] rounded-full"
-                      style={{
-                        background: dotColor,
-                        opacity: i < (signal.strength || 0) ? 1 : 0.15,
-                      }}
-                    />
-                  ))}
-                </div>
-              </button>
+                  <span className="text-[14px] font-semibold flex-shrink-0" style={{ color: nameColor }}>
+                    {extractName(signal)}
+                  </span>
+                  <span className="text-[13px] text-[#8B95A1] truncate flex-1 min-w-0">
+                    {getEasyLabel(signal)}
+                    {/* 적중률 배지 */}
+                    {botMap.get(signal.type)?.totalFired > 0 && (
+                      <span
+                        className="ml-1 text-[10px] font-bold px-1 py-[1px] rounded-full"
+                        style={{
+                          color: '#fff',
+                          background: (botMap.get(signal.type)?.accuracy ?? 0) >= 70 ? '#2AC769'
+                            : (botMap.get(signal.type)?.accuracy ?? 0) >= 50 ? '#FF9500' : '#F04452',
+                        }}
+                      >
+                        {botMap.get(signal.type)?.accuracy ?? 0}%
+                      </span>
+                    )}
+                  </span>
+                  {/* 강도 도트 (원형) */}
+                  <div className="flex gap-[3px] flex-shrink-0">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                      <div
+                        key={i}
+                        className="w-[5px] h-[5px] rounded-full"
+                        style={{
+                          background: dotColor,
+                          opacity: i < (signal.strength || 0) ? 1 : 0.15,
+                        }}
+                      />
+                    ))}
+                  </div>
+                </button>
+                {/* 내러티브 컨텍스트 — "왜 발화했는가" (매칭 부족 시 영역 숨김) */}
+                {narrative && (
+                  <div className="px-2 pb-2 -mt-1 text-[11px] text-[#6B7684] dark:text-[#8B95A1] leading-snug">
+                    🧩 컨텍스트: {narrative}
+                  </div>
+                )}
+              </div>
             );
           })}
         </div>

--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -38,23 +38,25 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
       // sector 보강 — meta.sector 없으면 KR 매핑 시도
       const sector = sig.meta?.sector
         || (sig.market === 'kr' ? KR_SECTOR_MAP.get(sig.symbol) : null);
-      // 관련 뉴스 (±2시간 + 키워드 매칭)
-      const ts = sig.timestamp || sig.createdAt || Date.now();
+      // 관련 뉴스 (±2시간 + 키워드 매칭) — timestamp 없으면 매칭 스킵
+      const ts = sig.timestamp || sig.createdAt || null;
       const market = sig.market === 'crypto' ? 'COIN' : sig.market?.toUpperCase();
       const keywords = buildStockKeywords(sig.symbol, sig.name, market);
-      const relatedNews = (keywords.length && allNews.length)
+      const relatedNews = (ts && keywords.length && allNews.length)
         ? allNews.filter(item => {
             const pubMs = item.pubDate ? new Date(item.pubDate).getTime() : 0;
-            if (!pubMs || Math.abs(ts - pubMs) > 2 * 60 * 60 * 1000) return false;
-            const text = item.title + ' ' + (item.summary || item.description || '');
+            if (!Number.isFinite(pubMs) || !pubMs || Math.abs(ts - pubMs) > 2 * 60 * 60 * 1000) return false;
+            const text = (item.title || '') + ' ' + (item.summary || item.description || '');
             return matchesKeywords(text, keywords);
           })
         : [];
-      // 섹터 동조 — ±3% 이상 동반 변동 종목 수 (자기 자신 제외)
+      // 섹터 동조 — 시그널 방향 일치 + ±3% 이상 동반 종목 수 (자기 자신 제외)
+      const sigDir = Math.sign((sig.changePct ?? 0) || (sig.direction === 'bearish' ? -1 : 1));
       const sectorPeers = (sector && allItems.length)
         ? allItems.filter(it =>
             it.symbol !== sig.symbol
-            && it.sector === sector
+            && it.sector && it.sector === sector
+            && Math.sign(it.changePct ?? 0) === sigDir
             && Math.abs(it.changePct ?? 0) >= 3,
           ).length
         : 0;

--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -38,8 +38,9 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
       // sector 보강 — meta.sector 없으면 KR 매핑 시도
       const sector = sig.meta?.sector
         || (sig.market === 'kr' ? KR_SECTOR_MAP.get(sig.symbol) : null);
-      // 관련 뉴스 (±2시간 + 키워드 매칭) — timestamp 없으면 매칭 스킵
-      const ts = sig.timestamp || sig.createdAt || null;
+      // 관련 뉴스 (±2시간 + 키워드 매칭) — timestamp 없거나 ms 범위 아니면 스킵
+      const rawTs = sig.timestamp || sig.createdAt || null;
+      const ts = rawTs && rawTs > 1_000_000_000_000 ? rawTs : null; // ms 단위 (13자리) 검증
       const market = sig.market === 'crypto' ? 'COIN' : sig.market?.toUpperCase();
       const keywords = buildStockKeywords(sig.symbol, sig.name, market);
       const relatedNews = (ts && keywords.length && allNews.length)
@@ -51,14 +52,15 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
           })
         : [];
       // 섹터 동조 — 시그널 방향 일치 + ±3% 이상 동반 종목 수 (자기 자신 제외)
-      const sigDir = Math.sign((sig.changePct ?? 0) || (sig.direction === 'bearish' ? -1 : 1));
+      // neutral=0, bullish=1, bearish=-1 — changePct는 0이 falsy라 direction 우선
+      const sigDir = sig.direction === 'bullish' ? 1 : sig.direction === 'bearish' ? -1 : Math.sign(sig.changePct ?? 0);
       const sectorPeers = (sector && allItems.length)
-        ? allItems.filter(it =>
-            it.symbol !== sig.symbol
-            && it.sector && it.sector === sector
-            && Math.sign(it.changePct ?? 0) === sigDir
-            && Math.abs(it.changePct ?? 0) >= 3,
-          ).length
+        ? allItems.filter(it => {
+            if (it.symbol === sig.symbol) return false;
+            if (!it.sector || it.sector !== sector) return false;
+            if (Math.abs(it.changePct ?? 0) < 3) return false;
+            return sigDir === 0 || Math.sign(it.changePct ?? 0) === sigDir;
+          }).length
         : 0;
       const enriched = sector ? { ...sig, meta: { ...sig.meta, sector } } : sig;
       map.set(sig.id, buildNarrative({ signal: enriched, relatedNews, sectorPeers }));

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -228,7 +228,7 @@ export default function HomeDashboard({
       )}
 
       {/* ─── 3. 시그널 보드 (시그널 + 세력 포착 통합) ────── */}
-      <SignalBoardWidget onItemClick={handleSignalItemClick} />
+      <SignalBoardWidget onItemClick={handleSignalItemClick} allItems={allItems} allNews={allNews} />
 
       {/* ─── 3.5. AI 종목토론 (별도 섹션) ──────────────── */}
       <AiDebateSection watchedItems={watchedItems} usStocks={usStocks} krStocks={krStocks} allItems={allItems} />

--- a/src/utils/narrativeBuilder.js
+++ b/src/utils/narrativeBuilder.js
@@ -35,7 +35,7 @@ export function buildNarrative({ signal, relatedNews = [], sectorPeers = 0, flow
 
   // 1. 뉴스 + 외인플로우 동시
   if (news.length > 0 && flow) {
-    const action = signal.direction === 'bearish' ? '순매도' : '순매수';
+    const action = signal.direction === 'bearish' ? '순매도' : signal.direction === 'bullish' ? '순매수' : '순매수/도';
     return truncate(`${name} ${flow} ${action} + '${newsHead20}' 뉴스`);
   }
   // 2. 뉴스 + 섹터 동조

--- a/src/utils/narrativeBuilder.js
+++ b/src/utils/narrativeBuilder.js
@@ -1,0 +1,55 @@
+// 내러티브 빌더 — 시그널 + 관련 데이터 → "왜 발화했는가" 1문장 (규칙 기반, AI 없이)
+// 우선순위: 뉴스+플로우 > 뉴스+섹터 > 뉴스 > 섹터 > null
+
+const MAX_LEN = 60;
+const SECTOR_MIN_PEERS = 2; // 섹터 동반 최소 종목 수
+
+// 길이 초과 시 자르고 ... 부착
+function truncate(text, max = MAX_LEN) {
+  if (!text) return '';
+  return text.length > max ? text.slice(0, max - 1) + '…' : text;
+}
+
+// 외인/기관 플로우 라벨 ("외인" / "기관" / null)
+function flowLabel(signal) {
+  const t = signal?.type || '';
+  if (t.includes('foreign')) return '외인';
+  if (t.includes('institutional')) return '기관';
+  return null;
+}
+
+/**
+ * 내러티브 1문장 생성 — 매칭 부족 시 null 반환
+ * @param {object} ctx { signal, relatedNews, sectorPeers, flowData }
+ * @returns {string|null}
+ */
+export function buildNarrative({ signal, relatedNews = [], sectorPeers = 0, flowData = null } = {}) {
+  if (!signal?.symbol) return null;
+  const name = signal.name || signal.symbol;
+  const sector = signal.meta?.sector;
+  const direction = signal.direction === 'bullish' ? '상승' : signal.direction === 'bearish' ? '하락' : '변동';
+  const news = Array.isArray(relatedNews) ? relatedNews : [];
+  const newsHead20 = news[0]?.title?.slice(0, 20) || '';
+  const newsHead30 = news[0]?.title?.slice(0, 30) || '';
+  const flow = flowData || flowLabel(signal);
+
+  // 1. 뉴스 + 외인플로우 동시
+  if (news.length > 0 && flow) {
+    const action = signal.direction === 'bearish' ? '순매도' : '순매수';
+    return truncate(`${name} ${flow} ${action} + '${newsHead20}' 뉴스`);
+  }
+  // 2. 뉴스 + 섹터 동조
+  if (news.length > 0 && sector && sectorPeers >= SECTOR_MIN_PEERS) {
+    return truncate(`${name} '${newsHead20}' + ${sector}섹터 ${sectorPeers}개 동반 상승`);
+  }
+  // 3. 뉴스만
+  if (news.length > 0) {
+    return truncate(`관련 뉴스 ${news.length}건 집중 — ${newsHead30}`);
+  }
+  // 4. 섹터 동조만
+  if (sector && sectorPeers >= SECTOR_MIN_PEERS) {
+    return truncate(`${sector}섹터 ${sectorPeers}개 종목 동반 ${direction} — 수급 이동 감지`);
+  }
+  // 5. 매칭 없음
+  return null;
+}

--- a/src/utils/narrativeBuilder.js
+++ b/src/utils/narrativeBuilder.js
@@ -10,9 +10,9 @@ function truncate(text, max = MAX_LEN) {
   return text.length > max ? text.slice(0, max - 1) + '…' : text;
 }
 
-// 외인/기관 플로우 라벨 ("외인" / "기관" / null)
+// 외인/기관 플로우 라벨 ("외인" / "기관" / null) — 대소문자 무관 매칭
 function flowLabel(signal) {
-  const t = signal?.type || '';
+  const t = (signal?.type || '').toLowerCase();
   if (t.includes('foreign')) return '외인';
   if (t.includes('institutional')) return '기관';
   return null;
@@ -40,7 +40,7 @@ export function buildNarrative({ signal, relatedNews = [], sectorPeers = 0, flow
   }
   // 2. 뉴스 + 섹터 동조
   if (news.length > 0 && sector && sectorPeers >= SECTOR_MIN_PEERS) {
-    return truncate(`${name} '${newsHead20}' + ${sector}섹터 ${sectorPeers}개 동반 상승`);
+    return truncate(`${name} '${newsHead20}' + ${sector}섹터 ${sectorPeers}개 동반 ${direction}`);
   }
   // 3. 뉴스만
   if (news.length > 0) {


### PR DESCRIPTION
## Summary

- `src/utils/narrativeBuilder.js` 신규 — 5단계 규칙 기반 내러티브 합성 (AI 없이)
- `SignalBoardWidget.jsx` — narrativeMap useMemo + '🧩 컨텍스트:' 인라인 표시
- `index.jsx` — allItems/allNews props 전달 추가

**내러티브 우선순위**: 뉴스+플로우 → 뉴스+섹터 → 뉴스 → 섹터 → null(숨김)

## Review highlights

code-reviewer BLOCK 이후 5라운드 수정:
- flowLabel toLowerCase() 대소문자 통일
- sectorPeers direction 매칭 (sigDir 분기, neutral=0이면 방향 무관)
- ts ms 단위 검증 (`> 1e12`)
- pubDate NaN → `Number.isFinite()` 체크
- item.title undefined 방지

- ✅ code-reviewer (Opus): PASS (최종)
- ✅ 88 테스트 전체 PASS

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)