### PR TITLE
fix: EUC-KR 모지바케 방어 강화 — 정적 테이블 우선 + Latin-1 오염 감지

### DIFF
--- a/workers/cron/src/crons/update-kr.js
+++ b/workers/cron/src/crons/update-kr.js
@@ -9,7 +9,7 @@ import KR_STOCK_NAMES from '../kr-stock-names.json';
 // EUC-KR 오염 판정 — U+FFFD(대체문자) 또는 Latin-1 보충 문자(U+0080~U+00FF) 포함 시
 // EUC-KR 바이트가 UTF-8로 잘못 디코딩되면 U+FFFD 또는 ÷/Ó 등 Latin-1 문자로 나타남
 function isKrNameCorrupted(name) {
-  return /[-ÿ�]/.test(name);
+  return /[\u0080-\u00FF\uFFFD]/.test(name);
 }
 
 // 정적 테이블 우선 — 4238종목 범위 내 종목은 항상 테이블 값 사용 (API 오염 방어)

--- a/workers/cron/src/crons/update-kr.js
+++ b/workers/cron/src/crons/update-kr.js
@@ -6,11 +6,18 @@ import { SNAP_KEYS, SNAP_TTL, setSnap, getSnap, getSnapWithFallback, recordCronF
 import { getHantooToken, HANTOO_BASE } from '../hantoo-token.js';
 import KR_STOCK_NAMES from '../kr-stock-names.json';
 
-// KRX ISU_ABBRV가 비거나 symbol과 같으면 정적 테이블로 보완
-// U+FFFD(대체문자) 포함 시 EUC-KR 오인코딩 오염으로 판단 → 정적 테이블 폴백
+// EUC-KR 오염 판정 — U+FFFD(대체문자) 또는 Latin-1 보충 문자(U+0080~U+00FF) 포함 시
+// EUC-KR 바이트가 UTF-8로 잘못 디코딩되면 U+FFFD 또는 ÷/Ó 등 Latin-1 문자로 나타남
+function isKrNameCorrupted(name) {
+  return /[-ÿ�]/.test(name);
+}
+
+// 정적 테이블 우선 — 4238종목 범위 내 종목은 항상 테이블 값 사용 (API 오염 방어)
+// 테이블 미포함 신규 종목: API 이름 유효성 검증 후 사용, 오염 감지 시 symbol 코드 반환
 function resolveKrName(symbol, apiName) {
-  if (apiName && apiName !== symbol && !apiName.includes('�')) return apiName;
-  return KR_STOCK_NAMES[symbol] || symbol;
+  if (KR_STOCK_NAMES[symbol]) return KR_STOCK_NAMES[symbol];
+  if (apiName && apiName !== symbol && !isKrNameCorrupted(apiName)) return apiName;
+  return symbol;
 }
 
 // KST 기준 마지막 거래일 날짜 (YYYYMMDD)


### PR DESCRIPTION
## Summary

Closes #289

- `isKrNameCorrupted`: U+FFFD 외 Latin-1 보충 문자(U+0080~U+00FF) 감지 추가 — EUC-KR 바이트가 UTF-8 오해석 시 `÷`/`Ó` 등 Latin-1 문자로 나타나는 케이스 포착
- `resolveKrName`: 정적 테이블(4238종목) 우선 적용 — API 오염 여부와 무관하게 알려진 종목은 항상 테이블 값 사용

## 배경

#284 픽스 이후에도 17개 종목명이 깨져 있음을 Playwright QA로 확인. `includes('?')` 체크가 U+FFFD만 잡고 Latin-1 가비지는 통과시키는 것이 근본 원인.

## 리뷰

- Claude Opus: PASS
- Gemini 2.5 Pro: PASS

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 한글 상품명 처리의 안정성을 개선했습니다.
  * 손상된 문자 인코딩 감지 및 복구 메커니즘을 강화하여 정확한 상품명 표시를 보장합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/290)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->