### PR TITLE
fix(#314): 시그널 meta/easyDesc 정합성 — COMPOSITE_SCORE·FOREIGN/INST·ETF API 크래시 수정

### DIFF
--- a/api/krx-etf.js
+++ b/api/krx-etf.js
@@ -56,7 +56,7 @@ export default async function handler(_req) {
         const rows = await fetchEtfForDate(basDd);
         if (rows.length > 0) { list = rows; break; }
       } catch (e) {
-        console.error(`[krx-etf] ${basDd} 실패:`, e?.message || e);
+        console.error(`[krx-etf] ${basDd} 실패:`, e);
       }
     }
 

--- a/api/krx-etf.js
+++ b/api/krx-etf.js
@@ -38,57 +38,67 @@ function num(s) {
 }
 
 export default async function handler(_req) {
-  if (!AUTH_KEY) {
-    return Response.json({ error: 'KRX_API_KEY not set', etfs: [] }, { status: 500 });
-  }
+  try {
+    if (!AUTH_KEY) {
+      return Response.json({ error: 'KRX_API_KEY not set', etfs: [] }, { status: 500 });
+    }
 
-  // 순차 5 영업일 시도 — 첫 성공 날짜에서 즉시 중단 (최신 우선 + KRX 쿼터 보호)
-  // 각 2s 타임아웃 × 최대 5일 = 최악 10s (게이트웨이 12s 이내, #115 해소).
-  // dateStr()이 주말을 금요일로 collapse → 월요일엔 Fri 3중복 발생.
-  // offset을 최대 2주(14)까지 확장하고 dedup으로 **5 영업일 보장** (Codex P2).
-  let list = [];
-  const uniqueDates = [...new Set(
-    Array.from({ length: 14 }, (_, i) => dateStr(i + 1)),
-  )].slice(0, 5);
-  for (const basDd of uniqueDates) {
-    try {
-      const rows = await fetchEtfForDate(basDd);
-      if (rows.length > 0) { list = rows; break; }
-    } catch { /* 다음 날짜 시도 */ }
-  }
+    // 순차 5 영업일 시도 — 첫 성공 날짜에서 즉시 중단 (최신 우선 + KRX 쿼터 보호)
+    // 각 2s 타임아웃 × 최대 5일 = 최악 10s (게이트웨이 12s 이내, #115 해소).
+    // dateStr()이 주말을 금요일로 collapse → 월요일엔 Fri 3중복 발생.
+    // offset을 최대 2주(14)까지 확장하고 dedup으로 **5 영업일 보장** (Codex P2).
+    let list = [];
+    const uniqueDates = [...new Set(
+      Array.from({ length: 14 }, (_, i) => dateStr(i + 1)),
+    )].slice(0, 5);
+    for (const basDd of uniqueDates) {
+      try {
+        const rows = await fetchEtfForDate(basDd);
+        if (rows.length > 0) { list = rows; break; }
+      } catch (e) {
+        console.error(`[krx-etf] ${basDd} 실패:`, e?.message || e);
+      }
+    }
 
-  if (!list.length) {
-    return Response.json({ etfs: [] }, {
-      headers: { 'Cache-Control': 'public, s-maxage=3600' },
+    if (!list.length) {
+      return Response.json({ etfs: [] }, {
+        headers: { 'Cache-Control': 'public, s-maxage=3600' },
+      });
+    }
+
+    // KRX 응답 → 프론트 ETF_DATA 포맷으로 변환
+    const etfs = list.map(r => {
+      const price     = num(r.TDD_CLSPRC);
+      const prevClose = price - num(r.CMPPREVDD_PRC);
+      const change    = num(r.CMPPREVDD_PRC);
+      const changePct = prevClose > 0
+        ? parseFloat(((change / prevClose) * 100).toFixed(2))
+        : 0;
+      return {
+        symbol:    (r.ISU_CD  || r.ISU_SRT_CD || '').trim(),
+        name:      (r.ISU_NM  || r.ISU_ABBRV  || '').trim(),
+        market:    'kr',
+        sector:    'ETF',
+        category:  'ETF',
+        price:     parseFloat(price.toFixed(0)),
+        change:    parseFloat(change.toFixed(0)),
+        changePct,
+        volume:    num(r.ACC_TRDVOL),
+        aum:       num(r.MKTCAP),
+      };
+    }).filter(e => e.symbol && e.name && e.price > 0);
+
+    return Response.json({ etfs }, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=21600, stale-while-revalidate=3600', // 6시간 캐싱
+        'Access-Control-Allow-Origin': '*',
+      },
     });
+  } catch (e) {
+    console.error('[krx-etf] handler 크래시:', e);
+    return Response.json(
+      { error: e?.message || String(e), etfs: [] },
+      { status: 500 },
+    );
   }
-
-  // KRX 응답 → 프론트 ETF_DATA 포맷으로 변환
-  const etfs = list.map(r => {
-    const price     = num(r.TDD_CLSPRC);
-    const prevClose = price - num(r.CMPPREVDD_PRC);
-    const change    = num(r.CMPPREVDD_PRC);
-    const changePct = prevClose > 0
-      ? parseFloat(((change / prevClose) * 100).toFixed(2))
-      : 0;
-    return {
-      symbol:    (r.ISU_CD  || r.ISU_SRT_CD || '').trim(),
-      name:      (r.ISU_NM  || r.ISU_ABBRV  || '').trim(),
-      market:    'kr',
-      sector:    'ETF',
-      category:  'ETF',
-      price:     parseFloat(price.toFixed(0)),
-      change:    parseFloat(change.toFixed(0)),
-      changePct,
-      volume:    num(r.ACC_TRDVOL),
-      aum:       num(r.MKTCAP),
-    };
-  }).filter(e => e.symbol && e.name && e.price > 0);
-
-  return Response.json({ etfs }, {
-    headers: {
-      'Cache-Control': 'public, s-maxage=21600, stale-while-revalidate=3600', // 6시간 캐싱
-      'Access-Control-Allow-Origin': '*',
-    },
-  });
 }

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -306,7 +306,7 @@ export function createInvestorSignal(symbol, name, market, type, consecutiveDays
     direction,
     strength,
     title,
-    meta: { consecutiveDays, amount, currentPrice },
+    meta: { consecutiveDays, amount, currentPrice, name },
     source: 'client',
     confidence: Number.isFinite(consecutiveDays) ? Math.min(Math.max(0, 0.5 + consecutiveDays * 0.1), 1.0) : null,
     reasons: Number.isFinite(consecutiveDays)

--- a/src/engine/signalTypes.js
+++ b/src/engine/signalTypes.js
@@ -272,10 +272,12 @@ export const TYPE_META = {
       return '방향 탐색 중 👀';
     },
     easyDesc: (m) => {
+      const bd = m?.breakdown;
       const parts = [];
-      if (m?.rsi != null) parts.push(`RSI ${m.rsi}`);
-      if (m?.macd != null) parts.push(`MACD ${m.macd > 0 ? '상승' : '하락'}`);
-      return `복합 분석 점수 ${m?.compositeScore > 0 ? '+' : ''}${m?.compositeScore ?? 0}${parts.length ? ` (${parts.join(', ')})` : ''}`;
+      if (bd?.momentum != null) parts.push(`모멘텀 ${bd.momentum > 0 ? '+' : ''}${Math.round(bd.momentum)}`);
+      if (bd?.volumeZ != null) parts.push(`거래량 ${bd.volumeZ > 0 ? '+' : ''}${Math.round(bd.volumeZ)}`);
+      if (bd?.relMkt != null) parts.push(`시장대비 ${bd.relMkt > 0 ? '+' : ''}${Math.round(bd.relMkt)}`);
+      return `복합 분석 점수 ${(m?.compositeScore ?? 0) > 0 ? '+' : ''}${m?.compositeScore ?? 0}${parts.length ? ` (${parts.join(', ')})` : ''}`;
     },
   },
 };


