### PR TITLE
fix(P1): update-coins 빈 응답 무음 방지 + watchdog staleness 감지 (#266)

### DIFF
--- a/workers/cron/src/crons/update-coins.js
+++ b/workers/cron/src/crons/update-coins.js
@@ -8,7 +8,7 @@
 //   Phase 2: ticker/all(6s) or 청크 fallback(6s) → ~6s
 //   Worst case: ~11s
 
-import { SNAP_KEYS, SNAP_TTL, setSnap, recordCronFailure } from '../price-cache.js';
+import { SNAP_KEYS, SNAP_TTL, setSnap, recordCronFailure, recordCronSuccess } from '../price-cache.js';
 
 // #104 Opus: Upbit markets 전량 실패 + Bithumb fallback 경로에서도 최소한의 한글명 보장.
 // 라이브 Upbit 한글명 매핑을 1-off 로 추출 (Top 40 KRW 마켓).
@@ -142,24 +142,28 @@ export async function updateCoins(env) {
     });
     console.log(`[update-coins] 저장: ${items.length}개 (source=upbit)`);
 
-    if (items.length > 0) {
-      // #185: full 먼저 저장 → hot 후 저장 (kr/us와 순서 통일).
-      //        클라이언트가 hot → full lazy 순으로 읽으므로
-      //        full이 hot보다 오래된 적이 없어야 hot 데이터를 덮어쓰지 않음.
-      await setSnap(SNAP_KEYS.COINS, items, SNAP_TTL.COINS);
-      try {
-        const hot = [...items]
-          .sort((a, b) => {
-            const v = (b.accTradePrice24h || 0) - (a.accTradePrice24h || 0);
-            if (v !== 0) return v;
-            return String(a.symbol).localeCompare(String(b.symbol));
-          })
-          .slice(0, 200);
-        await setSnap(SNAP_KEYS.COINS_HOT, hot, SNAP_TTL.HOT);
-      } catch (e) {
-        console.warn('[update-coins] hot 저장 실패:', e?.message || e);
-      }
+    if (items.length === 0) {
+      await recordCronFailure('coins', 'items 0개 — tickers 변환 결과 없음');
+      return { ok: false, count: 0 };
     }
+
+    // #185: full 먼저 저장 → hot 후 저장 (kr/us와 순서 통일).
+    //        클라이언트가 hot → full lazy 순으로 읽으므로
+    //        full이 hot보다 오래된 적이 없어야 hot 데이터를 덮어쓰지 않음.
+    await setSnap(SNAP_KEYS.COINS, items, SNAP_TTL.COINS);
+    try {
+      const hot = [...items]
+        .sort((a, b) => {
+          const v = (b.accTradePrice24h || 0) - (a.accTradePrice24h || 0);
+          if (v !== 0) return v;
+          return String(a.symbol).localeCompare(String(b.symbol));
+        })
+        .slice(0, 200);
+      await setSnap(SNAP_KEYS.COINS_HOT, hot, SNAP_TTL.HOT);
+    } catch (e) {
+      console.warn('[update-coins] hot 저장 실패:', e?.message || e);
+    }
+    await recordCronSuccess('coins');
 
     return { ok: true, count: items.length };
   } catch (err) {

--- a/workers/cron/src/crons/update-coins.js
+++ b/workers/cron/src/crons/update-coins.js
@@ -155,6 +155,8 @@ export async function updateCoins(env) {
       await recordCronFailure('coins', 'snap:coins Redis 쓰기 실패');
       return { ok: false, count: 0 };
     }
+    // full snap 성공 직후 기록 — hot은 파생 데이터로 best-effort
+    await recordCronSuccess('coins');
     try {
       const hot = [...items]
         .sort((a, b) => {
@@ -167,7 +169,6 @@ export async function updateCoins(env) {
     } catch (e) {
       console.warn('[update-coins] hot 저장 실패:', e?.message || e);
     }
-    await recordCronSuccess('coins');
 
     return { ok: true, count: items.length };
   } catch (err) {

--- a/workers/cron/src/crons/update-coins.js
+++ b/workers/cron/src/crons/update-coins.js
@@ -150,7 +150,11 @@ export async function updateCoins(env) {
     // #185: full 먼저 저장 → hot 후 저장 (kr/us와 순서 통일).
     //        클라이언트가 hot → full lazy 순으로 읽으므로
     //        full이 hot보다 오래된 적이 없어야 hot 데이터를 덮어쓰지 않음.
-    await setSnap(SNAP_KEYS.COINS, items, SNAP_TTL.COINS);
+    const snapOk = await setSnap(SNAP_KEYS.COINS, items, SNAP_TTL.COINS);
+    if (!snapOk) {
+      await recordCronFailure('coins', 'snap:coins Redis 쓰기 실패');
+      return { ok: false, count: 0 };
+    }
     try {
       const hot = [...items]
         .sort((a, b) => {

--- a/workers/cron/src/crons/watchdog.js
+++ b/workers/cron/src/crons/watchdog.js
@@ -25,14 +25,15 @@ export async function watchdog(env) {
     return { ok: false, reason: 'no-redis' };
   }
 
-  // 5 크론 × 3 키(failCount / lastError / alertCooldown) + 1(lastOk:coins) = 16 키 한 번에 조회
+  // 5 크론 × 3 키(failCount / lastError / alertCooldown) + 2(lastOk:coins, stale cooldown) = 17 키
   const keys = [
     ...CRON_NAMES.flatMap((c) => [
       `cron:fail:${c}`,
       `cron:lastError:${c}`,
       `cron:watchdog:alert:${c}`,
     ]),
-    'cron:lastOk:coins',
+    'cron:lastOk:coins',              // index 15
+    'cron:watchdog:alert:coins:stale', // index 16 — fail alert(cron:watchdog:alert:coins)와 분리된 stale 전용 쿨다운
   ];
 
   let vals;
@@ -70,18 +71,17 @@ export async function watchdog(env) {
   }
 
   // coins 스테일니스 체크 — cron:fail 카운터와 별개로 장시간 미갱신 감지
-  // lastOk 가 null 이면 (첫 배포 직후 / 키 만료) 보수적으로 알림 생략.
-  // fail 카운터가 이미 누적 중이면 스킵 — 같은 cooldown 키 선점으로 실제 오류 알림 차단 방지.
-  const lastOkRaw = vals[CRON_NAMES.length * 3]; // index 15
-  if (lastOkRaw !== null) {
-    const coinsIdx = CRON_NAMES.indexOf('coins');
-    const coinsFailCount = parseInt(vals[coinsIdx * 3] || '0', 10);
-    const coinsCooldown = !!vals[coinsIdx * 3 + 2];
+  // - lastOk null 이면 (첫 배포 직후) 보수적으로 생략
+  // - stale 전용 쿨다운 키(cron:watchdog:alert:coins:stale) 사용 → fail alert cooldown과 충돌 없음
+  // - fail alert가 이미 발송 예정이면(alerts에 coins 존재) stale 스킵 — 중복 방지
+  const lastOkRaw = vals[CRON_NAMES.length * 3];     // index 15
+  const staleCooldown = !!vals[CRON_NAMES.length * 3 + 1]; // index 16
+  if (lastOkRaw !== null && !staleCooldown) {
     const lastOkMs = parseInt(lastOkRaw, 10);
     const ageMs = Number.isFinite(lastOkMs) ? Date.now() - lastOkMs : 0;
-    if (coinsFailCount === 0 && ageMs > COINS_STALE_MS && !coinsCooldown && !alerts.some((a) => a.cron === 'coins')) {
+    if (ageMs > COINS_STALE_MS && !alerts.some((a) => a.cron === 'coins')) {
       alerts.push({
-        cron: 'coins',
+        cron: 'coins:stale',
         failCount: 0,
         lastErrorMsg: `마지막 성공 ${Math.round(ageMs / 60000)}분 전 — 스케줄러 정지 의심`,
       });

--- a/workers/cron/src/crons/watchdog.js
+++ b/workers/cron/src/crons/watchdog.js
@@ -44,6 +44,7 @@ export async function watchdog(env) {
     return { ok: false, reason: 'mget-failed' };
   }
 
+  const baseLen = CRON_NAMES.length * 3; // 5 × 3 = 15; lastOk=15, staleCooldown=16
   const alerts = [];
   for (let i = 0; i < CRON_NAMES.length; i++) {
     const failCount = parseInt(vals[i * 3] || '0', 10);
@@ -74,8 +75,8 @@ export async function watchdog(env) {
   // - lastOk null 이면 (첫 배포 직후) 보수적으로 생략
   // - stale 전용 쿨다운 키(cron:watchdog:alert:coins:stale) 사용 → fail alert cooldown과 충돌 없음
   // - fail alert가 이미 발송 예정이면(alerts에 coins 존재) stale 스킵 — 중복 방지
-  const lastOkRaw = vals[CRON_NAMES.length * 3];     // index 15
-  const staleCooldown = !!vals[CRON_NAMES.length * 3 + 1]; // index 16
+  const lastOkRaw = vals[baseLen];       // index 15
+  const staleCooldown = !!vals[baseLen + 1]; // index 16
   if (lastOkRaw !== null && !staleCooldown) {
     const lastOkMs = parseInt(lastOkRaw, 10);
     const ageMs = Number.isFinite(lastOkMs) ? Date.now() - lastOkMs : 0;

--- a/workers/cron/src/crons/watchdog.js
+++ b/workers/cron/src/crons/watchdog.js
@@ -70,13 +70,16 @@ export async function watchdog(env) {
   }
 
   // coins 스테일니스 체크 — cron:fail 카운터와 별개로 장시간 미갱신 감지
-  // lastOk 가 null 이면 (첫 배포 직후 / 키 만료) 보수적으로 알림 생략
+  // lastOk 가 null 이면 (첫 배포 직후 / 키 만료) 보수적으로 알림 생략.
+  // fail 카운터가 이미 누적 중이면 스킵 — 같은 cooldown 키 선점으로 실제 오류 알림 차단 방지.
   const lastOkRaw = vals[CRON_NAMES.length * 3]; // index 15
   if (lastOkRaw !== null) {
     const coinsIdx = CRON_NAMES.indexOf('coins');
+    const coinsFailCount = parseInt(vals[coinsIdx * 3] || '0', 10);
     const coinsCooldown = !!vals[coinsIdx * 3 + 2];
-    const ageMs = Date.now() - parseInt(lastOkRaw, 10);
-    if (ageMs > COINS_STALE_MS && !coinsCooldown && !alerts.some((a) => a.cron === 'coins')) {
+    const lastOkMs = parseInt(lastOkRaw, 10);
+    const ageMs = Number.isFinite(lastOkMs) ? Date.now() - lastOkMs : 0;
+    if (coinsFailCount === 0 && ageMs > COINS_STALE_MS && !coinsCooldown && !alerts.some((a) => a.cron === 'coins')) {
       alerts.push({
         cron: 'coins',
         failCount: 0,

--- a/workers/cron/src/crons/watchdog.js
+++ b/workers/cron/src/crons/watchdog.js
@@ -9,6 +9,7 @@ import { getRedis } from '../price-cache.js';
 const CRON_NAMES = ['coins', 'kr', 'us', 'signal-accuracy', 'briefing'];
 const FAIL_THRESHOLD = 3;         // 누적 실패 3회 이상
 const COOLDOWN_SEC = 3600;        // 같은 크론 재알림 쿨다운 1h
+const COINS_STALE_MS = 10 * 60 * 1000; // coins 10분 이상 미갱신 시 스테일 감지
 const CF_ACCOUNT_ID = '43055b37765f34c1a1d7173a46ff5b92';
 
 export async function watchdog(env) {
@@ -24,12 +25,15 @@ export async function watchdog(env) {
     return { ok: false, reason: 'no-redis' };
   }
 
-  // 5 크론 × 3 키(failCount / lastError / alertCooldown) = 15 키 한 번에 조회
-  const keys = CRON_NAMES.flatMap((c) => [
-    `cron:fail:${c}`,
-    `cron:lastError:${c}`,
-    `cron:watchdog:alert:${c}`,
-  ]);
+  // 5 크론 × 3 키(failCount / lastError / alertCooldown) + 1(lastOk:coins) = 16 키 한 번에 조회
+  const keys = [
+    ...CRON_NAMES.flatMap((c) => [
+      `cron:fail:${c}`,
+      `cron:lastError:${c}`,
+      `cron:watchdog:alert:${c}`,
+    ]),
+    'cron:lastOk:coins',
+  ];
 
   let vals;
   try {
@@ -63,6 +67,22 @@ export async function watchdog(env) {
       failCount,
       lastErrorMsg,
     });
+  }
+
+  // coins 스테일니스 체크 — cron:fail 카운터와 별개로 장시간 미갱신 감지
+  // lastOk 가 null 이면 (첫 배포 직후 / 키 만료) 보수적으로 알림 생략
+  const lastOkRaw = vals[CRON_NAMES.length * 3]; // index 15
+  if (lastOkRaw !== null) {
+    const coinsIdx = CRON_NAMES.indexOf('coins');
+    const coinsCooldown = !!vals[coinsIdx * 3 + 2];
+    const ageMs = Date.now() - parseInt(lastOkRaw, 10);
+    if (ageMs > COINS_STALE_MS && !coinsCooldown && !alerts.some((a) => a.cron === 'coins')) {
+      alerts.push({
+        cron: 'coins',
+        failCount: 0,
+        lastErrorMsg: `마지막 성공 ${Math.round(ageMs / 60000)}분 전 — 스케줄러 정지 의심`,
+      });
+    }
   }
 
   if (alerts.length === 0) {

--- a/workers/cron/src/price-cache.js
+++ b/workers/cron/src/price-cache.js
@@ -113,15 +113,12 @@ export async function recordCronFailure(cronName, errorMessage) {
   } catch (e) { console.error(`[price-cache] recordCronFailure 실패:`, e); }
 }
 
-// 크론 정상 완료 시 호출 — lastOk 타임스탬프 갱신 + fail 카운터 리셋
-// TTL 없음: 장기 장애(수 시간+) 시에도 키 만료로 감지가 끊기지 않도록 영구 유지.
-//           cron 정상 실행마다 overwrite되므로 orphan 키 걱정 없음.
+// 크론 정상 완료 시 호출 — lastOk 타임스탬프만 갱신.
+// TTL 없음: 장기 장애 시에도 키 만료로 감지가 끊기지 않도록 영구 유지.
+// cron:fail은 건드리지 않음 — 1h TTL 자연 만료. del 시 flapping 감지 불가.
 export async function recordCronSuccess(cronName) {
   if (!_redis) return;
   try {
-    await Promise.all([
-      _redis.set(`cron:lastOk:${cronName}`, Date.now()),
-      _redis.del(`cron:fail:${cronName}`),
-    ]);
+    await _redis.set(`cron:lastOk:${cronName}`, Date.now());
   } catch (e) { console.error(`[price-cache] recordCronSuccess 실패:`, e); }
 }

--- a/workers/cron/src/price-cache.js
+++ b/workers/cron/src/price-cache.js
@@ -112,3 +112,15 @@ export async function recordCronFailure(cronName, errorMessage) {
     ]);
   } catch (e) { console.error(`[price-cache] recordCronFailure 실패:`, e); }
 }
+
+// 크론 정상 완료 시 호출 — lastOk 타임스탬프 갱신 + fail 카운터 리셋
+// TTL 1800s: 5분 주기 cron이 30분간 침묵하면 키 만료 → watchdog 스테일니스 감지
+export async function recordCronSuccess(cronName) {
+  if (!_redis) return;
+  try {
+    await Promise.all([
+      _redis.set(`cron:lastOk:${cronName}`, Date.now(), { ex: 1800 }),
+      _redis.del(`cron:fail:${cronName}`),
+    ]);
+  } catch (e) { console.error(`[price-cache] recordCronSuccess 실패:`, e); }
+}

--- a/workers/cron/src/price-cache.js
+++ b/workers/cron/src/price-cache.js
@@ -114,12 +114,13 @@ export async function recordCronFailure(cronName, errorMessage) {
 }
 
 // 크론 정상 완료 시 호출 — lastOk 타임스탬프 갱신 + fail 카운터 리셋
-// TTL 1800s: 5분 주기 cron이 30분간 침묵하면 키 만료 → watchdog 스테일니스 감지
+// TTL 없음: 장기 장애(수 시간+) 시에도 키 만료로 감지가 끊기지 않도록 영구 유지.
+//           cron 정상 실행마다 overwrite되므로 orphan 키 걱정 없음.
 export async function recordCronSuccess(cronName) {
   if (!_redis) return;
   try {
     await Promise.all([
-      _redis.set(`cron:lastOk:${cronName}`, Date.now(), { ex: 1800 }),
+      _redis.set(`cron:lastOk:${cronName}`, Date.now()),
       _redis.del(`cron:fail:${cronName}`),
     ]);
   } catch (e) { console.error(`[price-cache] recordCronSuccess 실패:`, e); }


### PR DESCRIPTION
## 개요

이슈 #265 (snap:coins 6.7h+ 정지 무음) 재발 방지를 위한 P1 수정.
원인 분석: `recordCronFailure` 미호출 → watchdog 무음 → `cron:lastOk:coins` 미기록 → staleness 감지 불가.

Closes #266

## 변경 내용

### `price-cache.js`
- `recordCronSuccess(cronName)` 신규 추가 — `cron:lastOk:{name}` 타임스탬프 영구 저장 (TTL 없음)
- `cron:fail` del 제거 — TTL 자연 만료 방식 유지 (flapping 감지 보존)

### `update-coins.js`
- `items.length === 0` 방어 추가 (`recordCronFailure` 호출 후 early return)
- `setSnap` 반환값 체크 — false 시 `recordCronFailure` 후 early return
- `recordCronSuccess('coins')` full snap 직후로 이동 (hot snap은 best-effort)

### `watchdog.js`
- `COINS_STALE_MS = 10 * 60 * 1000` 상수 추가
- mget keys에 `cron:lastOk:coins`(index 15), `cron:watchdog:alert:coins:stale`(index 16) 추가
- `baseLen = CRON_NAMES.length * 3` 변수 추출 (magic index 제거)
- staleness 감지: fail alert cooldown과 독립된 `cron:watchdog:alert:coins:stale` 키 사용
- `coins:stale` cron 이름으로 fail alert와 충돌 없이 Discord 발송

## 테스트

- `recordCronSuccess` → Redis `cron:lastOk:coins` 저장 확인
- `setSnap` false 반환 시 `recordCronFailure` 호출 경로 확인
- watchdog staleness 체크: lastOk 10분+ 이전 시 `coins:stale` alert 생성

---
🤖 code-reviewer (Claude Opus): PASS (Codex gate: SKIP_CODEX_REVIEW)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신뢰성 개선**
  * 코인 데이터 업데이트 실패 감지 및 오류 처리 강화
  * 코인 데이터 업데이트 지연 상태에 대한 모니터링 시스템 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->