### PR TITLE
fix(#331): Upstash bandwidth 12.7배 초과 — s-maxage 강화 + 폴링 60s

### DIFF
--- a/api/snapshot.js
+++ b/api/snapshot.js
@@ -102,12 +102,13 @@ export default async function handler(request) {
           headers: { 'Access-Control-Allow-Origin': '*', 'ETag': etag },
         });
       }
-      // hot 은 s-maxage=30 — 본 키와 동기화 지연 최소화 (갱신 주기 5분 대비 여유).
+      // #331: hot s-maxage 30→60 — Upstash bandwidth 12.7배 초과 대응.
+      //       cron 갱신 주기 5분 대비 1분 stale은 충분히 안전 (hot 키는 자주 변동).
       return new Response(body, {
         status: 200,
         headers: {
           ...CORS_HEADERS,
-          'Cache-Control': 'public, max-age=0, s-maxage=30',
+          'Cache-Control': 'public, max-age=0, s-maxage=60',
           'ETag': etag,
         },
       });
@@ -146,17 +147,19 @@ export default async function handler(request) {
 
     // Cache-Control 설계 (Upstash bandwidth 보호):
     // - max-age=0: 브라우저 HTTP 캐시 비활성 → 클라이언트 ETag 재검증 경로 보존
-    // - s-maxage=60: Vercel edge CDN 60초 캐싱 → Vercel Function 호출 최소화
+    // - #331: s-maxage 60→120 — Upstash bandwidth 12.7배 초과 대응.
+    //   CDN cache hit률 ~2배 → Redis MGET 호출 ~50% 감소.
+    //   CF Workers cron이 5분 주기로 snap 갱신 → 2분 stale은 5분 cycle 내 안전.
     // - stale-while-revalidate 미사용: 백그라운드 갱신 중 stale 반환 방지
     //   (KR 랭킹/급등 뷰는 refreshKoreanStocks가 fallback/워치리스트만 갱신하고
     //    나머지는 snapshot seed에 의존 → swr로 수분 stale 누적 시 서비스 본질 훼손.
     //    CF Workers check-signal-accuracy의 server-side snapshot 소비도 stale 누적 위험.
-    //    → swr 없이 stale 상한을 60s로 제한.)
+    //    → swr 없이 stale 상한을 120s로 제한.)
     return new Response(body, {
       status: 200,
       headers: {
         ...CORS_HEADERS,
-        'Cache-Control': 'public, max-age=0, s-maxage=60',
+        'Cache-Control': 'public, max-age=0, s-maxage=120',
         'ETag': etag,
       },
     });

--- a/src/api/snapshot.js
+++ b/src/api/snapshot.js
@@ -5,7 +5,12 @@
 //   - 기본 tier='full' 유지 → 기존 호출 사이트 회귀 방지
 //   - 캐시/TTL/ETag/inflight 모두 tier 단위 독립
 
-const SNAPSHOT_TTL = 120 * 1000; // 120초 (#331: 서버 s-maxage=120/60 과 동기화 — Upstash 절감)
+// #331: tier별 TTL 분리 — 서버 s-maxage(hot=60, full=120)와 정합성 유지.
+//        통합 TTL=120s면 hot tier에서 서버 갱신본을 최대 60s 더 늦게 받게 됨.
+const SNAPSHOT_TTL = {
+  hot: 60 * 1000,   // 60초 — 서버 s-maxage=60 동기화 (홈 첫 로드용, freshness 우선)
+  full: 120 * 1000, // 120초 — 서버 s-maxage=120 동기화 (lazy 보강, Upstash 절감)
+};
 
 // tier 별 독립 상태 — 교차 오염 없음.
 const state = {
@@ -21,7 +26,7 @@ export async function fetchSnapshot({ tier = 'full' } = {}) {
   const t = tier === 'hot' ? 'hot' : 'full';
   const st = getState(t);
   const now = Date.now();
-  if (st.cache && now - st.ts < SNAPSHOT_TTL) return st.cache;
+  if (st.cache && now - st.ts < SNAPSHOT_TTL[t]) return st.cache;
 
   // 동일 tier 중복 호출 dedupe (useCoins + usePrices 동시 호출 대비)
   if (st.inflight) return st.inflight;

--- a/src/api/snapshot.js
+++ b/src/api/snapshot.js
@@ -5,7 +5,7 @@
 //   - 기본 tier='full' 유지 → 기존 호출 사이트 회귀 방지
 //   - 캐시/TTL/ETag/inflight 모두 tier 단위 독립
 
-const SNAPSHOT_TTL = 60 * 1000; // 60초 (서버 s-maxage=60/30 과 유사 동기화)
+const SNAPSHOT_TTL = 120 * 1000; // 120초 (#331: 서버 s-maxage=120/60 과 동기화 — Upstash 절감)
 
 // tier 별 독립 상태 — 교차 오염 없음.
 const state = {

--- a/src/constants/polling.js
+++ b/src/constants/polling.js
@@ -6,7 +6,9 @@ const DEV_MULTIPLIER = Number(import.meta.env.VITE_DEV_POLLING_MULTIPLIER) || 1;
 
 export const POLLING = {
   FAST:       10_000  * DEV_MULTIPLIER,  // 10초  — Upbit WS 끊김 시 fallback
-  NORMAL:     30_000  * DEV_MULTIPLIER,  // 30초  — (사용 중단 예정, 환율→CLOSED 이동)
+  // #331: NORMAL 30→60초 — Yahoo/네이버 quota + Vercel function 호출 ~50% 감소.
+  // 5분(CLOSED)은 시세 신뢰지표 훼손 → 토스/네이버증권 수준 1분으로 절충.
+  NORMAL:     60_000  * DEV_MULTIPLIER,  // 60초  — 장중·프리·애프터마켓 폴링 (시세 freshness 유지)
   BACKGROUND: 120_000 * DEV_MULTIPLIER,  // 2분   — WS가 실시간 커버하는 REST 보조 (지수/ETF/코인)
   CLOSED:     300_000 * DEV_MULTIPLIER,  // 5분   — 환율·장 마감·주말 (Upstash 절감)
   SLOW:        60_000 * DEV_MULTIPLIER,  // 60초  — 하위호환 유지 (직접 참조 파일 없앤 후 제거 예정)

--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -238,7 +238,7 @@ export function usePrices() {
     let usInFlight = false;
     let krInFlight = false;
 
-    // 장중·프리·애프터마켓은 NORMAL(30s), 완전 마감·주말만 CLOSED(5min)
+    // 장중·프리·애프터마켓은 NORMAL(60s), 완전 마감·주말만 CLOSED(5min)
     const usActive = () => isUsMarketOpen() || isUsPreMarket() || isUsAfterMarket();
 
     const scheduleUs = () => {


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-2.5-pro)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #331

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 스냅샷 응답의 캐시 제어 설정을 최적화했습니다. 핫 버전의 캐시 유효 기간이 30초에서 60초로, 전체 버전은 60초에서 120초로 연장되었습니다.
  * 가격 데이터 REST 폴링 간격을 30초에서 60초로 조정했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->