### PR TITLE
fix(#333): marketHours 세션 정상화 — 미장 데이마켓·국장 NXT 시간대 추가

### DIFF
--- a/src/__tests__/marketHours.test.js
+++ b/src/__tests__/marketHours.test.js
@@ -4,6 +4,10 @@ import {
   isUsMarketOpen,
   isUsPreMarket,
   isUsAfterMarket,
+  isKrPreNxt,
+  isKrPreAuction,
+  isKrAfterNxt,
+  isUsDayMarket,
   getKoreanMarketStatus,
   getUsMarketStatus,
 } from '../utils/marketHours.js';
@@ -160,8 +164,16 @@ describe('marketHours', () => {
       expect(s.label).toBe('거래중');
     });
 
-    it('장 마감 후 → { status: closed }', () => {
+    // #333: 18:00 KST는 NXT 시간외(15:30~20:00) 구간 — phase=afterNxt, status는 'after'로 다운캐스트
+    it('NXT 시간외 (18:00 KST) → { phase: afterNxt, status: after }', () => {
       vi.setSystemTime(kst(2026, 4, 27, 18, 0));
+      const s = getKoreanMarketStatus();
+      expect(s.phase).toBe('afterNxt');
+      expect(s.status).toBe('after');
+    });
+
+    it('완전 마감 20:30 KST → { status: closed }', () => {
+      vi.setSystemTime(kst(2026, 4, 27, 20, 30));
       expect(getKoreanMarketStatus().status).toBe('closed');
     });
 
@@ -188,14 +200,203 @@ describe('marketHours', () => {
       expect(getUsMarketStatus().status).toBe('after');
     });
 
-    it('완전 마감 (22:00 EDT) → { status: closed }', () => {
+    // #333: 22:00 EDT(월 저녁)는 데이마켓 진입 — phase=dayMarket, status는 'after'로 다운캐스트
+    it('데이마켓 (22:00 EDT 월) → { phase: dayMarket, status: after }', () => {
       vi.setSystemTime(edt(2026, 4, 27, 22, 0));
-      expect(getUsMarketStatus().status).toBe('closed');
+      const s = getUsMarketStatus();
+      expect(s.phase).toBe('dayMarket');
+      expect(s.status).toBe('after');
     });
 
     it('NYSE 공휴일 → { status: closed }', () => {
       vi.setSystemTime(estTime(2026, 1, 1, 12, 0));
       expect(getUsMarketStatus().status).toBe('closed');
+    });
+  });
+
+  // ── 국장 NXT / 동시호가 (#333) ──────────────────────────────────
+  // 2026-04-27 = 월요일 평일, KRX 휴장 아님
+  describe('국장 NXT / 동시호가', () => {
+    it('08:00 KST → preNxt (NXT 프리)', () => {
+      vi.setSystemTime(kst(2026, 4, 27, 8, 0));
+      expect(isKrPreNxt()).toBe(true);
+      expect(getKoreanMarketStatus().phase).toBe('preNxt');
+    });
+
+    it('08:29 KST → preNxt (동시호가 직전)', () => {
+      vi.setSystemTime(kst(2026, 4, 27, 8, 29));
+      expect(getKoreanMarketStatus().phase).toBe('preNxt');
+    });
+
+    it('08:30 KST → preAuction (동시호가 우선)', () => {
+      vi.setSystemTime(kst(2026, 4, 27, 8, 30));
+      expect(isKrPreAuction()).toBe(true);
+      expect(getKoreanMarketStatus().phase).toBe('preAuction');
+    });
+
+    it('08:50 KST → isKrPreNxt false (NXT 프리 종료)', () => {
+      vi.setSystemTime(kst(2026, 4, 27, 8, 50));
+      expect(isKrPreNxt()).toBe(false);
+    });
+
+    it('15:30 KST → afterNxt (NXT 시간외 시작)', () => {
+      vi.setSystemTime(kst(2026, 4, 27, 15, 30));
+      expect(isKrAfterNxt()).toBe(true);
+      expect(getKoreanMarketStatus().phase).toBe('afterNxt');
+    });
+
+    it('19:59 KST → afterNxt (NXT 시간외 종료 직전)', () => {
+      vi.setSystemTime(kst(2026, 4, 27, 19, 59));
+      expect(getKoreanMarketStatus().phase).toBe('afterNxt');
+    });
+
+    it('20:00 KST → closed (NXT 시간외 종료)', () => {
+      vi.setSystemTime(kst(2026, 4, 27, 20, 0));
+      expect(isKrAfterNxt()).toBe(false);
+      expect(getKoreanMarketStatus().phase).toBe('closed');
+    });
+
+    it('공휴일 어린이날 2026-05-05 08:00 → 모든 NXT/동시호가 false', () => {
+      vi.setSystemTime(kst(2026, 5, 5, 8, 0));
+      expect(isKrPreNxt()).toBe(false);
+      expect(isKrPreAuction()).toBe(false);
+    });
+
+    it('토요일 16:00 → afterNxt false', () => {
+      vi.setSystemTime(kst(2026, 4, 25, 16, 0));
+      expect(isKrAfterNxt()).toBe(false);
+    });
+  });
+
+  // ── 미장 데이마켓 (#333) ────────────────────────────────────────
+  // ET 20:00~익일 04:00. 블루오션 거래시간: 일 저녁~금 저녁(금 밤·토·일 새벽 제외)
+  describe('미장 데이마켓', () => {
+    it('화 20:00 EDT → dayMarket', () => {
+      vi.setSystemTime(edt(2026, 4, 28, 20, 0));
+      expect(isUsDayMarket()).toBe(true);
+      expect(getUsMarketStatus().phase).toBe('dayMarket');
+    });
+
+    it('화 19:59 EDT → after (데이마켓 직전)', () => {
+      vi.setSystemTime(edt(2026, 4, 28, 19, 59));
+      expect(isUsDayMarket()).toBe(false);
+      expect(getUsMarketStatus().phase).toBe('after');
+    });
+
+    it('화 23:59 EDT → dayMarket', () => {
+      vi.setSystemTime(edt(2026, 4, 28, 23, 59));
+      expect(isUsDayMarket()).toBe(true);
+    });
+
+    it('수 00:00 EDT → dayMarket (자정 넘김)', () => {
+      vi.setSystemTime(edt(2026, 4, 29, 0, 0));
+      expect(isUsDayMarket()).toBe(true);
+    });
+
+    it('수 03:59 EDT → dayMarket (새벽 종료 직전)', () => {
+      vi.setSystemTime(edt(2026, 4, 29, 3, 59));
+      expect(isUsDayMarket()).toBe(true);
+    });
+
+    it('수 04:00 EDT → pre (프리마켓 경계, 데이마켓 종료)', () => {
+      vi.setSystemTime(edt(2026, 4, 29, 4, 0));
+      expect(isUsDayMarket()).toBe(false);
+      expect(getUsMarketStatus().phase).toBe('pre');
+    });
+
+    it('금 20:00 EDT → false (금 밤은 주말 진입, 데이마켓 차단)', () => {
+      vi.setSystemTime(edt(2026, 5, 1, 20, 0));
+      expect(isUsDayMarket()).toBe(false);
+    });
+
+    it('토 02:00 EDT → false (토 새벽 차단)', () => {
+      vi.setSystemTime(edt(2026, 5, 2, 2, 0));
+      expect(isUsDayMarket()).toBe(false);
+    });
+
+    it('일 20:00 EDT → dayMarket (일요일 저녁 진입)', () => {
+      vi.setSystemTime(edt(2026, 5, 3, 20, 0));
+      expect(isUsDayMarket()).toBe(true);
+    });
+
+    it('일 02:00 EDT → false (일 새벽은 주말 연장, 차단)', () => {
+      vi.setSystemTime(edt(2026, 5, 3, 2, 0));
+      expect(isUsDayMarket()).toBe(false);
+    });
+
+    it('NYSE 공휴일 22:00 → closed (데이마켓 차단)', () => {
+      // 2026-01-01(목) 신년 휴장
+      vi.setSystemTime(estTime(2026, 1, 1, 22, 0));
+      expect(isUsDayMarket()).toBe(false);
+      expect(getUsMarketStatus().phase).toBe('closed');
+    });
+  });
+
+  // ── 3축 통합: phase / status / isLive / dataMode (#333) ──────────
+  describe('3축 통합 (phase/status/isLive/dataMode)', () => {
+    it('미장 데이마켓 → phase=dayMarket, status=after, isLive=false, dataMode=lastClose', () => {
+      vi.setSystemTime(edt(2026, 4, 28, 22, 0)); // 화 22:00 ET
+      const s = getUsMarketStatus();
+      expect(s.phase).toBe('dayMarket');
+      expect(s.status).toBe('after');     // 거짓 라이브 금지 — 'open' 아님
+      expect(s.isLive).toBe(false);
+      expect(s.dataMode).toBe('lastClose');
+    });
+
+    it('미장 정규장 12:00 ET → open, isLive=true, dataMode=delayed', () => {
+      vi.setSystemTime(edt(2026, 4, 27, 12, 0));
+      const s = getUsMarketStatus();
+      expect(s.phase).toBe('open');
+      expect(s.status).toBe('open');
+      expect(s.isLive).toBe(true);
+      expect(s.dataMode).toBe('delayed');
+    });
+
+    it('국장 정규장 12:00 KST → open, isLive=true, dataMode=live', () => {
+      vi.setSystemTime(kst(2026, 4, 27, 12, 0));
+      const s = getKoreanMarketStatus();
+      expect(s.phase).toBe('open');
+      expect(s.status).toBe('open');
+      expect(s.isLive).toBe(true);
+      expect(s.dataMode).toBe('live');
+    });
+  });
+
+  // ── dataMode 매핑 검증 (#333) ───────────────────────────────────
+  describe('dataMode 매핑', () => {
+    it('미장 정규장 = delayed', () => {
+      vi.setSystemTime(edt(2026, 4, 27, 12, 0));
+      expect(getUsMarketStatus().dataMode).toBe('delayed');
+    });
+
+    it('미장 데이마켓 = lastClose', () => {
+      vi.setSystemTime(edt(2026, 4, 28, 22, 0));
+      expect(getUsMarketStatus().dataMode).toBe('lastClose');
+    });
+
+    it('미장 프리마켓 = lastClose', () => {
+      vi.setSystemTime(edt(2026, 4, 27, 7, 0));
+      expect(getUsMarketStatus().dataMode).toBe('lastClose');
+    });
+
+    it('미장 애프터마켓 = lastClose', () => {
+      vi.setSystemTime(edt(2026, 4, 27, 18, 0));
+      expect(getUsMarketStatus().dataMode).toBe('lastClose');
+    });
+
+    it('국장 정규장 = live', () => {
+      vi.setSystemTime(kst(2026, 4, 27, 12, 0));
+      expect(getKoreanMarketStatus().dataMode).toBe('live');
+    });
+
+    it('국장 NXT 프리 = lastClose', () => {
+      vi.setSystemTime(kst(2026, 4, 27, 8, 0));
+      expect(getKoreanMarketStatus().dataMode).toBe('lastClose');
+    });
+
+    it('국장 동시호가 = lastClose', () => {
+      vi.setSystemTime(kst(2026, 4, 27, 8, 30));
+      expect(getKoreanMarketStatus().dataMode).toBe('lastClose');
     });
   });
 });

--- a/src/__tests__/marketHours.test.js
+++ b/src/__tests__/marketHours.test.js
@@ -341,6 +341,19 @@ describe('marketHours', () => {
       expect(isUsDayMarket()).toBe(false);
       expect(getUsMarketStatus().phase).toBe('closed');
     });
+
+    // 회귀 방지(Gemini gate): 주말 정규시간대 거짓 'open' 방지 — 명시 weekday 가드
+    it('토 12:00 EDT → closed (주말 정규시간 거짓 open/라이브 방지)', () => {
+      vi.setSystemTime(edt(2026, 5, 2, 12, 0));   // 토요일
+      const s = getUsMarketStatus();
+      expect(s.phase).toBe('closed');
+      expect(s.isLive).toBe(false);
+    });
+
+    it('일 12:00 EDT → closed (주말 정규시간, 저녁 데이마켓 진입 전)', () => {
+      vi.setSystemTime(edt(2026, 5, 3, 12, 0));   // 일요일 낮
+      expect(getUsMarketStatus().phase).toBe('closed');
+    });
   });
 
   // ── 3축 통합: phase / status / isLive / dataMode (#333) ──────────

