### PR TITLE
fix(#318): 한투 지수 KOSPI/KOSDAQ change 부호 반전 수정

### DIFF
--- a/api/hantoo-indices.js
+++ b/api/hantoo-indices.js
@@ -36,14 +36,15 @@ async function fetchSingleIndex(code, token) {
   if (!value) throw new Error('지수 값 없음');
 
   // bstp_nmix_prdy_vrss: 전일 대비, bstp_nmix_prdy_ctrt: 전일 대비율
-  const sign   = o.prdy_vrss_sign ?? '3';
-  const absChg = parseFloat(o.bstp_nmix_prdy_vrss || '0');
-  const change = (sign === '4' || sign === '5') ? -absChg : absChg;
+  // prdy_vrss_sign 불응답 버그(#317)와 동일 — bstp_nmix_prdy_ctrt 부호로 방향 결정 (#318)
+  const absChg    = parseFloat(o.bstp_nmix_prdy_vrss || '0');
+  const changePct = parseFloat(o.bstp_nmix_prdy_ctrt || '0');
+  const change    = changePct < 0 ? -Math.abs(absChg) : Math.abs(absChg);
 
   return {
     value:     parseFloat(value.toFixed(2)),
     change:    parseFloat(change.toFixed(2)),
-    changePct: parseFloat(o.bstp_nmix_prdy_ctrt || '0'),
+    changePct,
   };
 }
 


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-2.5-pro)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #318

---
🤖 Generated by Claude Code [claude-sonnet-4-6]