### PR TITLE
fix(#308): 시그널 easyDesc meta 필드 불일치 6종 수정

### DIFF
--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -428,7 +428,7 @@ export function createFearGreedSignal(current, previous, market) {
     direction,
     strength,
     title,
-    meta: { current, previous, currentZone, previousZone, currentZoneKo: zoneKo[currentZone] },
+    meta: { current, previous, currentZone, previousZone, currentZoneKo: zoneKo[currentZone], previousZoneKo: zoneKo[previousZone] },
   });
   return addSignal(signal);
 }

--- a/src/engine/signalTypes.js
+++ b/src/engine/signalTypes.js
@@ -127,7 +127,7 @@ export const TYPE_META = {
   },
   [SIGNAL_TYPES.FEAR_GREED_SHIFT]: {
     easyLabel: '시장 심리가 바뀌고 있어요 🔄',
-    easyDesc: (m) => `시장이 ${m?.previousZone || '?'}에서 ${m?.currentZone || '?'}로 전환 중 — 역발상 기회?`,
+    easyDesc: (m) => `시장이 ${m?.previousZoneKo || m?.previousZone || '?'}에서 ${m?.currentZoneKo || m?.currentZone || '?'}로 전환 중 — 역발상 기회?`,
   },
   [SIGNAL_TYPES.PUT_CALL_RATIO]: {
     easyLabel: '하락 보험 변동 📊',

--- a/src/engine/signalTypes.js
+++ b/src/engine/signalTypes.js
@@ -120,15 +120,14 @@ export const TYPE_META = {
     },
     easyDesc: (m) => {
       const pct = m?.changePct ?? 0;
-      const name = m?.name || '종목';
-      if (pct <= -1) return `${name} 하락 중 거래량 ${m?.ratio || '?'}배 폭발 — 이상 거래량 감지`;
-      if (pct >= 1) return `${name} 상승 중 거래량 ${m?.ratio || '?'}배 폭발 — 강한 매수세`;
-      return `${name} 거래량이 평소의 ${m?.ratio || '?'}배 — 뭔가 일어나고 있어요`;
+      if (pct <= -1) return `하락 중 거래량 ${m?.ratio || '?'}배 폭발 — 이상 거래량 감지`;
+      if (pct >= 1) return `상승 중 거래량 ${m?.ratio || '?'}배 폭발 — 강한 매수세`;
+      return `거래량이 평소의 ${m?.ratio || '?'}배 — 뭔가 일어나고 있어요`;
     },
   },
   [SIGNAL_TYPES.FEAR_GREED_SHIFT]: {
     easyLabel: '시장 심리가 바뀌고 있어요 🔄',
-    easyDesc: (m) => `시장이 ${m.from || '?'}에서 ${m.to || '?'}로 전환 중 — 역발상 기회?`,
+    easyDesc: (m) => `시장이 ${m?.previousZone || '?'}에서 ${m?.currentZone || '?'}로 전환 중 — 역발상 기회?`,
   },
   [SIGNAL_TYPES.PUT_CALL_RATIO]: {
     easyLabel: '하락 보험 변동 📊',
@@ -150,7 +149,11 @@ export const TYPE_META = {
   },
   [SIGNAL_TYPES.ORDER_FLOW_IMBALANCE]: {
     easyLabel: '매수/매도 힘 균형이 깨졌어요 ⚖️',
-    easyDesc: (m) => `지금 ${m.direction === 'bullish' ? '매수' : '매도'}세가 ${m.pct || '?'}% 더 강해요`,
+    easyDesc: (m) => {
+      const side = (m?.imbalance ?? 0) > 0 ? '매수' : '매도';
+      const pct = Math.abs((m?.imbalance ?? 0) * 100).toFixed(0);
+      return `지금 ${side}세가 ${pct}% 더 강해요`;
+    },
   },
   [SIGNAL_TYPES.VWAP_DEVIATION]: {
     easyLabel: '평균가에서 벗어났어요 📏',
@@ -163,15 +166,19 @@ export const TYPE_META = {
   },
   [SIGNAL_TYPES.SOCIAL_SENTIMENT]: {
     easyLabel: 'SNS에서 화제 📱',
-    easyDesc: (m) => `소셜에서 ${m.symbol || '종목'} 관련 ${m.direction === 'bullish' ? '긍정' : '부정'} 의견이 ${m.pct || '?'}%`,
+    easyDesc: (m) => {
+      const side = (m?.bullRatio ?? 0) > 0.5 ? '긍정' : '부정';
+      const pct = ((m?.bullRatio ?? 0) * 100).toFixed(0);
+      return `소셜에서 ${side} 의견이 ${pct}% — ${m?.totalMessages ?? '?'}건 분석`;
+    },
   },
   [SIGNAL_TYPES.NEWS_SENTIMENT_CLUSTER]: {
     easyLabel: '관련 뉴스가 쏟아지고 있어요 📰',
-    easyDesc: (m) => `${m.name || '종목'} 관련 뉴스 ${m.count || '다수'}건 집중 — 주목`,
+    easyDesc: (m) => `관련 뉴스 ${m?.count || '다수'}건 집중 — 주목`,
   },
   [SIGNAL_TYPES.SECTOR_ROTATION]: {
     easyLabel: '돈이 섹터로 몰리고 있어요 🔄',
-    easyDesc: (m) => `${m.sector || '?'} 섹터 ${m.direction === 'bullish' ? '강세' : '약세'} — 자금 흐름 변화 감지`,
+    easyDesc: (m) => `${m?.sector || '?'} 섹터 ${m?.above ? '강세' : '약세'} — 자금 흐름 변화 감지`,
   },
   [SIGNAL_TYPES.CROSS_MARKET_CORRELATION]: {
     easyLabel: '다른 시장이 먼저 움직였어요 🌐',

--- a/src/engine/signalTypes.js
+++ b/src/engine/signalTypes.js
@@ -120,9 +120,9 @@ export const TYPE_META = {
     },
     easyDesc: (m) => {
       const pct = m?.changePct ?? 0;
-      if (pct <= -1) return `하락 중 거래량 ${m?.ratio || '?'}배 폭발 — 이상 거래량 감지`;
-      if (pct >= 1) return `상승 중 거래량 ${m?.ratio || '?'}배 폭발 — 강한 매수세`;
-      return `거래량이 평소의 ${m?.ratio || '?'}배 — 뭔가 일어나고 있어요`;
+      if (pct <= -1) return `하락 중 거래량 ${m?.ratio?.toFixed(1) || '?'}배 폭발 — 이상 거래량 감지`;
+      if (pct >= 1) return `상승 중 거래량 ${m?.ratio?.toFixed(1) || '?'}배 폭발 — 강한 매수세`;
+      return `거래량이 평소의 ${m?.ratio?.toFixed(1) || '?'}배 — 뭔가 일어나고 있어요`;
     },
   },
   [SIGNAL_TYPES.FEAR_GREED_SHIFT]: {
@@ -167,8 +167,10 @@ export const TYPE_META = {
   [SIGNAL_TYPES.SOCIAL_SENTIMENT]: {
     easyLabel: 'SNS에서 화제 📱',
     easyDesc: (m) => {
-      const side = (m?.bullRatio ?? 0) > 0.5 ? '긍정' : '부정';
-      const pct = ((m?.bullRatio ?? 0) * 100).toFixed(0);
+      const bullRatio = m?.bullRatio ?? 0;
+      const isBull = bullRatio > 0.5;
+      const side = isBull ? '긍정' : '부정';
+      const pct = ((isBull ? bullRatio : 1 - bullRatio) * 100).toFixed(0);
       return `소셜에서 ${side} 의견이 ${pct}% — ${m?.totalMessages ?? '?'}건 분석`;
     },
   },

--- a/src/hooks/useInvestorSignals.js
+++ b/src/hooks/useInvestorSignals.js
@@ -382,7 +382,7 @@ function detectSectorRotation(allItems, sectorRanksPrevRef) {
         direction: DIRECTIONS.BULLISH,
         strength: avg >= 5 ? 3 : 2,
         title: `${sector} 섹터 +${avg.toFixed(1)}% 강세`,
-        meta: { sector, avg },
+        meta: { sector, avg, above: true },
       });
       addSignal(signal);
     }
@@ -399,7 +399,7 @@ function detectSectorRotation(allItems, sectorRanksPrevRef) {
         direction: DIRECTIONS.BEARISH,
         strength: avg <= -5 ? 3 : 2,
         title: `${sector} 섹터 ${avg.toFixed(1)}% 약세`,
-        meta: { sector, avg },
+        meta: { sector, avg, above: false },
       });
       addSignal(signal);
     }
