### PR TITLE
feat: 헬스체크 이슈 쿨다운 — 동일 소스 24h 중복 방지 (P3-7, #246)

### DIFF
--- a/api/cron/health-check.js
+++ b/api/cron/health-check.js
@@ -60,6 +60,23 @@ async function runHealthChecks() {
   return Object.fromEntries(entries);
 }
 
+// ─── 24h 이내 동일 소스 이슈 중복 여부 확인 ─────────────
+async function hasRecentHealthIssue(failedSources, repo, token) {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${repo}/issues?state=open&labels=bug%2Cai-generated&since=${since}&per_page=20`,
+      { headers: { Authorization: `token ${token}`, 'User-Agent': 'market-dashboard-health-cron' } }
+    );
+    if (!res.ok) return false;
+    const issues = await res.json();
+    return issues.some(issue =>
+      issue.title.includes('[헬스체크]') &&
+      failedSources.some(s => issue.title.includes(s))
+    );
+  } catch { return false; }
+}
+
 // ─── GitHub Issue 자동 생성 ──────────────────────────────
 async function createGithubIssue(failedSources, date) {
   const token = process.env.GITHUB_TOKEN;
@@ -99,11 +116,19 @@ export default async function handler(req, res) {
     .map(([k]) => k);
   const failCount = failedSources.length;
 
-  // GitHub Issue 생성 (fail이 있을 때만)
+  // GitHub Issue 생성 (fail이 있고 24h 이내 동일 소스 이슈 없을 때만)
   let issueCreated = false;
+  let cooldown = false;
   if (failCount > 0) {
-    issueCreated = await createGithubIssue(failedSources, date).catch(() => false);
+    const token = process.env.GITHUB_TOKEN;
+    const repo  = process.env.GITHUB_REPO;
+    cooldown = token && repo
+      ? await hasRecentHealthIssue(failedSources, repo, token)
+      : false;
+    if (!cooldown) {
+      issueCreated = await createGithubIssue(failedSources, date).catch(() => false);
+    }
   }
 
-  return res.status(200).json({ date, results, failCount, issueCreated });
+  return res.status(200).json({ date, results, failCount, issueCreated, cooldown });
 }

--- a/api/cron/health-check.js
+++ b/api/cron/health-check.js
@@ -60,21 +60,35 @@ async function runHealthChecks() {
   return Object.fromEntries(entries);
 }
 
-// ─── 24h 이내 동일 소스 이슈 중복 여부 확인 ─────────────
-async function hasRecentHealthIssue(failedSources, repo, token) {
-  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+// ─── 24h 이내 이미 알림된 소스 집합 반환 ────────────────
+// since 파라미터는 updated_at 기준이라 created_at 필터는 클라이언트에서 처리
+async function getRecentlyAlertedSources(failedSources, repo, token) {
+  const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
   try {
     const res = await fetch(
-      `https://api.github.com/repos/${repo}/issues?state=open&labels=bug%2Cai-generated&since=${since}&per_page=20`,
-      { headers: { Authorization: `token ${token}`, 'User-Agent': 'market-dashboard-health-cron' } }
+      `https://api.github.com/repos/${repo}/issues?state=open&labels=bug%2Cai-generated&per_page=50`,
+      { headers: { Authorization: `token ${token}`, 'User-Agent': 'market-dashboard-health-cron' }, signal: controller.signal }
     );
-    if (!res.ok) return false;
+    if (!res.ok) return new Set();
     const issues = await res.json();
-    return issues.some(issue =>
-      issue.title.includes('[헬스체크]') &&
-      failedSources.some(s => issue.title.includes(s))
+    const alerted = new Set();
+    const recent = issues.filter(i =>
+      i.title.includes('[헬스체크]') && new Date(i.created_at).getTime() > cutoff
     );
-  } catch { return false; }
+    for (const issue of recent) {
+      for (const s of failedSources) {
+        if (issue.title.includes(s)) alerted.add(s);
+      }
+    }
+    return alerted;
+  } catch (err) {
+    console.error('[health-cron] cooldown lookup 실패:', err.message);
+    return new Set();
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 // ─── GitHub Issue 자동 생성 ──────────────────────────────
@@ -116,19 +130,21 @@ export default async function handler(req, res) {
     .map(([k]) => k);
   const failCount = failedSources.length;
 
-  // GitHub Issue 생성 (fail이 있고 24h 이내 동일 소스 이슈 없을 때만)
+  // GitHub Issue 생성 — 신규 소스만 (24h 이내 이미 알림된 소스 제외)
   let issueCreated = false;
-  let cooldown = false;
+  let suppressedSources = [];
   if (failCount > 0) {
     const token = process.env.GITHUB_TOKEN;
     const repo  = process.env.GITHUB_REPO;
-    cooldown = token && repo
-      ? await hasRecentHealthIssue(failedSources, repo, token)
-      : false;
-    if (!cooldown) {
-      issueCreated = await createGithubIssue(failedSources, date).catch(() => false);
+    const alerted = (token && repo)
+      ? await getRecentlyAlertedSources(failedSources, repo, token)
+      : new Set();
+    const fresh = failedSources.filter(s => !alerted.has(s));
+    suppressedSources = failedSources.filter(s => alerted.has(s));
+    if (fresh.length > 0) {
+      issueCreated = await createGithubIssue(fresh, date).catch(() => false);
     }
   }
 
-  return res.status(200).json({ date, results, failCount, issueCreated, cooldown });
+  return res.status(200).json({ date, results, failCount, issueCreated, suppressedSources });
 }

--- a/api/cron/health-check.js
+++ b/api/cron/health-check.js
@@ -68,7 +68,7 @@ async function getRecentlyAlertedSources(failedSources, repo, token) {
   const timer = setTimeout(() => controller.abort(), 8000);
   try {
     const res = await fetch(
-      `https://api.github.com/repos/${repo}/issues?state=open&labels=bug%2Cai-generated&per_page=50`,
+      `https://api.github.com/repos/${repo}/issues?state=all&labels=bug%2Cai-generated&sort=created&direction=desc&per_page=50`,
       { headers: { Authorization: `token ${token}`, 'User-Agent': 'market-dashboard-health-cron' }, signal: controller.signal }
     );
     if (!res.ok) return new Set();


### PR DESCRIPTION
## 요약
- 데이터 소스 장기 장애 시 매일 동일 이슈가 생성되는 노이즈 문제 해결
- `getRecentlyAlertedSources()`: 24h 이내 이미 알림된 소스 집합 반환 → 신규 소스만 이슈 생성
- AbortController 8s 타임아웃, `console.error` 로깅, `state=all + sort=created` 추가

## 변경 내용
- `hasRecentHealthIssue` → `getRecentlyAlertedSources` 재설계 (Set 반환)
- over-suppression 수정: 신규 소스만 이슈, 기존 알림된 소스는 억제
- `since` 파라미터 제거 → `created_at` 클라이언트 필터로 교체
- 응답에 `suppressedSources` 필드 추가

## 코드 리뷰
> 🤖 code-reviewer (Claude Opus): PASS
> 🔍 Codex Gate: SKIP (gpt-5.5 API 오류 — openai 인프라 이슈, 코드 변경과 무관)

Closes #246

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 최근 24시간 내 생성된 경고를 감지하여 중복 알림 발생을 방지하는 기능 추가
  * API 응답에 억제된 경고 목록 정보 추가

* **개선 사항**
  * 헬스 체크 프로세스 최적화로 불필요한 중복 알림 감소

<!-- end of auto-generated comment: release notes by coderabbit.ai -->