### PR TITLE
fix: P3-1 알고리즘 부채 3건 — batch invariant / accuracy 로딩 상태 / flow fallback (#256)

### DIFF
--- a/api/cron/compute-signals.js
+++ b/api/cron/compute-signals.js
@@ -578,6 +578,9 @@ function buildRecoverySignal(target, rec, currentPrice) {
 // 장 중에는 Naver 일중 데이터 변동 가능성이 있으므로 매 cron 신선 fetch
 const KR_FLOW_CACHE_KEY = 'flow:kr-investors';
 const KR_FLOW_CACHE_TTL = 2 * 3600;
+// fetch 실패 종목 fallback용 — 마지막 성공분 24h 보존 (#216)
+const KR_FLOW_LAST_GOOD_KEY = 'flow:kr-investors:last-good';
+const KR_FLOW_LAST_GOOD_TTL = 24 * 3600;
 
 // KRX 공휴일 (2025~2027 법정공휴일, marketHours.js와 동기화)
 // marketHours.js와 동일한 Set — 포맷 'YYYY-M-D' (선행 0 없음)
@@ -616,6 +619,13 @@ async function fetchKrFlowMap(krSymbols) {
       }
     } catch { /* cache miss → fresh fetch */ }
   }
+
+  // 실패 종목 fallback용 — 이전 cron 성공분 사전 로드 (#216)
+  let lastGood = {};
+  try {
+    const snap = await getSnap(KR_FLOW_LAST_GOOD_KEY);
+    if (snap && typeof snap === 'object') lastGood = snap;
+  } catch { /* lastGood 없으면 빈 객체 유지 */ }
 
   const map = new Map();
   await Promise.allSettled(
@@ -676,7 +686,26 @@ async function fetchKrFlowMap(krSymbols) {
     })
   );
 
-  // 장 외 + 전체 성공 시에만 캐시 저장 (장 중 신선도 보장, 부분 실패 오염 방지)
+  // 실패 종목에 last-good 값 fallback (flow=null 대신 이전 성공분 사용)
+  for (const symbol of krSymbols) {
+    if (!map.has(symbol) && lastGood[symbol]) {
+      map.set(symbol, lastGood[symbol]);
+      console.warn(`[compute-signals] ${symbol} flow fallback → last-good 사용`);
+    }
+  }
+
+  // 성공 종목만 last-good에 누적 저장 (부분 실패해도 성공분은 항상 보존)
+  if (map.size > 0) {
+    try {
+      const merged = { ...lastGood };
+      for (const symbol of krSymbols) {
+        if (map.has(symbol)) merged[symbol] = map.get(symbol);
+      }
+      await setSnap(KR_FLOW_LAST_GOOD_KEY, merged, KR_FLOW_LAST_GOOD_TTL);
+    } catch { /* last-good 저장 실패는 무시 */ }
+  }
+
+  // 장 외 + 전체 성공 시에만 전수성공 캐시 저장 (기존 정책 유지)
   if (!marketOpen && map.size === krSymbols.length) {
     try {
       await setSnap(cacheKey, Object.fromEntries(map), KR_FLOW_CACHE_TTL);

--- a/api/cron/compute-signals.js
+++ b/api/cron/compute-signals.js
@@ -686,6 +686,9 @@ async function fetchKrFlowMap(krSymbols) {
     })
   );
 
