### PR TITLE
fix(#307): snap:kr:hot TTL 600→86400 장마감후 국장탭 빈화면방지

### DIFF
--- a/workers/cron/src/price-cache.js
+++ b/workers/cron/src/price-cache.js
@@ -34,8 +34,9 @@ export const SNAP_TTL = {
   US: 600,
   COINS: 600,
   ETF: 600,
-  // #185: hot 키는 본 키와 동일 주기로 갱신 → 동일 TTL.
-  HOT: 600,
+  // #307: KR cron UTC 11 이후 중단 → hot snap 10분 후 만료 → 국장 탭 빈 화면.
+  // 24h로 연장하여 장 마감 후에도 최신 스냅 유지 (다음 날 장 오픈 전까지).
+  HOT: 86400,
 };
 
 // #176: 1h → 24h. 미장 quiet window(ET post 20 UTC ~ pre 08 UTC = 11h) 를 커버해

--- a/workers/cron/src/price-cache.js
+++ b/workers/cron/src/price-cache.js
@@ -35,8 +35,8 @@ export const SNAP_TTL = {
   COINS: 600,
   ETF: 600,
   // #307: KR cron UTC 11 이후 중단 → hot snap 10분 후 만료 → 국장 탭 빈 화면.
-  // 24h로 연장하여 장 마감 후에도 최신 스냅 유지 (다음 날 장 오픈 전까지).
-  HOT: 86400,
+  // 3일(259200)로 연장 — 주말 공백(금 마감→월 오픈 ~63h) 포함 커버.
+  HOT: 259200,
 };
 
 // #176: 1h → 24h. 미장 quiet window(ET post 20 UTC ~ pre 08 UTC = 11h) 를 커버해


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-2.5-pro)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #307

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 시세 캐시 보관 시간을 단축한 조정으로 장 마감과 장 개시 사이에 발생하는 빈 화면 표시 현상을 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->