### PR TITLE
fix(#291): usePrices resolveKrName EUC-KR 오염 감지 추가 — 실시간 폴링 종목명 깨짐

### DIFF
--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -12,11 +12,17 @@ import { isKoreanMarketOpen, isUsMarketOpen, isUsPreMarket, isUsAfterMarket } fr
 // US_STOCK_LIST 메타맵 — 모듈 스코프에 1회만 생성 (sector/nameEn fallback)
 const US_META_MAP = new Map(US_STOCK_LIST.map(s => [s.symbol, s]));
 
-// KR 종목명 룩업 — API name이 없거나 symbol과 같으면 정적 테이블로 보완
+// EUC-KR 모지바케 감지 — Latin-1 보충 범위 + U+FFFD
+function isKrNameCorrupted(name) {
+  return /[\u0080-\u00FF\uFFFD]/.test(name);
+}
+
+// KR 종목명 룩업 — 정적 테이블 우선, 오염된 API 이름은 무시
 // null 반환 시 call site에서 old.name 등 상위 fallback이 동작할 수 있도록 symbol 반환 제거
 function resolveKrName(symbol, apiName) {
-  if (apiName && apiName !== symbol) return apiName;
-  return KR_STOCK_NAMES[symbol] || null;
+  if (KR_STOCK_NAMES[symbol]) return KR_STOCK_NAMES[symbol];
+  if (apiName && apiName !== symbol && !isKrNameCorrupted(apiName)) return apiName;
+  return null;
 }
 
 // snapshot 없을 때 국장 최소 fallback 심볼 (코스피 시총 상위)


### PR DESCRIPTION
## 요약

- `src/hooks/usePrices.js`의 `resolveKrName`에 EUC-KR 모지바케 감지 추가
- 정적 테이블(`KR_STOCK_NAMES`) 우선 조회로 오염된 API 이름이 덮어쓰는 문제 차단
- CF Workers `update-kr.js`(PR #290)와 동일한 로직으로 통일

## 근본 원인

KRX API가 EUC-KR로 응답할 때 프론트엔드 실시간 폴링 경로에서  
오염된 이름(Latin-1/U+FFFD)을 그대로 통과시켜 화면에 `●●●●●` 표시.

CF Workers 크론은 #290에서 수정됐으나 프론트엔드 폴링 경로는 미수정.

## 변경

```js
// 추가
function isKrNameCorrupted(name) {
  return /[-ÿ�]/.test(name);
}

// 수정 전 → 후
// 전: API 이름 그대로 반환 (오염 이름 통과)
// 후: 정적 테이블 우선, 오염 이름 무시
function resolveKrName(symbol, apiName) {
  if (KR_STOCK_NAMES[symbol]) return KR_STOCK_NAMES[symbol];
  if (apiName && apiName !== symbol && !isKrNameCorrupted(apiName)) return apiName;
  return null;
}
```

## 게이트 결과

- ✅ 빌드: 통과
- ✅ code-reviewer (Opus): PASS — 지적 없음
- ✅ Gemini gate: PASS

Closes #291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 한국 주식 종목의 이름이 더욱 정확하게 표시되도록 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/292)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->