### PR TITLE
fix: KRX EUC-KR 모지바케 방어 — resolveKrName U+FFFD 감지 폴백 (#283)

### DIFF
--- a/workers/cron/src/crons/update-kr.js
+++ b/workers/cron/src/crons/update-kr.js
@@ -7,8 +7,9 @@ import { getHantooToken, HANTOO_BASE } from '../hantoo-token.js';
 import KR_STOCK_NAMES from '../kr-stock-names.json';
 
 // KRX ISU_ABBRV가 비거나 symbol과 같으면 정적 테이블로 보완
+// U+FFFD(대체문자) 포함 시 EUC-KR 오인코딩 오염으로 판단 → 정적 테이블 폴백
 function resolveKrName(symbol, apiName) {
-  if (apiName && apiName !== symbol) return apiName;
+  if (apiName && apiName !== symbol && !apiName.includes('�')) return apiName;
   return KR_STOCK_NAMES[symbol] || symbol;
 }
 


### PR DESCRIPTION
## 변경 내용

`workers/cron/src/crons/update-kr.js`의 `resolveKrName` 함수에 인코딩 오염 감지 로직 추가.

## 문제

KRX API가 EUC-KR로 응답할 때 `res.json()`이 UTF-8로 오디코딩하여 U+FFFD(대체문자) 포함 문자열이 생성됨.
`resolveKrName`이 non-empty인 apiName을 그대로 사용하므로, 깨진 종목명이 Redis에 저장되고 UI에 노출됨.

사용자 보고: "LG화학" → "LG?????" 형태로 노출 (2026-05-12)

## 수정

```js
// 기존
if (apiName && apiName !== symbol) return apiName;

// 수정 — U+FFFD 포함 시 인코딩 오염으로 판단, 정적 테이블 폴백
if (apiName && apiName !== symbol && !apiName.includes('')) return apiName;
```

## 영향 범위

- `workers/cron/src/crons/update-kr.js` 1줄 변경
- KRX/Naver/한투 모든 데이터 소스 경로에서 `resolveKrName`이 공유하므로 전체 커버

Closes #283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 한국 주식 종목명 인코딩 오류 처리 개선 - EUC-KR 인코딩 오류로 인한 종목명 손상 문제를 감지하고 처리하는 기능이 강화되었습니다. 이제 잘못된 문자로 표시되는 종목명도 올바르게 처리됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/284)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->