### PR TITLE
fix: 시그널보드 로고 + 관심종목 폰트 잘림 (#285)

### DIFF
--- a/src/components/home/CommandCenterWidget.jsx
+++ b/src/components/home/CommandCenterWidget.jsx
@@ -356,13 +356,13 @@ function WatchlistMini({ watchedItems, popularItems, toggle, onItemClick }) {
                       {badge.label}
                     </span>
                     <TickerLogo item={item} size={20} />
-                    <span className="text-[15px] font-semibold text-[#191F28] truncate">{item.name}</span>
+                    <span className="text-[13px] font-semibold text-[#191F28] truncate">{item.name}</span>
                   </div>
                   <div className="flex items-center gap-2.5 flex-shrink-0 ml-2">
                     <span className="text-[13px] font-semibold tabular-nums font-mono" style={{ color }}>
                       {isUp ? '+' : ''}{(Number.isFinite(pct) ? pct : 0).toFixed(2)}%
                     </span>
-                    <span className="text-[15px] font-bold tabular-nums font-mono text-[#191F28]">
+                    <span className="text-[13px] font-bold tabular-nums font-mono text-[#191F28]">
                       {fmt(item.price || item.priceKrw || 0)}
                     </span>
                     {/* + / ✕ 버튼 */}

--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -350,7 +350,7 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
                   }`}
                 >
                   {signal.symbol && (
-                    <TickerLogo item={matchedItem || { symbol: signal.symbol, name: signal.name, _market: signal.market === 'kr' ? 'KR' : signal.market === 'us' ? 'US' : signal.market === 'crypto' ? 'COIN' : '' }} size={24} />
+                    <TickerLogo item={matchedItem || { symbol: signal.symbol, name: signal.name, _market: signal.market === 'kr' ? 'KR' : signal.market === 'us' ? 'US' : signal.market === 'crypto' ? 'COIN' : '', id: signal.market === 'crypto' ? signal.symbol : undefined }} size={24} />
                   )}
                   <span className="text-[14px] font-semibold flex-shrink-0" style={{ color: nameColor }}>
                     {extractName(signal)}

--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -350,7 +350,7 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
                   }`}
                 >
                   {signal.symbol && (
-                    <TickerLogo item={{ symbol: signal.symbol, name: signal.name, _market: signal.market === 'kr' ? 'KR' : signal.market === 'us' ? 'US' : signal.market === 'crypto' ? 'COIN' : '', id: signal.market === 'crypto' ? signal.symbol : undefined }} size={24} />
+                    <TickerLogo item={matchedItem || { symbol: signal.symbol, name: signal.name, _market: signal.market === 'kr' ? 'KR' : signal.market === 'us' ? 'US' : signal.market === 'crypto' ? 'COIN' : '' }} size={24} />
                   )}
                   <span className="text-[14px] font-semibold flex-shrink-0" style={{ color: nameColor }}>
                     {extractName(signal)}


### PR DESCRIPTION
## 변경 내용

### 1. 시그널보드 로고 누락 수정 (`SignalBoardWidget.jsx:353`)

기존: 코인 시그널에 `id: signal.symbol`("BTC") 전달 → CoinPaprika URL 생성 실패 → 이니셜 아바타 표시

수정: `allItemsLookup`으로 이미 계산된 `matchedItem`을 TickerLogo에 우선 전달.
코인의 경우 `matchedItem.id`가 CoinGecko ID("bitcoin")이므로 `COIN_PAPRIKA_IDS` 조회 → 정상 로고 URL 생성.

### 2. 관심종목 폰트 잘림 수정 (`CommandCenterWidget.jsx:359,365`)

기존: 데스크톱 리스트에서 name/price 모두 `text-[15px]` → 긴 종목명(KODEX 200 선물 인버스2X 등) 잘림

수정: `text-[15px]` → `text-[13px]` (name, price 모두)

## 영향 범위

- `src/components/home/SignalBoardWidget.jsx` — 로고 렌더링 1줄
- `src/components/home/CommandCenterWidget.jsx` — 관심종목 데스크톱 리스트 2줄

Closes #285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 감시 목록의 행 텍스트 크기를 줄여 데스크톱 리스트의 가독성을 개선했습니다.

* **Refactor**
  * 신호 보드에서 로고에 전달되는 항목 데이터를 우선 매칭된 항목으로 전달하도록 개선하여 표시에 일관성을 높였습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/286)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->