### PR TITLE
feat(#275): 시그널 객체 source/confidence/reasons 구조 확장

### DIFF
--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -48,7 +48,7 @@ function _generateId() {
 // ─── 시그널 CRUD ────────────────────────────────────────────
 
 /** 시그널 객체 생성 (저장소에 추가하지 않음) */
-export function createSignal({ type, symbol, name, market, direction, strength, title, meta }) {
+export function createSignal({ type, symbol, name, market, direction, strength, title, meta, source, confidence, reasons }) {
   const now = Date.now();
   return {
     id: _generateId(),
@@ -60,6 +60,9 @@ export function createSignal({ type, symbol, name, market, direction, strength, 
     strength: Math.max(1, Math.min(5, strength ?? 1)),
     title: title ?? '',
     meta: meta ?? {},
+    source: source ?? 'client',
+    confidence: confidence ?? null,
+    reasons: reasons ?? null,
     timestamp: now,
     expiresAt: now + getTTL(type),
   };
@@ -304,6 +307,13 @@ export function createInvestorSignal(symbol, name, market, type, consecutiveDays
     strength,
     title,
     meta: { consecutiveDays, amount, currentPrice },
+    source: 'client',
+    confidence: Math.min(0.5 + consecutiveDays * 0.1, 1.0),
+    reasons: [
+      { label: '연속', value: `${consecutiveDays}일` },
+      { label: '금액', value: _formatAmount(amount) },
+      { label: '투자자', value: investorLabel },
+    ],
   });
   return addSignal(signal);
 }
@@ -342,6 +352,12 @@ export function createVolumeSignal(symbol, name, market, currentVol, avgVol, cha
     strength,
     title,
     meta: { currentVol, avgVol, ratio, changePct: pct, currentPrice },
+    source: 'client',
+    confidence: Math.min(0.4 + (ratio / 20), 1.0),
+    reasons: [
+      { label: '거래량', value: `평소 ${ratio.toFixed(1)}배` },
+      ...(Math.abs(pct) >= 0.5 ? [{ label: '가격', value: `${pct > 0 ? '+' : ''}${pct.toFixed(1)}%` }] : []),
+    ],
   });
   return addSignal(signal);
 }
@@ -599,6 +615,13 @@ export function createSmartMoneySignal(symbol, name, foreignDays, instDays, tota
     direction, strength,
     title,
     meta: { name, foreignDays, instDays, totalAmt, action, currentPrice },
+    source: 'client',
+    confidence: Math.min(0.5 + Math.min(foreignDays, instDays) * 0.1, 1.0),
+    reasons: [
+      { label: '외국인', value: `${foreignDays}일` },
+      { label: '기관', value: `${instDays}일` },
+      { label: '합산', value: _formatAmount(totalAmt) },
+    ],
   }));
 }
 

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -62,7 +62,7 @@ export function createSignal({ type, symbol, name, market, direction, strength, 
     meta: meta ?? {},
     source: source ?? 'client',
     confidence: confidence ?? null,
-    reasons: reasons ?? null,
+    reasons: reasons ?? [],
     timestamp: now,
     expiresAt: now + getTTL(type),
   };
@@ -353,7 +353,7 @@ export function createVolumeSignal(symbol, name, market, currentVol, avgVol, cha
     title,
     meta: { currentVol, avgVol, ratio, changePct: pct, currentPrice },
     source: 'client',
-    confidence: Math.min(0.4 + (ratio / 20), 1.0),
+    confidence: Number.isFinite(ratio) ? Math.min(0.4 + (ratio / 20), 1.0) : null,
     reasons: [
       { label: '거래량', value: `평소 ${ratio.toFixed(1)}배` },
       ...(Math.abs(pct) >= 0.5 ? [{ label: '가격', value: `${pct > 0 ? '+' : ''}${pct.toFixed(1)}%` }] : []),

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -312,7 +312,7 @@ export function createInvestorSignal(symbol, name, market, type, consecutiveDays
     reasons: Number.isFinite(consecutiveDays)
       ? [
           { label: '연속', value: `${consecutiveDays}일` },
-          { label: '금액', value: _formatAmount(amount) },
+          ...(Number.isFinite(amount) ? [{ label: '금액', value: _formatAmount(amount) }] : []),
           ...(investorLabel != null ? [{ label: '투자자', value: investorLabel }] : []),
         ]
       : [],
@@ -355,7 +355,7 @@ export function createVolumeSignal(symbol, name, market, currentVol, avgVol, cha
     title,
     meta: { currentVol, avgVol, ratio, changePct: pct, currentPrice },
     source: 'client',
-    confidence: Number.isFinite(ratio) ? Math.min(0.4 + (ratio / 20), 1.0) : null,
+    confidence: Number.isFinite(ratio) ? Math.min(Math.max(0, 0.4 + (ratio / 20)), 1.0) : null,
     reasons: Number.isFinite(ratio)
       ? [
           { label: '거래량', value: `평소 ${ratio.toFixed(1)}배` },
@@ -625,7 +625,7 @@ export function createSmartMoneySignal(symbol, name, foreignDays, instDays, tota
       ? [
           { label: '외국인', value: `${foreignDays}일` },
           { label: '기관', value: `${instDays}일` },
-          { label: '합산', value: _formatAmount(totalAmt) },
+          ...(Number.isFinite(totalAmt) ? [{ label: '합산', value: _formatAmount(totalAmt) }] : []),
         ]
       : [],
   }));

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -308,7 +308,7 @@ export function createInvestorSignal(symbol, name, market, type, consecutiveDays
     title,
     meta: { consecutiveDays, amount, currentPrice },
     source: 'client',
-    confidence: Math.min(0.5 + consecutiveDays * 0.1, 1.0),
+    confidence: Number.isFinite(consecutiveDays) ? Math.min(0.5 + consecutiveDays * 0.1, 1.0) : null,
     reasons: [
       { label: '연속', value: `${consecutiveDays}일` },
       { label: '금액', value: _formatAmount(amount) },
@@ -618,7 +618,7 @@ export function createSmartMoneySignal(symbol, name, foreignDays, instDays, tota
     title,
     meta: { name, foreignDays, instDays, totalAmt, action, currentPrice },
     source: 'client',
-    confidence: Math.min(0.5 + Math.min(foreignDays, instDays) * 0.1, 1.0),
+    confidence: Number.isFinite(foreignDays) && Number.isFinite(instDays) ? Math.min(0.5 + Math.min(foreignDays, instDays) * 0.1, 1.0) : null,
     reasons: [
       { label: '외국인', value: `${foreignDays}일` },
       { label: '기관', value: `${instDays}일` },

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -308,12 +308,12 @@ export function createInvestorSignal(symbol, name, market, type, consecutiveDays
     title,
     meta: { consecutiveDays, amount, currentPrice },
     source: 'client',
-    confidence: Number.isFinite(consecutiveDays) ? Math.min(0.5 + consecutiveDays * 0.1, 1.0) : null,
+    confidence: Number.isFinite(consecutiveDays) ? Math.min(Math.max(0, 0.5 + consecutiveDays * 0.1), 1.0) : null,
     reasons: Number.isFinite(consecutiveDays)
       ? [
           { label: '연속', value: `${consecutiveDays}일` },
           { label: '금액', value: _formatAmount(amount) },
-          { label: '투자자', value: investorLabel },
+          ...(investorLabel != null ? [{ label: '투자자', value: investorLabel }] : []),
         ]
       : [],
   });
@@ -620,7 +620,7 @@ export function createSmartMoneySignal(symbol, name, foreignDays, instDays, tota
     title,
     meta: { name, foreignDays, instDays, totalAmt, action, currentPrice },
     source: 'client',
-    confidence: Number.isFinite(foreignDays) && Number.isFinite(instDays) ? Math.min(0.5 + Math.min(foreignDays, instDays) * 0.1, 1.0) : null,
+    confidence: Number.isFinite(foreignDays) && Number.isFinite(instDays) ? Math.min(Math.max(0, 0.5 + Math.min(foreignDays, instDays) * 0.1), 1.0) : null,
     reasons: Number.isFinite(foreignDays) && Number.isFinite(instDays)
       ? [
           { label: '외국인', value: `${foreignDays}일` },

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -354,10 +354,12 @@ export function createVolumeSignal(symbol, name, market, currentVol, avgVol, cha
     meta: { currentVol, avgVol, ratio, changePct: pct, currentPrice },
     source: 'client',
     confidence: Number.isFinite(ratio) ? Math.min(0.4 + (ratio / 20), 1.0) : null,
-    reasons: [
-      { label: '거래량', value: `평소 ${ratio.toFixed(1)}배` },
-      ...(Math.abs(pct) >= 0.5 ? [{ label: '가격', value: `${pct > 0 ? '+' : ''}${pct.toFixed(1)}%` }] : []),
-    ],
+    reasons: Number.isFinite(ratio)
+      ? [
+          { label: '거래량', value: `평소 ${ratio.toFixed(1)}배` },
+          ...(Math.abs(pct) >= 0.5 ? [{ label: '가격', value: `${pct > 0 ? '+' : ''}${pct.toFixed(1)}%` }] : []),
+        ]
+      : [],
   });
   return addSignal(signal);
 }

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -309,11 +309,13 @@ export function createInvestorSignal(symbol, name, market, type, consecutiveDays
     meta: { consecutiveDays, amount, currentPrice },
     source: 'client',
     confidence: Number.isFinite(consecutiveDays) ? Math.min(0.5 + consecutiveDays * 0.1, 1.0) : null,
-    reasons: [
-      { label: '연속', value: `${consecutiveDays}일` },
-      { label: '금액', value: _formatAmount(amount) },
-      { label: '투자자', value: investorLabel },
-    ],
+    reasons: Number.isFinite(consecutiveDays)
+      ? [
+          { label: '연속', value: `${consecutiveDays}일` },
+          { label: '금액', value: _formatAmount(amount) },
+          { label: '투자자', value: investorLabel },
+        ]
+      : [],
   });
   return addSignal(signal);
 }
@@ -619,11 +621,13 @@ export function createSmartMoneySignal(symbol, name, foreignDays, instDays, tota
     meta: { name, foreignDays, instDays, totalAmt, action, currentPrice },
     source: 'client',
     confidence: Number.isFinite(foreignDays) && Number.isFinite(instDays) ? Math.min(0.5 + Math.min(foreignDays, instDays) * 0.1, 1.0) : null,
-    reasons: [
-      { label: '외국인', value: `${foreignDays}일` },
-      { label: '기관', value: `${instDays}일` },
-      { label: '합산', value: _formatAmount(totalAmt) },
-    ],
+    reasons: Number.isFinite(foreignDays) && Number.isFinite(instDays)
+      ? [
+          { label: '외국인', value: `${foreignDays}일` },
+          { label: '기관', value: `${instDays}일` },
+          { label: '합산', value: _formatAmount(totalAmt) },
+        ]
+      : [],
   }));
 }
 


### PR DESCRIPTION
## 요약
- `createSignal`에 `source('client'|'server'|'hybrid')`, `confidence(0~1)`, `reasons([{label,value}])` 선택적 필드 추가
- `createInvestorSignal`, `createVolumeSignal`, `createSmartMoneySignal` 3종에 reasons 태그 및 confidence 적용
- 모든 필드에 `Number.isFinite` NaN 가드 + `Math.max(0,...)` 음수 하한 클램프 적용

## 검증
- architect (Opus): PASS
- code-reviewer (Opus): PASS
- Gemini gate: PASS

Closes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 신호에 출처, 신뢰도 및 근거 정보 필드가 추가되었습니다.
  * 신호 생성 시 보다 상세한 구조화된 데이터를 포함하도록 업데이트되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/280)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->