### PR TITLE
feat: HeroSignalCard 봇 배지 + 성적표 브리지 (#287)

### DIFF
--- a/src/components/home/CommandCenterWidget.jsx
+++ b/src/components/home/CommandCenterWidget.jsx
@@ -1,5 +1,6 @@
 // 커맨드 센터 위젯 — MarketPulse + Sentiment + HeroSignal + Watchlist + EventTicker 통합
 import { useMemo } from 'react';
+import { useSignalAccuracy } from '../../hooks/useSignalAccuracy';
 import { useSignals, useTopSignals } from '../../hooks/useSignals';
 import { useWatchlistAlert } from '../../hooks/useWatchlistAlert';
 import { useFearGreedScores } from '../../hooks/useFearGreed';
@@ -107,8 +108,9 @@ function MiniSparkline({ data, color, width = 80, height = 28 }) {
   );
 }
 
-function HeroSignalCard({ onItemClick, allItems }) {
+function HeroSignalCard({ onItemClick, allItems, onShowScorecard }) {
   const topSignals = useTopSignals(3);
+  const { botMap } = useSignalAccuracy();
 
   if (!topSignals.length) {
     return (
@@ -123,6 +125,7 @@ function HeroSignalCard({ onItemClick, allItems }) {
   const [hero, ...rest] = topSignals;
   const heroItem = findItemBySignal(hero, allItems);
   const isBullHero = hero.direction === 'bullish';
+  const heroBotAccuracy = botMap?.get(hero.type)?.accuracy ?? null;
   const heroAccent = isBullHero ? '#F04452' : '#1764ED';
   const heroBg = isBullHero ? 'rgba(240,68,82,0.03)' : 'rgba(23,100,237,0.03)';
   const heroPct = heroItem ? getPct(heroItem) : null;
@@ -177,8 +180,25 @@ function HeroSignalCard({ onItemClick, allItems }) {
           </div>
           <span className="text-[13px] text-[#4E5968] truncate flex-1 min-w-0">{getEasyLabel(hero)}</span>
           <span className="text-[11px] text-[#8B95A1] flex-shrink-0">{TYPE_META[hero.type]?.label || ''}</span>
+          {heroBotAccuracy != null && heroBotAccuracy > 0 && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded-full font-semibold flex-shrink-0"
+              style={{ background: 'rgba(49,130,246,0.08)', color: '#3182F6' }}>
+              적중 {heroBotAccuracy}%
+            </span>
+          )}
         </div>
       </div>
+
+      {/* 브리지 — 봇 성적표 스크롤 유도 */}
+      {onShowScorecard && (
+        <button
+          type="button"
+          onClick={onShowScorecard}
+          className="text-[12px] text-[#3182F6] hover:text-[#1764ED] font-medium flex items-center gap-1 px-1 -mt-1 mb-0.5 transition-colors"
+        >
+          봇 성적표 보기 →
+        </button>
+      )}
 
       {/* 2~3위 시그널 — HotRow 스타일 컴팩트 행 */}
       {rest.map((signal, idx) => {
@@ -406,6 +426,7 @@ export default function CommandCenterWidget({
   popularItems,
   onItemClick,
   toggle,
+  onShowScorecard,
 }) {
   return (
     <div className="bg-white rounded-2xl px-5 pt-6 pb-4">
@@ -415,7 +436,7 @@ export default function CommandCenterWidget({
       {/* 히어로 시그널 + 관심종목 그리드 */}
       <div className="grid grid-cols-1 md:grid-cols-[1fr_260px] gap-4 mt-4 mb-3.5">
         <div className="min-w-0">
-          <HeroSignalCard onItemClick={onItemClick} allItems={allItems} />
+          <HeroSignalCard onItemClick={onItemClick} allItems={allItems} onShowScorecard={onShowScorecard} />
         </div>
         <div>
           <WatchlistMini

--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -1,6 +1,6 @@
 // 시그널 보드 위젯 — SignalSummaryWidget + SeoulForceSection 통합
 // 카운터 3개 (강세/약세/중립) + 시그널 리스트 + 접기/펼치기 + 성적표 탭
-import { useState, useCallback, useMemo, useEffect } from 'react';
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { cycleStep } from '../../utils/cycleTracker';
 import { useTopSignals } from '../../hooks/useSignals';
 import { extractName, getEasyLabel } from '../../utils/signalLabel';
@@ -21,11 +21,22 @@ const FORCE_TYPES = [
   SIGNAL_TYPES.INSTITUTIONAL_CONSECUTIVE_SELL,
 ];
 
-export default function SignalBoardWidget({ onItemClick, allItems = [], allNews = [] }) {
+export default function SignalBoardWidget({ onItemClick, allItems = [], allNews = [], scorecardTrigger = 0 }) {
   // 탭 상태: 'live' | 'scorecard'
   const [activeTab, setActiveTab] = useState('live');
   // 모바일 기본 접힘 — 카운터만 노출
   const [expanded, setExpanded] = useState(false);
+
+  const rootRef = useRef(null);
+
+  // HeroSignalCard 브리지에서 scorecardTrigger가 바뀌면 성적표 탭으로 전환 + 스크롤
+  useEffect(() => {
+    if (scorecardTrigger > 0) {
+      setActiveTab('scorecard');
+      setExpanded(true);
+      rootRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [scorecardTrigger]);
   // 방향 필터 — null=전체, 'bullish', 'bearish', 'neutral'
   const [filterDir, setFilterDir] = useState(null);
   // 인라인 결정 패널 — 펼쳐진 시그널 id (null=모두 닫힘)
@@ -222,7 +233,7 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
   }
 
   return (
-    <div className="bg-white rounded-2xl px-5 pt-6 pb-4">
+    <div ref={rootRef} className="bg-white rounded-2xl px-5 pt-6 pb-4">
       {/* 헤더 + 탭 */}
       {tabHeader}
 

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -146,6 +146,10 @@ export default function HomeDashboard({
   }, [allItems, onItemClick]);
 
   // ─── Pull-to-refresh ──────────────────────────────────────
+  // 봇 성적표 브리지 — HeroSignalCard → SignalBoardWidget 탭 전환 트리거
+  const [scorecardTrigger, setScorecardTrigger] = useState(0);
+  const handleShowScorecard = useCallback(() => setScorecardTrigger(n => n + 1), []);
+
   const [pulling, setPulling] = useState(false);
   const [pullDistance, setPullDistance] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
@@ -216,6 +220,7 @@ export default function HomeDashboard({
         popularItems={popularItems}
         onItemClick={onItemClick}
         toggle={toggle}
+        onShowScorecard={handleShowScorecard}
       />
 
       {/* ─── 2. 주목할 종목 (WHY 카드) ───────────────────── */}
@@ -229,7 +234,7 @@ export default function HomeDashboard({
       )}
 
       {/* ─── 3. 시그널 보드 (시그널 + 세력 포착 통합) ────── */}
-      <SignalBoardWidget onItemClick={handleSignalItemClick} allItems={allItems} allNews={allNews} />
+      <SignalBoardWidget onItemClick={handleSignalItemClick} allItems={allItems} allNews={allNews} scorecardTrigger={scorecardTrigger} />
 
       {/* ─── 3.5. AI 종목토론 (별도 섹션) ──────────────── */}
       <AiDebateSection watchedItems={watchedItems} usStocks={usStocks} krStocks={krStocks} allItems={allItems} />


### PR DESCRIPTION
## 요약

- HeroSignalCard에 시그널 타입별 **봇 적중률 배지** 추가 (`적중 74%` 형태)
- 히어로 카드 하단에 **봇 성적표 보기 →** 브리지 버튼 추가
- 클릭 시 SignalBoardWidget이 성적표 탭으로 전환 + 스크롤

## 변경 파일

- `src/components/home/CommandCenterWidget.jsx` — useSignalAccuracy 연결, 배지·브리지 렌더
- `src/components/home/SignalBoardWidget.jsx` — scorecardTrigger prop + useEffect + ref
- `src/components/home/index.jsx` — scorecardTrigger state 끌어올리기

## 구현 특이사항

- useSignalAccuracy는 SignalBoardWidget에서도 호출 중 → React Query 캐시 공유, 네트워크 추가 비용 없음
- scorecardTrigger가 0보다 클 때만 탭 전환 (초기 렌더 사이드이펙트 방지)

## 검증

- ✅ Opus code-reviewer: PASS
- ✅ Gemini gate (gemini-2.5-pro): PASS
- ✅ 빌드: 에러 없음

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 영웅 카드에 봇 정확도 배지 표시
  * 봇 성적표 보기 버튼 추가
  * 성적표 버튼 클릭 시 성적표 탭으로 자동 전환 및 자동 스크롤 기능 구현

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/288)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->