+  // fallback 전 신선 성공 심볼 고정 (캐시 오염 방지 — Copilot/Gemini HIGH #257)
+  const freshSymbols = new Set(map.keys());
+
   // 실패 종목에 last-good 값 fallback (flow=null 대신 이전 성공분 사용)
   for (const symbol of krSymbols) {
     if (!map.has(symbol) && lastGood[symbol]) {
@@ -694,19 +697,19 @@ async function fetchKrFlowMap(krSymbols) {
     }
   }
 
-  // 성공 종목만 last-good에 누적 저장 (부분 실패해도 성공분은 항상 보존)
-  if (map.size > 0) {
+  // 신선 성공분만 last-good에 누적 저장 (fallback 값으로 기존 last-good 덮어쓰기 방지)
+  if (freshSymbols.size > 0) {
     try {
       const merged = { ...lastGood };
-      for (const symbol of krSymbols) {
-        if (map.has(symbol)) merged[symbol] = map.get(symbol);
+      for (const symbol of freshSymbols) {
+        merged[symbol] = map.get(symbol);
       }
       await setSnap(KR_FLOW_LAST_GOOD_KEY, merged, KR_FLOW_LAST_GOOD_TTL);
     } catch { /* last-good 저장 실패는 무시 */ }
   }
 
-  // 장 외 + 전체 성공 시에만 전수성공 캐시 저장 (기존 정책 유지)
-  if (!marketOpen && map.size === krSymbols.length) {
+  // 장 외 + 전수 신선 성공 시에만 전수성공 캐시 저장 (fallback 포함 시 오염 방지)
+  if (!marketOpen && freshSymbols.size === krSymbols.length) {
     try {
       await setSnap(cacheKey, Object.fromEntries(map), KR_FLOW_CACHE_TTL);
     } catch { /* cache write 실패는 무시 */ }

--- a/src/hooks/useInvestorSignals.js
+++ b/src/hooks/useInvestorSignals.js
@@ -192,8 +192,11 @@ export function useInvestorSignals(allItems = [], krwRate = null, krwRateLoaded 
 
       const items = allItemsRef.current;
       // 스캔 전체를 배치로 묶어 _notify를 1회로 압축 — 다수 addSignal 호출로 인한 연속 리렌더 방지
-      beginBatch();
+      // beginBatch를 try 안에서 호출해 pair invariant 보장 (#229)
+      let _batchOpened = false;
       try {
+        beginBatch();
+        _batchOpened = true;
         // ── P0-1: 외국인/기관 연속 매수매도 시그널 ──
         await scanInvestorTrends(items);
 
@@ -236,8 +239,8 @@ export function useInvestorSignals(allItems = [], krwRate = null, krwRateLoaded 
         // 에러 무시 — 다음 폴링에서 재시도
       } finally {
         runningRef.current = false;
-        // 배치 종료 — 스캔 중 쌓인 _notify를 1회 실행
-        endBatch();
+        // 배치 종료 — beginBatch가 성공한 경우에만 (pair invariant)
+        if (_batchOpened) endBatch();
       }
     }
 

--- a/src/hooks/useSignalAccuracy.js
+++ b/src/hooks/useSignalAccuracy.js
@@ -29,7 +29,7 @@ async function fetchSignalAccuracy() {
  * @returns {{ bots: Array, overallAccuracy: number, isLoading: boolean, botMap: Map }}
  */
 export function useSignalAccuracy() {
-  const { data: raw = [], isLoading } = useQuery({
+  const { data: raw = [], isLoading, isError } = useQuery({
     queryKey: ['signal-accuracy'],
     queryFn: fetchSignalAccuracy,
     staleTime: 10 * 60_000,
@@ -60,22 +60,25 @@ export function useSignalAccuracy() {
       ])
   );
 
-  // API에 없는 봇도 "집계 중" 상태로 포함 (레거시 제외)
-  const missingBots = ALL_BOT_TYPES
-    .filter((t) => !apiBotsMap.has(t) && !LEGACY_SIGNAL_TYPES.has(t))
-    .map((t) => ({
-      type: t,
-      totalFired: 0,
-      hitCount: 0,
-      accuracy: 0,
-      accuracy1h: null,
-      accuracy4h: null,
-      accuracy24h: null,
-      trend: 0,
-      recentResults: [],
-      recentSignals: [],
-      isMissing: true,
-    }));
+  // 로딩/에러 중에는 placeholder 억제 — 실제 API 응답 후에만 "집계 중" 표시 (#226)
+  const dataReady = !isLoading && !isError;
+  const missingBots = dataReady
+    ? ALL_BOT_TYPES
+        .filter((t) => !apiBotsMap.has(t) && !LEGACY_SIGNAL_TYPES.has(t))
+        .map((t) => ({
+          type: t,
+          totalFired: 0,
+          hitCount: 0,
+          accuracy: 0,
+          accuracy1h: null,
+          accuracy4h: null,
+          accuracy24h: null,
+          trend: 0,
+          recentResults: [],
+          recentSignals: [],
+          isMissing: true,
+        }))
+    : [];
 
   const bots = [...apiBotsMap.values(), ...missingBots];
 
@@ -88,5 +91,5 @@ export function useSignalAccuracy() {
   // 타입별 빠른 조회용 Map
   const botMap = new Map(bots.map((b) => [b.type, b]));
 
-  return { bots, overallAccuracy, isLoading, botMap };
+  return { bots, overallAccuracy, isLoading, isError, botMap };
 }


### PR DESCRIPTION
Closes #256

## 수정 내용

### 1) #229 — `useInvestorSignals.js` batch pair invariant
`beginBatch()`를 `try` 블록 밖에서 호출하면 pair invariant 위반.
`try` 안으로 이동 + `_batchOpened` 플래그로 `finally`에서 조건부 `endBatch`.

### 2) #226 — `useSignalAccuracy.js` 로딩 중 "집계 중" 오표시 제거
`placeholderData:[]`로 인해 `isLoading=true` 상태에서 ALL_BOT_TYPES 전부 "집계 중"으로 표시되던 버그.
`dataReady = !isLoading && !isError` 가드 추가 → 실제 API 응답 후에만 missingBots 생성.

### 3) #216 — `compute-signals.js` KR flow fetch 실패 시 last-good fallback
`flow:kr-investors:last-good` KV 캐시(24h) 도입.
Naver fetch 실패 종목은 이전 성공분으로 fallback → flow 기여 누락 방지.
전수성공 캐시 정책(`flow:kr-investors` 2h)은 기존 유지.

## 검토 결과
- Claude Opus code-reviewer: **PASS**
- Architect gate: **PASS**
- Codex gate: **SKIP** — `gpt-5.5` 모델 버전 오류로 실행 불가 (Opus + architect 이중 검토로 대체)
- 빌드: ✓ (에러 0)
- 단위 테스트: 88/88 PASS

## 영향 범위
- `src/hooks/useInvestorSignals.js` — beginBatch 위치 변경 (로직 무변경)
- `src/hooks/useSignalAccuracy.js` — 로딩 중 bots=[] 반환 (컴포넌트 empty 상태 정상 처리)
- `api/cron/compute-signals.js` — KV 키 1개 추가, flow fallback 로직 ~15줄

🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 배치 작업 오류로 인한 실패 상황 처리 개선
  * 데이터 로딩 중 오류 상태 처리 강화

* **안정성 개선**
  * 부분적인 데이터 조회 실패 시 폴백 메커니즘 추가로 서비스 연속성 향상
  * 데이터 로딩 및 오류 상태에서 더 정확한 화면 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->