### PR TITLE
fix: 국장 공포탐욕지수 실패 원인 상태 분리

### DIFF
--- a/api/kr-fear-greed.js
+++ b/api/kr-fear-greed.js
@@ -133,62 +133,67 @@ function foreignToScore(net) {
 export default async function handler(req, res) {
   const hantooReady = !!(process.env.HANTOO_APP_KEY && process.env.HANTOO_APP_SECRET);
 
-  // 모든 응답에 CORS 헤더 공통 적용 — 에러 응답 포함
   res.setHeader('Access-Control-Allow-Origin', '*');
+
+  // HANTOO 환경변수 미설정 — Redis 캐시 먼저 시도, 없으면 not_configured
+  if (!hantooReady) {
+    let cached = null;
+    try { cached = await getSnap(CACHE_KEY); } catch {}
+    if (cached) {
+      const ageSec = Math.round((Date.now() - (cached.savedAt ?? 0)) / 1000);
+      res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=60');
+      return res.json({ ...cached, status: 'stale_cache', cached: true, ageSec });
+    }
+    res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=60');
+    return res.json({ score: null, status: 'not_configured', closed: false, label: '설정 필요' });
+  }
 
   try {
     const today = todayStr();
+    const token = await getHantooToken();
 
-    // HANTOO 키 없으면 전체 불가 (VKOSPI + 외국인 모두 한투 의존)
-    let vkospiRes, kospiRes, kosdaqRes;
-    if (hantooReady) {
-      const token = await getHantooToken();
-      [vkospiRes, kospiRes, kosdaqRes] = await Promise.allSettled([
-        fetchVkospiKis(token),
-        fetchForeignNet(token, '0001', today),  // KOSPI
-        fetchForeignNet(token, '1001', today),  // KOSDAQ
-      ]);
-    } else {
-      vkospiRes = { status: 'rejected', reason: 'HANTOO not configured' };
-      kospiRes  = { status: 'rejected', reason: 'HANTOO not configured' };
-      kosdaqRes = { status: 'rejected', reason: 'HANTOO not configured' };
+    const [vkospiRes, kospiRes, kosdaqRes] = await Promise.allSettled([
+      fetchVkospiKis(token),
+      fetchForeignNet(token, '0001', today),  // KOSPI
+      fetchForeignNet(token, '1001', today),  // KOSDAQ
+    ]);
+
+    // vkospiSource 추적: KIS 성공 → 'kis', 실패 후 Naver → 'naver', 모두 실패 → null
+    let vkospiFinal = vkospiRes.status === 'fulfilled' ? vkospiRes.value : null;
+    let vkospiSource = vkospiFinal != null ? 'kis' : null;
+
+    if (vkospiFinal == null) {
+      try {
+        vkospiFinal = await fetchVkospiNaver();
+        vkospiSource = 'naver';
+      } catch (e) {
+        console.warn('[kr-fear-greed] Naver VKOSPI fallback failed:', e.message);
+      }
     }
 
-    const vkospi = vkospiRes.status === 'fulfilled' ? vkospiRes.value : null;
-
-    // 실제로 성공한 외국인 데이터만 합산 (실패는 0으로 대체하지 않음)
     const foreignAvailable = kospiRes.status === 'fulfilled' || kosdaqRes.status === 'fulfilled';
     const foreignNet = foreignAvailable
       ? (kospiRes.status  === 'fulfilled' ? kospiRes.value  : 0)
       + (kosdaqRes.status === 'fulfilled' ? kosdaqRes.value : 0)
       : null;
+    const foreignSource = foreignAvailable ? 'kis' : null;
 
-    // 한투 VKOSPI 실패 시 Naver fallback (장 마감/주말에도 전일 종가 반환)
-    // 외국인 데이터는 Naver fallback 없음 — KIS 7일 날짜 범위 확장으로 주말 대응
-    let vkospiFinal = vkospi;
-    const foreignNetFinal = foreignNet;
-    const foreignAvailableFinal = foreignAvailable;
-
-    if (vkospiFinal == null) {
-      try { vkospiFinal = await fetchVkospiNaver(); } catch (e) { console.warn('[kr-fear-greed] Naver VKOSPI fallback failed:', e.message); }
-    }
-
-    // 모두 실패 = Redis 캐시 → 그것도 없으면 closed
-    if (vkospiFinal == null && !foreignAvailableFinal) {
+    // 모두 실패 → Redis 캐시, 그것도 없으면 error
+    if (vkospiFinal == null && !foreignAvailable) {
       let cached = null;
       try { cached = await getSnap(CACHE_KEY); } catch {}
       if (cached) {
+        const ageSec = Math.round((Date.now() - (cached.savedAt ?? 0)) / 1000);
         res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=60');
-        return res.json({ ...cached, cached: true });
+        return res.json({ ...cached, status: 'stale_cache', cached: true, ageSec });
       }
       res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=60');
-      return res.json({ score: null, closed: true, label: '데이터 없음' });
+      return res.json({ score: null, status: 'error', closed: true, label: '데이터 없음' });
     }
 
     const vs = vkospiFinal != null ? vkospiToScore(vkospiFinal) : null;
-    const fs = foreignNetFinal != null ? foreignToScore(foreignNetFinal) : null;
+    const fs = foreignNet    != null ? foreignToScore(foreignNet) : null;
 
-    // 합성: VKOSPI 60% + 외국인 40% (한쪽 실패 시 나머지 100%)
     let score;
     if (vs != null && fs != null) {
       score = Math.round(vs * VKOSPI_WEIGHT + fs * FOREIGN_WEIGHT);
@@ -198,8 +203,21 @@ export default async function handler(req, res) {
       score = fs;
     }
 
-    const payload = { score, vkospi: vkospiFinal, vkospiScore: vs, foreignNet: foreignNetFinal, foreignScore: fs };
-    // 성공 시 Redis에 저장 (48시간 — 주말/공휴일 대비)
+    // VKOSPI만 성공한 경우 partial
+    const status = foreignAvailable ? 'ok' : 'partial';
+    const sources = { vkospi: vkospiSource, foreign: foreignSource };
+
+    const payload = {
+      score,
+      status,
+      sources,
+      closed: false,
+      vkospi: vkospiFinal,
+      vkospiScore: vs,
+      foreignNet,
+      foreignScore: fs,
+      savedAt: Date.now(),
+    };
     try { await setSnap(CACHE_KEY, payload, CACHE_TTL); } catch {}
 
     res.setHeader('Cache-Control', 's-maxage=120, stale-while-revalidate=30');
@@ -207,6 +225,6 @@ export default async function handler(req, res) {
   } catch (e) {
     console.error('[kr-fear-greed]', e.message);
     res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=60');
-    res.json({ score: null, closed: true, label: '데이터 없음' });
+    res.json({ score: null, status: 'error', closed: true, label: '데이터 없음' });
   }
 }

--- a/api/kr-fear-greed.js
+++ b/api/kr-fear-greed.js
@@ -140,7 +140,7 @@ export default async function handler(req, res) {
     let cached = null;
     try { cached = await getSnap(CACHE_KEY); } catch {}
     if (cached) {
-      const ageSec = Math.round((Date.now() - (cached.savedAt ?? 0)) / 1000);
+      const ageSec = cached.savedAt ? Math.round((Date.now() - cached.savedAt) / 1000) : null;
       res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=60');
       return res.json({ ...cached, status: 'stale_cache', cached: true, ageSec });
     }
@@ -183,7 +183,7 @@ export default async function handler(req, res) {
       let cached = null;
       try { cached = await getSnap(CACHE_KEY); } catch {}
       if (cached) {
-        const ageSec = Math.round((Date.now() - (cached.savedAt ?? 0)) / 1000);
+        const ageSec = cached.savedAt ? Math.round((Date.now() - cached.savedAt) / 1000) : null;
         res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=60');
         return res.json({ ...cached, status: 'stale_cache', cached: true, ageSec });
       }
@@ -203,8 +203,8 @@ export default async function handler(req, res) {
       score = fs;
     }
 
-    // VKOSPI만 성공한 경우 partial
-    const status = foreignAvailable ? 'ok' : 'partial';
+    // 양쪽 모두 성공해야 ok, 한쪽이라도 실패하면 partial
+    const status = (vkospiFinal != null && foreignAvailable) ? 'ok' : 'partial';
     const sources = { vkospi: vkospiSource, foreign: foreignSource };
 
     const payload = {

--- a/src/components/home/widgets/MarketSentimentWidget.jsx
+++ b/src/components/home/widgets/MarketSentimentWidget.jsx
@@ -35,23 +35,23 @@ function toEasyFgLabel(score) {
 }
 
 // ── 공포탐욕 미니 게이지 (서브 컴포넌트) ──
-function FgMiniGauge({ emoji, marketLabel, score, isLoading, isError, closed }) {
+function FgMiniGauge({ emoji, marketLabel, score, isLoading, isError, closed, status }) {
   if (isLoading) return (
     <div className="flex items-center gap-2">
       <span className="text-[10px]">{emoji}</span>
       <div className="h-4 w-16 bg-[#F2F4F6] rounded animate-pulse" />
     </div>
   );
-  if (isError) return (
+  if (status === 'not_configured' || (isError && score == null)) return (
     <div className="flex items-center gap-2">
       <span className="text-[10px]">{emoji}</span>
       <span className="text-[10px] text-[#B0B8C1]">{marketLabel} —</span>
     </div>
   );
-  if (closed) return (
+  if (status === 'error' || (closed && score == null)) return (
     <div className="flex items-center gap-2">
       <span className="text-[10px]">{emoji}</span>
-      <span className="text-[10px] text-[#B0B8C1]">{marketLabel} 휴장</span>
+      <span className="text-[10px] text-[#B0B8C1]">{marketLabel} 데이터 없음</span>
     </div>
   );
 
@@ -63,6 +63,12 @@ function FgMiniGauge({ emoji, marketLabel, score, isLoading, isError, closed }) 
       <span className="text-[10px]">{emoji}</span>
       <span className="text-[11px] font-bold tabular-nums font-mono" style={{ color }}>{score}</span>
       <span className="text-[10px] font-medium" style={{ color }}>{label}</span>
+      {status === 'stale_cache' && (
+        <span className="text-[9px] text-[#B0B8C1]">캐시</span>
+      )}
+      {status === 'partial' && (
+        <span className="text-[9px] text-[#B0B8C1]">일부</span>
+      )}
     </div>
   );
 }
@@ -191,6 +197,7 @@ export default function MarketSentimentWidget({ allItems = [] }) {
               isLoading={kr.isLoading}
               isError={kr.isError}
               closed={kr.data?.closed}
+              status={kr.data?.status}
             />
             <FgMiniGauge
               emoji="🇺🇸"


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-2.5-pro)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #271

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캐시된 데이터 상태 표시 기능 추가
  * 데이터 소스 정보 표시 기능 추가
  * 부분 데이터 및 불완전한 응답 상태 표시 기능 추가
  * 자세한 점수 구성요소 및 저장 시간 정보 제공

* **개선 사항**
  * 데이터 오류 처리 및 폴백 메커니즘 강화
  * 응답 구조 확장으로 더 많은 상태 정보 제공

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/278)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->