@@ -424,7 +424,7 @@ function detectSectorRotation(allItems, sectorRanksPrevRef) {
         direction,
         strength,
         title,
-        meta: { sector, prevRank, curRank, diff },
+        meta: { sector, prevRank, curRank, diff, above: diff > 0 },
       });
       addSignal(signal);
     }


### PR DESCRIPTION
## 변경 내용

`signalTypes.js`의 `easyDesc` 함수들이 실제 `signal.meta` 구조와 맞지 않는 필드를 참조하던 버그 6종 수정.

### 수정 내역

| 시그널 | 기존 (잘못됨) | 수정 후 |
|--------|-------------|---------|
| VOLUME_ANOMALY | `m.name` (meta에 없음) | 제거 — title에 이미 포함 |
| FEAR_GREED_SHIFT | `m.from/m.to` | `m.previousZoneKo/m.currentZoneKo` + 한국어 fallback |
| ORDER_FLOW_IMBALANCE | `m.direction/m.pct` | `m.imbalance` (-1~+1) 기반 부호 판별 |
| SOCIAL_SENTIMENT | `m.direction/m.pct` | `m.bullRatio/m.totalMessages` |
| NEWS_SENTIMENT_CLUSTER | `m.name` (meta에 없음) | 제거 — `m.count`로 대체 |
| SECTOR_ROTATION | `m.direction` | `m.above` (boolean) |

### 연관 파일

- `src/engine/signalTypes.js` — easyDesc 6종 수정
- `src/engine/signalEngine.js` — FEAR_GREED_SHIFT meta에 `previousZoneKo` 추가
- `src/hooks/useInvestorSignals.js` — SECTOR_ROTATION meta에 `above` 필드 3곳 추가

### Gemini gate 1차 BLOCK 기각 사유

Gemini: "`SECTOR_RANK_SHIFT`에서 `above: diff > 0`이 BEARISH이므로 `diff < 0`으로 수정 필요"

기각 근거: `useInvestorSignals.js:413` 주석 `const diff = prevRank - curRank; // 양수면 순위 상승`
- prevRank=5, curRank=2 → diff=3>0 → 2위로 상승 = BULLISH → `above: diff > 0` 올바름
- Gemini가 순위 번호와 순위 방향을 반대로 이해한 오판
- 2차 실행에서 PASS 확인

### 검증

- architect gate: PASS (commit `6e1bc57`)
- code-reviewer (Opus): PASS
- Gemini gate: PASS (2차)

Closes #308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 신호 메타데이터 구조 확장으로 더 자세한 신호 컨텍스트 제공
  * 거래량 이상, 공포/탐욕 지표 변동, 주문 불균형, 소셜 센티먼트, 섹터 로테이션 신호의 설명 문구 개선
  * 신호 분석 정보의 정확성과 명확성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->