### PR TITLE
fix(#317): 한투 KR change 부호 반전 수정 — prdy_vrss_sign 불응답 대응

### DIFF
--- a/api/hantoo-price.js
+++ b/api/hantoo-price.js
@@ -34,10 +34,11 @@ async function fetchSinglePrice(symbol, token) {
   const price = parseInt(o.stck_prpr || '0', 10);
   if (!price) throw new Error(`${symbol}: 가격 없음`);
 
-  // prdy_vrss_sign: 1=상한 2=상승 3=보합 4=하한 5=하락 → 하락 계열이면 음수
-  const sign      = o.prdy_vrss_sign ?? '3';
+  // prdy_ctrt(등락률)의 부호로 change 방향 결정 — prdy_vrss_sign이 '3'(보합)으로 fallback되어
+  // 하락 종목도 양수로 반환되는 버그 수정 (#317)
   const changeAbs = parseInt(o.prdy_vrss || '0', 10);
-  const change    = (sign === '4' || sign === '5') ? -changeAbs : changeAbs;
+  const changePctRaw = parseFloat(o.prdy_ctrt || '0');
+  const change    = changePctRaw < 0 ? -changeAbs : changeAbs;
 
   // ── 시간외(애프터마켓) 단일가 ────────────────────────────────
   // ovtm_untp_prpr: 시간외 단일가 현재가 (장 마감 후 15:30~18:00 KST)

--- a/api/hantoo-price.js
+++ b/api/hantoo-price.js
@@ -43,14 +43,12 @@ async function fetchSinglePrice(symbol, token) {
   // ── 시간외(애프터마켓) 단일가 ────────────────────────────────
   // ovtm_untp_prpr: 시간외 단일가 현재가 (장 마감 후 15:30~18:00 KST)
   // 정규장 중에는 0 또는 미응답 → null 처리
-  const afterHoursPrice   = parseInt(o.ovtm_untp_prpr   || '0', 10) || null;
-  const afterHoursSign    = o.ovtm_untp_prpd_vrss_sign ?? '3';
-  const afterHoursChgAbs  = parseInt(o.ovtm_untp_prpd_vrss || '0', 10);
+  const afterHoursPrice     = parseInt(o.ovtm_untp_prpr   || '0', 10) || null;
+  const afterHoursChgAbs    = parseInt(o.ovtm_untp_prpd_vrss || '0', 10);
+  const afterHoursChangePct = afterHoursPrice ? parseFloat(o.ovtm_untp_prdy_ctrt || '0') : null;
+  // 시간외도 동일 원인 — ovtm_untp_prpd_vrss_sign 대신 ctrt 부호 사용 (#317)
   const afterHoursChange  = afterHoursPrice
-    ? ((afterHoursSign === '4' || afterHoursSign === '5') ? -afterHoursChgAbs : afterHoursChgAbs)
-    : null;
-  const afterHoursChangePct = afterHoursPrice
-    ? parseFloat(o.ovtm_untp_prdy_ctrt || '0')
+    ? (afterHoursChangePct !== null && afterHoursChangePct < 0 ? -afterHoursChgAbs : afterHoursChgAbs)
     : null;
 
   return {
@@ -58,7 +56,7 @@ async function fetchSinglePrice(symbol, token) {
     name:      (o.hts_kor_isnm || '').trim(),
     price,
     change,
-    changePct: parseFloat(o.prdy_ctrt || '0'),
+    changePct: changePctRaw,
     volume:    parseInt(o.acml_vol    || '0', 10),
     // hts_avls: HTS 시가총액 (억원 단위) → 원화로 변환
     marketCap: (parseInt(o.hts_avls   || '0', 10) || 0) * 100_000_000,


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-2.5-pro)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #317

---
🤖 Generated by Claude Code [claude-sonnet-4-6]