### PR TITLE
feat(#275): 시그널 카드 reasons 태그 + 신뢰도 pill UI

### DIFF
--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -398,6 +398,21 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
                     <path d="m6 9 6 6 6-6" />
                   </svg>}
                 </button>
+                {/* reasons 태그 — source/confidence/reasons 구조 확장(#275) 적용 시그널에만 표시 */}
+                {signal.reasons?.length > 0 && (
+                  <div className="px-2 pb-1.5 -mt-1 flex flex-wrap gap-1">
+                    {signal.reasons.map((r, i) => (
+                      <span key={i} className="text-[10px] px-1.5 py-0.5 rounded-full bg-[#F2F4F6] text-[#6B7684] font-medium">
+                        {r.label} {r.value}
+                      </span>
+                    ))}
+                    {signal.confidence != null && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-[#EDF4FF] text-[#1764ED] font-medium">
+                        신뢰 {Math.round(signal.confidence * 100)}%
+                      </span>
+                    )}
+                  </div>
+                )}
                 {/* 내러티브 컨텍스트 — "왜 발화했는가" (매칭 부족 시 영역 숨김) */}
                 {narrative && !isExpanded && (
                   <div className="px-2 pb-2 -mt-1 text-[11px] text-[#6B7684] dark:text-[#8B95A1] leading-snug">

--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -401,14 +401,14 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
                 {/* reasons 태그 — source/confidence/reasons 구조 확장(#275) 적용 시그널에만 표시 */}
                 {signal.reasons?.length > 0 && (
                   <div className="px-2 pb-1.5 -mt-1 flex flex-wrap gap-1">
-                    {signal.reasons.map((r, i) => (
-                      <span key={i} className="text-[10px] px-1.5 py-0.5 rounded-full bg-[#F2F4F6] text-[#6B7684] font-medium">
+                    {signal.reasons.filter(r => r.label).map((r) => (
+                      <span key={r.label} className="text-[10px] px-1.5 py-0.5 rounded-full bg-[#F2F4F6] dark:bg-[#2D3748] text-[#6B7684] dark:text-[#8B95A1] font-medium">
                         {r.label} {r.value}
                       </span>
                     ))}
                     {signal.confidence != null && (
-                      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-[#EDF4FF] text-[#1764ED] font-medium">
-                        신뢰 {Math.round(signal.confidence * 100)}%
+                      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-[#EDF4FF] dark:bg-[#1C2D4A] text-[#1764ED] dark:text-[#4D9EFF] font-medium">
+                        신뢰 {Math.round(Math.min(Math.max(signal.confidence, 0), 1) * 100)}%
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
## 요약
- `signal.reasons[]`가 있는 시그널에 키워드 태그(연속 N일, 금액, 투자자 등) 표시
- `signal.confidence`가 있는 시그널에 신뢰도 % pill 표시
- 다크모드 지원, stable key, confidence 클램프(0~1), label 필터 포함
- `source` 필드는 UI에 노출하지 않음

## 검증
- code-reviewer (Opus): PASS
- Gemini gate: PASS
- 빌드: PASS

Closes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 신호 목록의 각 항목에 신뢰도 배지("신뢰 XX%")와 이유 태그 영역이 표시됩니다. 신뢰도는 백분율 형식으로 변환되어 표시되며, 이유 항목이 있을 때만 태그가 렌더링됩니다. 모든 배지는 pill 스타일로 스타일링됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/281)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->