--- a/src/__tests__/marketHours.test.js
+++ b/src/__tests__/marketHours.test.js
@@ -324,6 +324,17 @@ describe('marketHours', () => {
       expect(isUsDayMarket()).toBe(false);
     });
 
+    // 회귀 방지(architect BLOCK): 일요일 저녁 세션은 월요일 새벽까지 연속 — 월 새벽 누락 버그 차단
+    it('월 02:00 EDT → dayMarket (일요일밤→월새벽 연속, day=1 하한)', () => {
+      vi.setSystemTime(edt(2026, 5, 4, 2, 0));
+      expect(isUsDayMarket()).toBe(true);
+    });
+
+    it('금 02:00 EDT → dayMarket (목요일밤→금새벽 연속, day=5 상한)', () => {
+      vi.setSystemTime(edt(2026, 5, 8, 2, 0));
+      expect(isUsDayMarket()).toBe(true);
+    });
+
     it('NYSE 공휴일 22:00 → closed (데이마켓 차단)', () => {
       // 2026-01-01(목) 신년 휴장
       vi.setSystemTime(estTime(2026, 1, 1, 22, 0));

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -85,15 +85,15 @@ export default function Header({
           {/* 장 운영 상태 */}
           <div className="flex items-center gap-3 text-[13px]">
             <span className="flex items-center gap-1.5">
-              <span className={`w-2 h-2 rounded-full flex-shrink-0 ${kr.status === 'open' ? 'bg-[#2AC769] animate-pulse' : 'bg-[#E5E8EB]'}`} />
+              <span className={`w-2 h-2 rounded-full flex-shrink-0 ${kr.isLive ? 'bg-[#2AC769] animate-pulse' : 'bg-[#E5E8EB]'}`} />
               <span className="text-[#6B7684]">국장</span>
-              <span className={`font-semibold text-[12px] ${kr.status === 'open' ? 'text-[#2AC769]' : 'text-[#B0B8C1]'}`}>{kr.label}</span>
+              <span className={`font-semibold text-[12px] ${kr.isLive ? 'text-[#2AC769]' : 'text-[#B0B8C1]'}`}>{kr.label}</span>
             </span>
             <span className="text-[#E5E8EB]">|</span>
             <span className="flex items-center gap-1.5">
-              <span className={`w-2 h-2 rounded-full flex-shrink-0 ${us.status === 'open' ? 'bg-[#2AC769] animate-pulse' : 'bg-[#E5E8EB]'}`} />
+              <span className={`w-2 h-2 rounded-full flex-shrink-0 ${us.isLive ? 'bg-[#2AC769] animate-pulse' : 'bg-[#E5E8EB]'}`} />
               <span className="text-[#6B7684]">미장</span>
-              <span className={`font-semibold text-[12px] ${us.status === 'open' ? 'text-[#2AC769]' : 'text-[#B0B8C1]'}`}>{us.label}</span>
+              <span className={`font-semibold text-[12px] ${us.isLive ? 'text-[#2AC769]' : 'text-[#B0B8C1]'}`}>{us.label}</span>
             </span>
           </div>
 

--- a/src/components/MarketSummaryBar.jsx
+++ b/src/components/MarketSummaryBar.jsx
@@ -87,14 +87,14 @@ export default function MarketSummaryBar({ indices = [], krwRate = DEFAULT_KRW_R
       {/* 장 운영 상태 */}
       <div className="flex-shrink-0 flex flex-col justify-center gap-1.5 px-4 py-3 border-r border-[#F2F4F6]">
         <div className="flex items-center gap-1.5">
-          <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${kr.status === 'open' ? 'bg-[#2AC769] animate-pulse' : 'bg-[#E5E8EB]'}`} />
+          <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${kr.isLive ? 'bg-[#2AC769] animate-pulse' : 'bg-[#E5E8EB]'}`} />
           <span className="text-[10px] text-[#8B95A1]">국장</span>
-          <span className={`text-[10px] font-bold ${kr.status === 'open' ? 'text-[#2AC769]' : 'text-[#B0B8C1]'}`}>{kr.label}</span>
+          <span className={`text-[10px] font-bold ${kr.isLive ? 'text-[#2AC769]' : 'text-[#B0B8C1]'}`}>{kr.label}</span>
         </div>
         <div className="flex items-center gap-1.5">
-          <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${us.status === 'open' ? 'bg-[#2AC769] animate-pulse' : 'bg-[#E5E8EB]'}`} />
+          <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${us.isLive ? 'bg-[#2AC769] animate-pulse' : 'bg-[#E5E8EB]'}`} />
           <span className="text-[10px] text-[#8B95A1]">미장</span>
-          <span className={`text-[10px] font-bold ${us.status === 'open' ? 'text-[#2AC769]' : 'text-[#B0B8C1]'}`}>{us.label}</span>
+          <span className={`text-[10px] font-bold ${us.isLive ? 'text-[#2AC769]' : 'text-[#B0B8C1]'}`}>{us.label}</span>
         </div>
       </div>
 
@@ -102,7 +102,7 @@ export default function MarketSummaryBar({ indices = [], krwRate = DEFAULT_KRW_R
       <div className="flex items-center py-2 px-1">
         {displayIndices.map(idx => {
           const market = INDEX_MARKET[idx.id];
-          const isOpen = market === 'kr' ? kr.status === 'open' : market === 'us' ? us.status === 'open' : false;
+          const isOpen = market === 'kr' ? kr.isLive : market === 'us' ? us.isLive : false;
           return <IndexItem key={idx.id} idx={idx} isOpen={isOpen} />;
         })}
       </div>

--- a/src/components/SurgeBanner.jsx
+++ b/src/components/SurgeBanner.jsx
@@ -39,8 +39,9 @@ const C = {
 // React.memo: coins WS 틱마다 재렌더 방지 — 급등 순위 실제 변경 시에만 업데이트
 const SurgeBanner = memo(function SurgeBanner({ stocks = [], coins = [], indices = [], onClick }) {
   const { items, hasHot, isIndexMode } = useMemo(() => {
-    const krOpen = getKoreanMarketStatus().status === 'open';
-    const usOpen = getUsMarketStatus().status === 'open';
+    // isLive 기반 — 데이마켓 등 비라이브 세션 종목은 자동 제외(거짓 라이브 방지)
+    const krOpen = getKoreanMarketStatus().isLive;
+    const usOpen = getUsMarketStatus().isLive;
 
     // ELW/ETN/파생상품 필터 — 이름 미해결, 상한가 초과, 또는 파생상품 키워드
     const isDerivative = (s) => {

--- a/src/components/WatchlistTable.jsx
+++ b/src/components/WatchlistTable.jsx
@@ -501,18 +501,25 @@ function SortHeader({ label, sortKey, currentKey, currentDir, onSort, className 
 
 
 // 탭 타입별 장 상태 배지 (사용자에게 데이터 freshness 명시)
+// phase + dataMode 기반 — isLive(라이브 표현) 세션은 배지 생략, lastClose 세션만 freshness 안내
 function MarketStatusBadge({ type }) {
   if (type === 'etf' || type === 'coin') return null;
-  const { status, label } = type === 'kr' ? getKoreanMarketStatus() : getUsMarketStatus();
-  if (status === 'open') return null; // 거래 중이면 배지 불필요
-  const text = type === 'kr'
-    ? `${label} · 전일 종가 기준`
-    : status === 'pre' ? `${label} · 정규장 전`
-    : status === 'after' ? `${label} · 정규장 후`
-    : `${label} · 전일 종가 기준`;
+  const { phase, label, isLive } = type === 'kr' ? getKoreanMarketStatus() : getUsMarketStatus();
+  if (isLive) return null; // 라이브(국장 정규장·미장 정규장)는 배지 불필요
+  // phase별 부가 설명 — 모두 lastClose(전일 종가 기준)이나 세션 성격을 함께 노출
+  let suffix;
+  switch (phase) {
+    case 'pre':        suffix = '정규장 전'; break;       // 미장 프리마켓
+    case 'after':      suffix = '정규장 후'; break;       // 미장 애프터
+    case 'dayMarket':  suffix = '실시간 추적 안됨'; break; // 미장 데이마켓
+    case 'preNxt':     suffix = '정규장 전'; break;       // 국장 NXT 프리
+    case 'preAuction': suffix = '정규장 전'; break;       // 국장 동시호가
+    case 'afterNxt':   suffix = '정규장 후'; break;       // 국장 NXT 시간외
+    default:           suffix = '전일 종가 기준'; break;   // closed
+  }
   return (
     <span className="text-[11px] text-[#8B95A1] bg-[#F2F4F6] px-2 py-1 rounded-lg flex-shrink-0">
-      {text}
+      {label} · {suffix}
     </span>
   );
 }

--- a/src/components/home/HotListSection.jsx
+++ b/src/components/home/HotListSection.jsx
@@ -83,16 +83,22 @@ function SkeletonHotRow({ count = 5 }) {
 }
 
 export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop, usDrop, coinDrop, krwRate, onItemClick }) {
-  const krOpen = getKoreanMarketStatus().status === 'open';
-  const usOpen = getUsMarketStatus().status === 'open';
-  const krLabel = getKoreanMarketStatus().label;
-  const usLabel = getUsMarketStatus().label;
+  // isLive: 녹색 펄스(거래중 표현) 단일 트리거 — 국장 정규장(live)·미장 정규장(delayed) 모두 true
+  const krStatus = getKoreanMarketStatus();
+  const usStatus = getUsMarketStatus();
+  const krOpen = krStatus.isLive;
+  const usOpen = usStatus.isLive;
+  const krLabel = krStatus.label;
+  const usLabel = usStatus.label;
 
-  // 휴장 시 종목 리스트 위에 라벨 표시 (종목은 딤 처리로 유지)
-  const ClosedLabel = ({ label }) => (
+  // 휴장/비라이브 시 종목 리스트 위에 라벨 표시 (종목은 딤 처리로 유지)
+  // dataMode별 부가 텍스트: 데이마켓="실시간 추적 안됨", 그 외 lastClose="종가 기준"
+  const ClosedLabel = ({ label, phase }) => (
     <div className="px-4 pt-2 pb-1 flex items-center gap-1.5">
       <span className="text-[10px] text-[#B0B8C1]">🌙 {label}</span>
-      <span className="text-[10px] text-[#C9CDD2]">· 전일 종가 기준</span>
+      <span className="text-[10px] text-[#C9CDD2]">
+        · {phase === 'dayMarket' ? '실시간 추적 안됨' : '종가 기준'}
+      </span>
     </div>
   );
 
@@ -111,7 +117,7 @@ export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop,
             <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#FFF0F0] text-[#F04452]">TOP 5</span>
           </div>
           <div className="py-1">
-            {!krOpen && <ClosedLabel label={krLabel} />}
+            {!krOpen && <ClosedLabel label={krLabel} phase={krStatus.phase} />}
             {!hasData
               ? <SkeletonHotRow count={5} />
               : krHot.length > 0
@@ -140,7 +146,7 @@ export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop,
             <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#EDF4FF] text-[#3182F6]">TOP 5</span>
           </div>
           <div className="py-1">
-            {!usOpen && <ClosedLabel label={usLabel} />}
+            {!usOpen && <ClosedLabel label={usLabel} phase={usStatus.phase} />}
             {!hasData
               ? <SkeletonHotRow count={5} />
               : usHot.length > 0
@@ -199,7 +205,7 @@ export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop,
             <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#EDF4FF] text-[#1764ED]">TOP 5</span>
           </div>
           <div className="py-1">
-            {!krOpen && <ClosedLabel label={krLabel} />}
+            {!krOpen && <ClosedLabel label={krLabel} phase={krStatus.phase} />}
             {!hasData
               ? <SkeletonHotRow count={5} />
               : krDrop.map((item, i) => (
@@ -226,7 +232,7 @@ export default function HotListSection({ hasData, krHot, usHot, coinHot, krDrop,
             <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-[#EDF4FF] text-[#1764ED]">TOP 5</span>
           </div>
           <div className="py-1">
-            {!usOpen && <ClosedLabel label={usLabel} />}
+            {!usOpen && <ClosedLabel label={usLabel} phase={usStatus.phase} />}
             {!hasData
               ? <SkeletonHotRow count={5} />
               : usDrop.map((item, i) => (

--- a/src/components/home/NotableMoversSection.jsx
+++ b/src/components/home/NotableMoversSection.jsx
@@ -179,8 +179,9 @@ function NotableCard({ item, newsCount, volumeRank, whyReason, krwRate, onClick 
 const SLOT_MS = 20 * 60 * 1000;
 
 export default function NotableMoversSection({ allItems = [], recentNews = [], krwRate = DEFAULT_KRW_RATE, onItemClick }) {
-  const krOpen = getKoreanMarketStatus().status === 'open';
-  const usOpen = getUsMarketStatus().status === 'open';
+  // isLive 기반 — 데이마켓/프리/애프터 등 비라이브 세션은 _isClosed=true로 -5 페널티 유지(거짓 라이브 방지, 의도적)
+  const krOpen = getKoreanMarketStatus().isLive;
+  const usOpen = getUsMarketStatus().isLive;
 
   // 20분마다 바뀌는 슬롯 — 동점 항목 순환을 위해 사용
   const [timeSlot, setTimeSlot] = useState(Math.floor(Date.now() / SLOT_MS));

--- a/src/constants/polling.js
+++ b/src/constants/polling.js
@@ -14,3 +14,7 @@ export const POLLING = {
   SLOW:        60_000 * DEV_MULTIPLIER,  // 60초  — 하위호환 유지 (직접 참조 파일 없앤 후 제거 예정)
   SPARKLINE:  600_000 * DEV_MULTIPLIER,  // 10분  — CoinGecko sparkline (분봉 delta)
 };
+
+// 폴링 대상 dataMode — live/delayed 만 NORMAL 폴링, lastClose는 CLOSED(폴링 안 함)
+// usePrices의 usActive/krActive가 이 집합으로 판정 (거짓 라이브·Upstash 낭비 방지)
+export const POLLABLE_DATA_MODES = new Set(['live', 'delayed']);

--- a/src/constants/sessionDataMode.js
+++ b/src/constants/sessionDataMode.js
@@ -1,0 +1,23 @@
+// 세션 → 데이터 신뢰 모드 매핑
+// dataMode: 'live' | 'delayed' | 'lastClose'
+//   - live:      실시간 시세 (국장 정규장 = 한국투자증권 실시간)
+//   - delayed:   지연 시세 (미장 정규장 = Yahoo 15분 지연)
+//   - lastClose: 전일 종가 기준 (실시간 추적 안 됨)
+//
+// 2차 실데이터 연동 시 이 테이블만 수정하면 됨 (marketHours.js는 불변).
+// 1차는 보수적으로 신규 세션(NXT·동시호가·데이마켓·프리·애프터)을 전부 lastClose로 둔다.
+export const KR_SESSION_DATA_MODE = {
+  open:       'live',
+  preAuction: 'lastClose',
+  preNxt:     'lastClose',
+  afterNxt:   'lastClose',
+  closed:     'lastClose',
+};
+
+export const US_SESSION_DATA_MODE = {
+  open:      'delayed',
+  pre:       'lastClose',
+  after:     'lastClose',
+  dayMarket: 'lastClose',
+  closed:    'lastClose',
+};

--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -6,8 +6,8 @@ import KR_STOCK_NAMES from '../data/krStockNames.json';
 import { fetchSnapshot } from '../api/snapshot';
 import { fetchUsStocksBatch, fetchKoreanStocksBatch } from '../api/stocks';
 import { checkAndAlertBatch } from '../utils/priceAlert';
-import { POLLING } from '../constants/polling';
-import { isKoreanMarketOpen, isUsMarketOpen, isUsPreMarket, isUsAfterMarket } from '../utils/marketHours';
+import { POLLING, POLLABLE_DATA_MODES } from '../constants/polling';
+import { getKoreanMarketStatus, getUsMarketStatus } from '../utils/marketHours';
 
 // US_STOCK_LIST 메타맵 — 모듈 스코프에 1회만 생성 (sector/nameEn fallback)
 const US_META_MAP = new Map(US_STOCK_LIST.map(s => [s.symbol, s]));
@@ -238,8 +238,10 @@ export function usePrices() {
     let usInFlight = false;
     let krInFlight = false;
 
-    // 장중·프리·애프터마켓은 NORMAL(60s), 완전 마감·주말만 CLOSED(5min)
-    const usActive = () => isUsMarketOpen() || isUsPreMarket() || isUsAfterMarket();
+    // 폴링 활성 판정은 dataMode 기반 — live/delayed 세션만 NORMAL(60s), lastClose는 CLOSED(5min)
+    // (1차: 신규 세션 전부 lastClose → 거짓 라이브·Upstash 낭비 0)
+    const usActive = () => POLLABLE_DATA_MODES.has(getUsMarketStatus().dataMode);
+    const krActive = () => POLLABLE_DATA_MODES.has(getKoreanMarketStatus().dataMode);
 
     const scheduleUs = () => {
       if (destroyed) return;
@@ -260,8 +262,8 @@ export function usePrices() {
     const scheduleKr = () => {
       if (destroyed) return;
       const myGen = ++krGen;
-      // 한국장: 정규장(09:00~15:30)만 NORMAL, 이후 시간외/주말은 CLOSED
-      const delay = isKoreanMarketOpen() ? POLLING.NORMAL : POLLING.CLOSED;
+      // 한국장: dataMode 기반 — live(정규장)만 NORMAL, lastClose(시간외/NXT/주말)는 CLOSED
+      const delay = krActive() ? POLLING.NORMAL : POLLING.CLOSED;
       krTimerId = setTimeout(async () => {
         if (destroyed || myGen !== krGen) return;
         try {
@@ -276,7 +278,7 @@ export function usePrices() {
 
     // 단일 스냅샷으로 scheduleUs/Kr 및 prev* 초기화 — 경계 시점 이중 읽기 race 방지
     let prevUsActive = usActive();
-    let prevKrActive = isKoreanMarketOpen();
+    let prevKrActive = krActive();
 
     refreshUsStocks();
     refreshKoreanStocks();
@@ -300,7 +302,7 @@ export function usePrices() {
     const transitionCheckerId = setInterval(() => {
       if (destroyed) return;
       const nowUsActive = usActive();
-      const nowKrActive = isKoreanMarketOpen();
+      const nowKrActive = krActive();
       if (!document.hidden) {
         if (!prevUsActive && nowUsActive) {
           clearTimeout(usTimerId);

--- a/src/utils/marketHours.js
+++ b/src/utils/marketHours.js
@@ -204,8 +204,9 @@ export function isUsDayMarket(est = nowEST()) {
   const isDawn    = minutes < 4 * 60;        // 00:00~03:59
   // 저녁(20~24시): 일~목만 (금·토 밤은 주말 진입이므로 제외)
   if (isEvening) return day >= 0 && day <= 4;
-  // 새벽(0~4시): 화~금만 (목요일밤→금새벽이 마지막. 토·일 새벽은 주말이므로 제외, 월 새벽도 제외)
-  if (isDawn)    return day >= 2 && day <= 5;
+  // 새벽(0~4시): 월~금 (일요일밤→월새벽 시작 ~ 목요일밤→금새벽 마지막. 토·일 새벽만 주말이므로 제외)
+  // 저녁 일~목(0~4)과 짝: 일저녁→월새벽, 목저녁→금새벽으로 자정 연속성 유지
+  if (isDawn)    return day >= 1 && day <= 5;
   return false;
 }
 
@@ -238,7 +239,7 @@ function buildLabel(market, phase, opts = {}) {
 function buildStatus(market, phase, opts = {}) {
   const dataMode = (market === 'kr' ? KR_SESSION_DATA_MODE : US_SESSION_DATA_MODE)[phase];
   const status   = bucketize(phase);                 // 하위호환 다운캐스트
-  const isLive   = dataMode !== 'lastClose';         // 녹색 펄스(거래중 표현) 단일 트리거
+  const isLive   = dataMode === 'live' || dataMode === 'delayed'; // 녹색 펄스 단일 트리거 (allowlist — 미지/누락 phase는 안전측 false)
   const label    = buildLabel(market, phase, opts);
   const color    = isLive ? 'up' : 'neutral';        // 死필드(기존 color) 호환 유지
   return { status, phase, label, color, isLive, dataMode };

--- a/src/utils/marketHours.js
+++ b/src/utils/marketHours.js
@@ -133,8 +133,7 @@ function isWeekday(d) {
 }
 
 // 국내 주식 (KST 09:00~15:30)
-export function isKoreanMarketOpen() {
-  const kst = nowKST();
+export function isKoreanMarketOpen(kst = nowKST()) {
   if (!isWeekday(kst)) return false;
   if (isKrxHoliday(kst)) return false;
   const h = kst.getHours(), m = kst.getMinutes();
@@ -250,7 +249,7 @@ export function getKoreanMarketStatus() {
   const isHolidayOrWeekend = !isWeekday(kst) || isKrxHoliday(kst);
   let phase;
   if (isHolidayOrWeekend)         phase = 'closed';
-  else if (isKoreanMarketOpen())  phase = 'open';
+  else if (isKoreanMarketOpen(kst)) phase = 'open';   // 단일 스냅샷 kst 주입(경계 흔들림 방지)
   else if (isKrPreAuction(kst))   phase = 'preAuction'; // 08:30~09:00 우선
   else if (isKrPreNxt(kst))       phase = 'preNxt';     // 08:00~08:30 단독
   else if (isKrAfterNxt(kst))     phase = 'afterNxt';
@@ -260,15 +259,16 @@ export function getKoreanMarketStatus() {
 
 export function getUsMarketStatus() {
   const est = nowEST();                               // 단일 스냅샷 — 모든 판정에 주입
-  // 주말 가드는 제거: isUsDayMarket이 일요일 저녁/평일 새벽을 통과해야 하므로
-  // 요일 경계는 각 세션 함수 내부가 담당하고, 최상단 가드는 휴장일만.
+  // 정규/프리/애프터는 평일에만 판정(주말 거짓 라이브 방지 — 명시적 이중 가드).
+  // 데이마켓은 자체 요일 로직(isUsDayMarket)이 일요일밤·평일새벽 경계를 담당하므로 주말 가드 제외.
+  const weekday = isWeekday(est);
   let phase;
-  if (isNyseHoliday(est))         phase = 'closed';
-  else if (isUsMarketOpen(est))   phase = 'open';
-  else if (isUsPreMarket(est))    phase = 'pre';
-  else if (isUsAfterMarket(est))  phase = 'after';
-  else if (isUsDayMarket(est))    phase = 'dayMarket';
-  else                            phase = 'closed';
+  if (isNyseHoliday(est))                    phase = 'closed';
+  else if (weekday && isUsMarketOpen(est))   phase = 'open';
+  else if (weekday && isUsPreMarket(est))    phase = 'pre';
+  else if (weekday && isUsAfterMarket(est))  phase = 'after';
+  else if (isUsDayMarket(est))               phase = 'dayMarket';
+  else                                       phase = 'closed';
   const earlyClose = phase === 'open' && isNyseEarlyClose(est);
   const isHolidayOrWeekend = phase === 'closed' && (isNyseHoliday(est) || !isWeekday(est));
   return buildStatus('us', phase, { earlyClose, isHolidayOrWeekend });

--- a/src/utils/marketHours.js
+++ b/src/utils/marketHours.js
@@ -220,7 +220,7 @@ function bucketize(phase) {
 }
 
 // ─── phase → 한국어 라벨 ────────────────────────────────────────
-function buildLabel(market, phase, opts = {}) {
+function buildLabel(phase, opts = {}) {
   switch (phase) {
     case 'open':       return opts.earlyClose ? '거래중(조기종료)' : '거래중';
     case 'dayMarket':  return '데이마켓';
@@ -239,7 +239,7 @@ function buildStatus(market, phase, opts = {}) {
   const dataMode = (market === 'kr' ? KR_SESSION_DATA_MODE : US_SESSION_DATA_MODE)[phase];
   const status   = bucketize(phase);                 // 하위호환 다운캐스트
   const isLive   = dataMode === 'live' || dataMode === 'delayed'; // 녹색 펄스 단일 트리거 (allowlist — 미지/누락 phase는 안전측 false)
-  const label    = buildLabel(market, phase, opts);
+  const label    = buildLabel(phase, opts);
   const color    = isLive ? 'up' : 'neutral';        // 死필드(기존 color) 호환 유지
   return { status, phase, label, color, isLive, dataMode };
 }

--- a/src/utils/marketHours.js
+++ b/src/utils/marketHours.js
@@ -1,4 +1,5 @@
 // 장 운영시간 유틸리티
+import { KR_SESSION_DATA_MODE, US_SESSION_DATA_MODE } from '../constants/sessionDataMode';
 
 // ─── KRX 휴장일 (완전 휴장) ────────────────────────────────────
 // 출처: 한국법령정보센터 공공기관 법정 공휴일 + KRX 거래소 휴장일 기준
@@ -168,25 +169,106 @@ export function isUsAfterMarket(est = nowEST()) {
   return minutes >= afterStart && minutes < 20 * 60;
 }
 
+// ─── 신규 세션 판정 함수 (NXT·동시호가·미장 데이마켓) ───────────
+// 모두 단일 스냅샷 주입 가능 (getXxxMarketStatus에서 동일 시각 재사용 → 경계 흔들림 방지)
+
+// 국장 NXT 프리마켓 (KST 08:00~08:50) — 평일·휴장일 가드
+export function isKrPreNxt(kst = nowKST()) {
+  if (!isWeekday(kst) || isKrxHoliday(kst)) return false;
+  const minutes = kst.getHours() * 60 + kst.getMinutes();
+  return minutes >= 8 * 60 && minutes < 8 * 60 + 50;
+}
+
+// 국장 동시호가 (KST 08:30~09:00) — 기존 getKoreanMarketStatus 인라인 로직을 함수로 추출
+export function isKrPreAuction(kst = nowKST()) {
+  if (!isWeekday(kst) || isKrxHoliday(kst)) return false;
+  const minutes = kst.getHours() * 60 + kst.getMinutes();
+  return minutes >= 8 * 60 + 30 && minutes < 9 * 60;
+}
+
+// 국장 NXT 시간외 (KST 15:30~20:00) — 평일·휴장일 가드
+export function isKrAfterNxt(kst = nowKST()) {
+  if (!isWeekday(kst) || isKrxHoliday(kst)) return false;
+  const minutes = kst.getHours() * 60 + kst.getMinutes();
+  return minutes >= 15 * 60 + 30 && minutes < 20 * 60;
+}
+
+// 미장 데이마켓 (ET 20:00~익일 04:00) — 자정 넘김 + 요일 경계 처리
+// 블루오션 거래 시간: 일요일 저녁 ~ 금요일 저녁(금 밤 제외).
+// 주말 차단은 isWeekday가 아니라 아래 요일 로직이 담당 (일요일 저녁 통과 필요).
+export function isUsDayMarket(est = nowEST()) {
+  if (isNyseHoliday(est)) return false;
+  const day = est.getDay();                 // 0=일 … 6=토
+  const minutes = est.getHours() * 60 + est.getMinutes();
+  const isEvening = minutes >= 20 * 60;      // 20:00~23:59
+  const isDawn    = minutes < 4 * 60;        // 00:00~03:59
+  // 저녁(20~24시): 일~목만 (금·토 밤은 주말 진입이므로 제외)
+  if (isEvening) return day >= 0 && day <= 4;
+  // 새벽(0~4시): 화~금만 (목요일밤→금새벽이 마지막. 토·일 새벽은 주말이므로 제외, 월 새벽도 제외)
+  if (isDawn)    return day >= 2 && day <= 5;
+  return false;
+}
+
+// ─── phase → 하위호환 status 다운캐스트 ─────────────────────────
+// 기존 소비처(status==='open' 단일 기준)가 신규 phase에서도 안전 폴백되도록 버킷화.
+// ⚠️ dataMode가 lastClose인 세션(데이마켓·프리·애프터·NXT 등)은 절대 'open'으로 올리지 않는다(거짓 라이브 방지).
+function bucketize(phase) {
+  if (phase === 'open') return 'open';
+  if (phase === 'pre' || phase === 'preNxt' || phase === 'preAuction') return 'pre';
+  if (phase === 'after' || phase === 'afterNxt' || phase === 'dayMarket') return 'after';
+  return 'closed';
+}
+
+// ─── phase → 한국어 라벨 ────────────────────────────────────────
+function buildLabel(market, phase, opts = {}) {
+  switch (phase) {
+    case 'open':       return opts.earlyClose ? '거래중(조기종료)' : '거래중';
+    case 'dayMarket':  return '데이마켓';
+    case 'pre':        return '프리마켓';
+    case 'after':      return '애프터';
+    case 'preNxt':     return 'NXT 프리';
+    case 'afterNxt':   return 'NXT 시간외';
+    case 'preAuction': return '동시호가';
+    case 'closed':     return opts.isHolidayOrWeekend ? '휴장' : '장마감';
+    default:           return '장마감';
+  }
+}
+
+// ─── 통합 상태 빌더 — 3축 분리(phase / isLive / dataMode) + 하위호환 status ─────
+function buildStatus(market, phase, opts = {}) {
+  const dataMode = (market === 'kr' ? KR_SESSION_DATA_MODE : US_SESSION_DATA_MODE)[phase];
+  const status   = bucketize(phase);                 // 하위호환 다운캐스트
+  const isLive   = dataMode !== 'lastClose';         // 녹색 펄스(거래중 표현) 단일 트리거
+  const label    = buildLabel(market, phase, opts);
+  const color    = isLive ? 'up' : 'neutral';        // 死필드(기존 color) 호환 유지
+  return { status, phase, label, color, isLive, dataMode };
+}
+
 export function getKoreanMarketStatus() {
-  const kst = nowKST();
-  if (!isWeekday(kst) || isKrxHoliday(kst)) return { status: 'closed', label: '휴장', color: 'neutral' };
-  if (isKoreanMarketOpen()) return { status: 'open', label: '거래중', color: 'up' };
-  const h = kst.getHours(), m = kst.getMinutes();
-  const minutes = h * 60 + m;
-  if (minutes >= 8 * 60 + 30 && minutes < 9 * 60) return { status: 'pre', label: '동시호가', color: 'neutral' };
-  return { status: 'closed', label: '장마감', color: 'neutral' };
+  const kst = nowKST();                               // 단일 스냅샷 — 모든 판정에 주입
+  const isHolidayOrWeekend = !isWeekday(kst) || isKrxHoliday(kst);
+  let phase;
+  if (isHolidayOrWeekend)         phase = 'closed';
+  else if (isKoreanMarketOpen())  phase = 'open';
+  else if (isKrPreAuction(kst))   phase = 'preAuction'; // 08:30~09:00 우선
+  else if (isKrPreNxt(kst))       phase = 'preNxt';     // 08:00~08:30 단독
+  else if (isKrAfterNxt(kst))     phase = 'afterNxt';
+  else                            phase = 'closed';
+  return buildStatus('kr', phase, { isHolidayOrWeekend });
 }
 
 export function getUsMarketStatus() {
-  // 단일 스냅샷으로 모든 판정 — 경계 시점 흔들림 방지
-  const est = nowEST();
-  if (!isWeekday(est) || isNyseHoliday(est)) return { status: 'closed', label: '휴장', color: 'neutral' };
-  if (isUsMarketOpen(est)) {
-    if (isNyseEarlyClose(est)) return { status: 'open', label: '거래중(조기종료)', color: 'up' };
-    return { status: 'open', label: '거래중', color: 'up' };
-  }
-  if (isUsPreMarket(est)) return { status: 'pre', label: '프리마켓', color: 'neutral' };
-  if (isUsAfterMarket(est)) return { status: 'after', label: '애프터', color: 'neutral' };
-  return { status: 'closed', label: '장마감', color: 'neutral' };
+  const est = nowEST();                               // 단일 스냅샷 — 모든 판정에 주입
+  // 주말 가드는 제거: isUsDayMarket이 일요일 저녁/평일 새벽을 통과해야 하므로
+  // 요일 경계는 각 세션 함수 내부가 담당하고, 최상단 가드는 휴장일만.
+  let phase;
+  if (isNyseHoliday(est))         phase = 'closed';
+  else if (isUsMarketOpen(est))   phase = 'open';
+  else if (isUsPreMarket(est))    phase = 'pre';
+  else if (isUsAfterMarket(est))  phase = 'after';
+  else if (isUsDayMarket(est))    phase = 'dayMarket';
+  else                            phase = 'closed';
+  const earlyClose = phase === 'open' && isNyseEarlyClose(est);
+  const isHolidayOrWeekend = phase === 'closed' && (isNyseHoliday(est) || !isWeekday(est));
+  return buildStatus('us', phase, { earlyClose, isHolidayOrWeekend });
 }


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-3.1-pro-preview)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #333

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 국내 시장의 세분화된 거래 단계 표시 추가 (NXT, 동시호가, 시간외 등)
  * 미국 시장 데이마켓 세션 구분 추가
  * 거래 중/비거래 상태 판정 정확도 개선

* **Tests**
  * 시장 운영 상태 테스트 범위 확장 및 다양한 세션 경계 케이스 검증 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->