### PR DESCRIPTION
## 변경 내용

### 수정 1: COMPOSITE_SCORE easyDesc — 없는 필드 참조 제거
- `m.rsi`, `m.macd` → 실제 meta에 존재하는 `m.breakdown.{momentum, volumeZ, relMkt}` 로 교체
- 이전: "복합 분석 점수 +45 (RSI ?, MACD ?)" → 이후: "복합 분석 점수 +45 (모멘텀 +60, 거래량 +40, 시장대비 +20)"

### 수정 2: FOREIGN/INSTITUTIONAL createSignal meta에 name 누락
- `signalEngine.js:309` meta 객체에 `name` 필드 추가
- 이전: easyDesc가 항상 '종목' fallback 표시 → 이후: 실제 종목명 표시

### 수정 3: api/krx-etf.js handler try/catch 래퍼
- handler 전체를 try/catch로 감싸 FUNCTION_INVOCATION_FAILED 시 실제 에러 메시지 응답 노출
- 날짜별 fetch 실패 catch에 `console.error` 추가 (이전엔 silent 실패)
- Issue #312 디버깅을 위한 변경

## 리뷰

> 🤖 code-reviewer (Claude Opus): PASS
> 🏗️ architect (Claude Opus): PASS
> ✨ Gemini gate (gemini-3.1-pro-preview): PASS

Closes #314