### PR TITLE
feat(#335): 주도주 알고리즘 + 시간대 인지 모핑 포커스 UI

### DIFF
--- a/.algo-files
+++ b/.algo-files
@@ -5,6 +5,7 @@ src/utils/newsAlias.js
 src/utils/newsTopicMap.js
 src/utils/newsSignal.js
 src/utils/signalCardRenderer.js
+src/utils/leadingStocks.js
 src/data/relatedAssets.js
 src/hooks/useSignals.js
 src/hooks/useDerivativeSignals.js

--- a/api/snapshot.js
+++ b/api/snapshot.js
@@ -12,7 +12,7 @@ const CORS_HEADERS = {
 };
 
 // ─── 필드 스트리핑 (화면에 사용하는 필드만 전송) ───────────────
-// 제거: Coins→accTradePrice24h/highPrice/lowPrice
+// 제거: Coins→highPrice/lowPrice
 // #185: KR exchange(kospi/kosdaq) 보존 — 뱃지 렌더링 회귀 방지.
 function stripStocks(items) {
   if (!Array.isArray(items)) return items;
@@ -20,10 +20,13 @@ function stripStocks(items) {
     ({ symbol, name, price, change, changePct, volume, marketCap, market, exchange }));
 }
 
+// #335: accTradePrice24h 추가 — 코인 거래대금 복구 (volume24h는 0 고정이라 사용 불가).
+//       소스(update-coins.js)는 t.acc_trade_price_24h로 채우지만 strip에서 버려졌음.
+//       주도주 알고리즘(leadingStocks.js)이 코인 회전율 대체값으로 소비.
 function stripCoins(items) {
   if (!Array.isArray(items)) return items;
-  return items.map(({ id, symbol, name, market, priceKrw, change24h, priceUsd, marketCap, volume24h }) =>
-    ({ id, symbol, name, market, priceKrw, change24h, priceUsd, marketCap, volume24h }));
+  return items.map(({ id, symbol, name, market, priceKrw, change24h, priceUsd, marketCap, volume24h, accTradePrice24h }) =>
+    ({ id, symbol, name, market, priceKrw, change24h, priceUsd, marketCap, volume24h, accTradePrice24h }));
 }
 
 // ─── ETag: JSON 문자열 해시 (모든 필드 변경 감지, 충돌 불가) ────

--- a/src/__tests__/home-layout.test.js
+++ b/src/__tests__/home-layout.test.js
@@ -50,7 +50,8 @@ const REQUIRED_IMPORTS = [
   'AiDebateSection',
   'ExploreTabsWidget',
   'NewsFeedWidget',
-  'NotableMoversSection',
+  // NotableMoversSection → MorphingFocusSection으로 흡수 (#335, 시간대별 주도주/주목 자동 전환)
+  'MorphingFocusSection',
 ];
 
 describe('홈 레이아웃 — 핵심 위젯 누락 방지', () => {

--- a/src/__tests__/leadingStocks.test.js
+++ b/src/__tests__/leadingStocks.test.js
@@ -121,6 +121,27 @@ describe('MIN_TURNOVER 잡주 컷', () => {
     expect(scored.find((s) => s.symbol === 'SMALL')).toBeUndefined();
     expect(scored.find((s) => s.symbol === 'BTC')).toBeDefined();
   });
+  // [HIGH3] 지수 ETF(_isEtf) 배제 — 주도주/테마는 개별주여야 함
+  it('지수 ETF(_isEtf)는 거래대금 압도적이라도 leaders/movers에서 제외', () => {
+    const spy = { ...usStock({ symbol: 'SPY', name: 'SPDR S&P 500', price: 500, volume: 50_000_000, marketCap: 600e9, changePct: 1 }), _isEtf: true };
+    const qqq = { ...usStock({ symbol: 'QQQ', name: 'Invesco QQQ', price: 400, volume: 40_000_000, marketCap: 300e9, changePct: 1.2 }), _isEtf: true };
+    const aapl = usStock({ symbol: 'AAPL', name: 'Apple', price: 200, volume: 5_000_000, marketCap: 3e12, changePct: 2 });
+    const scored = scoreMarketItems([spy, qqq, aapl], { krwRate: KRW, recentNews: [] });
+    expect(scored.find((s) => s.symbol === 'SPY')).toBeUndefined();
+    expect(scored.find((s) => s.symbol === 'QQQ')).toBeUndefined();
+    expect(scored.find((s) => s.symbol === 'AAPL')).toBeDefined();
+  });
+  // [W2/STYLE4] 코인 무변동 컷 — turnoverPercentileOf(코인 분기) 기준 판정.
+  // 기존엔 ratioPercentileOf(주식 분기)를 코인에 적용해 항상 0→무조건 컷되던 버그.
+  // 거래대금 상위 코인은 변동 0이라도 보존되어야 함.
+  it('변동 0인 거래대금 최상위 코인은 보존(코인은 turnoverPercentile 기준)', () => {
+    // 3개 모수에서 거래대금 최상위(percentile≈83)인 FLAT을 변동 0으로 둠 → 보존되어야 정상
+    const small1 = coin({ symbol: 'SC1', accTradePrice24h: 2e10, change24h: 5 });   // 200억(최소 통과)
+    const small2 = coin({ symbol: 'SC2', accTradePrice24h: 3e10, change24h: 4 });   // 300억
+    const flatTop = coin({ symbol: 'FLAT', accTradePrice24h: 1e12, change24h: 0 }); // 1조, 변동 0
+    const scored = scoreMarketItems([small1, small2, flatTop], { krwRate: KRW, recentNews: [] });
+    expect(scored.find((s) => s.symbol === 'FLAT')).toBeDefined();
+  });
 });
 
 // ─── scoreLeading 분해 ────────────────────────────────────────
@@ -207,6 +228,32 @@ describe('clusterThemes', () => {
     expect(hotBat.score).toBeGreaterThan(coldBat.score);
   });
 
+  // [W1] AI 뉴스가 범용 '소프트웨어' 섹터를 자동으로 부스트하지 않아야 함
+  it('AI 뉴스: AI/IT소프트웨어는 핫, 범용 "소프트웨어"는 콜드(과합치 방지)', () => {
+    const items = [
+      { symbol: 'A',  name: 'AI Co',   sector: 'AI/소프트웨어', _leadScore: 80 },
+      { symbol: 'IT', name: 'IT Soft', sector: 'IT소프트웨어',  _leadScore: 70 },
+      { symbol: 'SW', name: 'Generic', sector: '소프트웨어',    _leadScore: 70 },
+    ];
+    const aiNews = [{ title: 'AI 데이터센터 신규 수주, 인공지능 칩 수요 폭발' }]; // → AI/IT소프트웨어/반도체
+    const res = clusterThemes(items, aiNews);
+    const aiT  = res.themes.find((t) => t.theme === 'AI/소프트웨어');
+    const itT  = res.themes.find((t) => t.theme === 'IT소프트웨어');
+    const swT  = res.themes.find((t) => t.theme === '소프트웨어');
+    expect(aiT.hot).toBe(true);
+    expect(itT.hot).toBe(true);
+    expect(swT.hot).toBe(false); // 범용 '소프트웨어'는 AI 뉴스로 자동 핫섹터 처리되지 않음
+  });
+
+  // [W5] precomputedHotList 주입 — detectNewsSectors 중복 계산 회피 경로
+  it('precomputedHotList 주입 시 recentNews 무시하고 외부 핫섹터 적용', () => {
+    const items = [{ symbol: 'A', name: 'A', sector: '반도체', _leadScore: 100 }];
+    // recentNews는 비어 있지만 precomputedHotList로 '반도체' 주입
+    const res = clusterThemes(items, [], ['반도체']);
+    const semi = res.themes.find((t) => t.theme === '반도체');
+    expect(semi.hot).toBe(true);
+  });
+
   it('음수 _leadScore 테마는 핫섹터 부스트로 더 낮아지지 않음(Math.max 가드)', () => {
     // 휴장 penalty 등으로 sum이 음수면 newsBoost(1.3)가 점수를 더 낮추던 역효과 방지.
     const negScored = [{ symbol: 'X', name: 'X', sector: '반도체', _leadScore: -20 }];
@@ -226,7 +273,7 @@ describe('decideMorphMode', () => {
   it('US open(국장 휴장) → US_LEAD', () => {
     expect(decideMorphMode(st('closed'), st('open'))).toBe(MORPH_MODE.US_LEAD);
   });
-  it('US pre/after/dayMarket → US_GAP', () => {
+  it('US pre/after/dayMarket(KR closed) → US_GAP', () => {
     expect(decideMorphMode(st('closed'), st('pre'))).toBe(MORPH_MODE.US_GAP);
     expect(decideMorphMode(st('closed'), st('after'))).toBe(MORPH_MODE.US_GAP);
     expect(decideMorphMode(st('closed'), st('dayMarket'))).toBe(MORPH_MODE.US_GAP);
@@ -235,7 +282,7 @@ describe('decideMorphMode', () => {
     expect(decideMorphMode(st('preAuction'), st('closed'))).toBe(MORPH_MODE.KR_GAP);
     expect(decideMorphMode(st('preNxt'), st('closed'))).toBe(MORPH_MODE.KR_GAP);
   });
-  it('KR afterNxt(NXT 시간외, 미장 휴장) → KR_GAP (미장 after와 대칭)', () => {
+  it('KR afterNxt(NXT 시간외, 미장 휴장) → KR_GAP', () => {
     expect(decideMorphMode(st('afterNxt'), st('closed'))).toBe(MORPH_MODE.KR_GAP);
   });
   it('둘 다 closed → COIN_LEAD', () => {
@@ -244,19 +291,32 @@ describe('decideMorphMode', () => {
   it('KR open 우선(KR open + US open) → KR_LEAD', () => {
     expect(decideMorphMode(st('open'), st('open'))).toBe(MORPH_MODE.KR_LEAD);
   });
+  // ─── B1/HIGH2: KR_GAP > US_GAP 우선순위 (평일 시간대 중첩 케이스) ───
+  // marketHours 평일 ET는 pre→open→after→dayMarket로 24h 커버 → usPhase가 closed가 안 됨.
+  // KR 활동시간(afterNxt/preNxt/preAuction)에 KR_GAP을 우선시켜 의도-구현 일치.
+  it('afterNxt(KR) + dayMarket(US) 동시 → KR_GAP (한국 활동시간 우선)', () => {
+    expect(decideMorphMode(st('afterNxt'), st('dayMarket'))).toBe(MORPH_MODE.KR_GAP);
+  });
+  it('preNxt(KR) + after(US) 동시 → KR_GAP (한국 활동시간 우선)', () => {
+    expect(decideMorphMode(st('preNxt'), st('after'))).toBe(MORPH_MODE.KR_GAP);
+  });
+  it('preAuction(KR) + pre(US) 동시 → KR_GAP', () => {
+    expect(decideMorphMode(st('preAuction'), st('pre'))).toBe(MORPH_MODE.KR_GAP);
+  });
 });
 
 // ─── buildTransitionBridge 단정 회피 ──────────────────────────
 describe('buildTransitionBridge', () => {
-  const idx = (ndxPct) => [{ id: 'NDX', name: '나스닥', changePct: ndxPct }];
+  const idx = (ndxPct) => [{ id: 'NDX', name: '나스닥100', changePct: ndxPct }];
 
   it('미장 모드(US_LEAD)는 브릿지 없음(null)', () => {
     expect(buildTransitionBridge({ mode: MORPH_MODE.US_LEAD, indices: idx(2) })).toBeNull();
   });
-  it('나스닥 |변동|<0.5% → 보합 표기(단정 회피)', () => {
+  it('나스닥100 |변동|<0.5% → 보합 표기(단정 회피)', () => {
     const b = buildTransitionBridge({ mode: MORPH_MODE.KR_LEAD, indices: idx(0.3) });
     expect(b.tone).toBe('flat');
     expect(b.line).toContain('보합');
+    expect(b.line).toContain('나스닥100');
     expect(b.pair).toBeNull();
   });
   it('지수 데이터 없으면 브릿지 생략(null)', () => {
@@ -407,6 +467,78 @@ describe('computeMorphFocus', () => {
     const scored = res._scored.kr.find((s) => s.symbol === '005930');
     expect(scored._leadBreakdown.surge).toBeGreaterThan(0);
     expect(scored._leadBreakdown.surge).toBeCloseTo(80, 0);
+  });
+
+  // [W4] baselineMap 주입 + weights 미지정 → 자동 secondary 전환(surge 점수가 결과 점수에 반영)
+  it('baselineMap만 주면 weights 자동 secondary 전환 — surge가 _leadScore에 반영', () => {
+    const item = krStock({ symbol: '005930', name: '삼성전자', sector: '반도체', price: 80000, volume: 10_000_000, marketCap: 500e12, changePct: 3 });
+    const turn = turnoverKRW(item, KRW); // 8000억
+    // weights 미지정 — 기본은 primary였으나 baselineMap 주입 시 secondary로 자동 전환
+    const res = computeMorphFocus({
+      krItems: [item], usItems: [], coinItems: [],
+      recentNews: [], krwRate: KRW, indices: [],
+      krStatus: st('open'), usStatus: st('closed'),
+      baselineMap: { '005930': { avg20d: turn / 4 } }, // 4배 → surge 80
+    });
+    const scored = res._scored.kr.find((s) => s.symbol === '005930');
+    // surge 점수가 계산되었고(>0), weight가 0이 아니라 _leadScore에 기여하는지 확인
+    expect(scored._leadBreakdown.surge).toBeGreaterThan(0);
+    // secondary의 w_surge=0.40 → score >= surge * 0.4
+    expect(scored._leadScore).toBeGreaterThan(scored._leadBreakdown.surge * 0.3);
+  });
+
+  // [STYLE6] COIN_LEAD는 clusterThemes 미실행 — primaryTheme/altThemes null/빈배열
+  it('COIN_LEAD: primaryTheme=null, altThemes=[], movers만 유효', () => {
+    const coinItems = [
+      coin({ symbol: 'BTC', accTradePrice24h: 5e11, change24h: 3 }),
+      coin({ symbol: 'ETH', accTradePrice24h: 3e11, change24h: 5 }),
+    ];
+    const res = computeMorphFocus({
+      krItems: [], usItems: [], coinItems,
+      recentNews: [], krwRate: KRW, indices: [],
+      krStatus: st('closed'), usStatus: st('closed'),
+    });
+    expect(res.mode).toBe(MORPH_MODE.COIN_LEAD);
+    expect(res.primaryTheme).toBeNull();
+    expect(res.altThemes).toEqual([]);
+    expect(res.movers.length).toBeGreaterThan(0);
+  });
+
+  // [HIGH3] computeMorphFocus 진입 시에도 ETF 배제 — _scored에 안 들어감
+  it('US_LEAD: SPY/QQQ 같은 _isEtf 종목은 _scored.us에 포함되지 않음', () => {
+    const usItems = [
+      { ...usStock({ symbol: 'SPY', name: 'SPDR S&P 500', price: 500, volume: 50_000_000, marketCap: 600e9, changePct: 1.5 }), _isEtf: true },
+      usStock({ symbol: 'NVDA', name: 'NVIDIA', price: 800, volume: 30_000_000, marketCap: 2e12, changePct: 3 }),
+    ];
+    const res = computeMorphFocus({
+      krItems: [], usItems, coinItems: [],
+      recentNews: [], krwRate: KRW, indices: [],
+      krStatus: st('closed'), usStatus: st('open'),
+    });
+    expect(res.mode).toBe(MORPH_MODE.US_LEAD);
+    expect(res._scored.us.find((s) => s.symbol === 'SPY')).toBeUndefined();
+    expect(res._scored.us.find((s) => s.symbol === 'NVDA')).toBeDefined();
+  });
+
+  // [W3/perf] percentileRank 최적화 정확성 검증 — 정렬+이진탐색 결과가 선형 순회와 동일
+  it('대량 모수에서도 percentile 기반 순위가 의미 있게 유지(정렬+이진탐색 정확성)', () => {
+    // 100종목 모수, 회전율이 다양한 분포 → 상위 회전율 종목이 최상위 점수가 되는지 확인
+    const many = [];
+    for (let i = 0; i < 100; i++) {
+      many.push(krStock({
+        symbol: String(i).padStart(6, '0'),
+        name: `T${i}`,
+        price: 10000,
+        volume: 1_000_000 + i * 10_000,  // 거래대금 점진 증가
+        marketCap: (200 - i) * 1e12,     // 시총 감소 → 회전율 i가 커질수록 상승
+        changePct: 1,
+      }));
+    }
+    const scored = scoreMarketItems(many, { krwRate: KRW, recentNews: [] });
+    // i=99 종목이 회전율 최상위
+    expect(scored[0].symbol).toBe('000099');
+    // 점수가 단조 가까운 순서로 (회전율 순위와 일치)
+    expect(scored[scored.length - 1]._leadScore).toBeLessThan(scored[0]._leadScore);
   });
 });
 

--- a/src/__tests__/leadingStocks.test.js
+++ b/src/__tests__/leadingStocks.test.js
@@ -1,0 +1,373 @@
+import { describe, it, expect } from 'vitest';
+import {
+  turnoverKRW,
+  turnoverRatio,
+  scoreLeading,
+  scoreMarketItems,
+  clusterThemes,
+  decideMorphMode,
+  buildTransitionBridge,
+  computeMorphFocus,
+  MORPH_MODE,
+  MIN_TURNOVER,
+  SCORE_WEIGHTS,
+} from '../utils/leadingStocks.js';
+
+// ─── 헬퍼: 종목/코인 팩토리 ───────────────────────────────────
+const krStock = (o = {}) => ({
+  _market: 'KR', market: 'kr',
+  symbol: o.symbol || '000000', name: o.name || '테스트',
+  price: o.price ?? 10000, volume: o.volume ?? 1_000_000,
+  changePct: o.changePct ?? 0, marketCap: o.marketCap ?? 1_000_000_000_000,
+  sector: o.sector,
+});
+const usStock = (o = {}) => ({
+  _market: 'US', market: 'us',
+  symbol: o.symbol || 'TST', name: o.name || 'Test',
+  price: o.price ?? 100, volume: o.volume ?? 1_000_000,
+  changePct: o.changePct ?? 0, marketCap: o.marketCap ?? 100_000_000_000,
+  sector: o.sector,
+});
+const coin = (o = {}) => ({
+  _market: 'COIN', market: 'coin', id: (o.symbol || 'btc').toLowerCase(),
+  symbol: o.symbol || 'BTC', name: o.name || '비트코인',
+  priceKrw: o.priceKrw ?? 50_000_000, change24h: o.change24h ?? 0,
+  marketCap: 0, volume24h: 0,
+  accTradePrice24h: o.accTradePrice24h ?? 0,
+});
+
+const KRW = 1400; // 환율
+
+// ─── turnoverKRW ──────────────────────────────────────────────
+describe('turnoverKRW', () => {
+  it('KR = price × volume', () => {
+    expect(turnoverKRW(krStock({ price: 10000, volume: 5000 }))).toBe(50_000_000);
+  });
+  it('US = price × volume × krwRate', () => {
+    expect(turnoverKRW(usStock({ price: 100, volume: 1000 }), KRW)).toBe(100 * 1000 * KRW);
+  });
+  it('COIN = accTradePrice24h (환율 무관)', () => {
+    expect(turnoverKRW(coin({ accTradePrice24h: 1.5e10 }), KRW)).toBe(1.5e10);
+  });
+  it('음수/누락 가격·거래량 → 0 방어', () => {
+    expect(turnoverKRW(krStock({ price: -1, volume: 1000 }))).toBe(0);
+    expect(turnoverKRW(krStock({ price: 100, volume: 0 }))).toBe(0);
+    expect(turnoverKRW(null)).toBe(0);
+  });
+  it('US 환율 미로드(0) → 0', () => {
+    expect(turnoverKRW(usStock({ price: 100, volume: 1000 }), 0)).toBe(0);
+  });
+});
+
+// ─── turnoverRatio ────────────────────────────────────────────
+describe('turnoverRatio', () => {
+  it('주식 = 거래대금 / 시총', () => {
+    const s = krStock({ price: 10000, volume: 1_000_000, marketCap: 1e12 });
+    expect(turnoverRatio(s)).toBeCloseTo(1e10 / 1e12, 6);
+  });
+  it('코인(marketCap=0) → null', () => {
+    expect(turnoverRatio(coin({ accTradePrice24h: 1e10 }))).toBeNull();
+  });
+  it('시총 0/누락 → null', () => {
+    expect(turnoverRatio(krStock({ marketCap: 0 }))).toBeNull();
+  });
+});
+
+// ─── 회전율 핵심: 중소형 고회전 > 대형 저회전 ──────────────────
+describe('회전율 기반 주도주 포착', () => {
+  it('삼성전자(대형 저회전)보다 중소형 고회전주가 상위', () => {
+    const samsung = krStock({
+      symbol: '005930', name: '삼성전자',
+      price: 80000, volume: 10_000_000, // 거래대금 8000억 (절대값은 큼)
+      marketCap: 500e12,                // 시총 500조 → 회전율 0.0016
+      changePct: 1,
+    });
+    const midCap = krStock({
+      symbol: '900000', name: '중소형테마주',
+      price: 20000, volume: 5_000_000,  // 거래대금 1000억
+      marketCap: 500e9,                 // 시총 5000억 → 회전율 0.2 (삼성의 ~125배)
+      changePct: 5,
+    });
+    const scored = scoreMarketItems([samsung, midCap], {
+      krwRate: KRW, recentNews: [], hotSectors: [], weights: SCORE_WEIGHTS.primary,
+    });
+    expect(scored[0].symbol).toBe('900000');
+    expect(scored[0]._leadScore).toBeGreaterThan(scored[1]._leadScore);
+  });
+});
+
+// ─── MIN_TURNOVER 잡주 컷 ─────────────────────────────────────
+describe('MIN_TURNOVER 잡주 컷', () => {
+  it('KR 50억 미달 잡주 제외', () => {
+    const junk = krStock({ symbol: 'JUNK', price: 1000, volume: 1000, changePct: 20 }); // 거래대금 100만
+    const valid = krStock({ symbol: 'VALID', price: 10000, volume: 1_000_000, changePct: 5 }); // 100억
+    const scored = scoreMarketItems([junk, valid], { krwRate: KRW, recentNews: [] });
+    expect(scored.find((s) => s.symbol === 'JUNK')).toBeUndefined();
+    expect(scored.find((s) => s.symbol === 'VALID')).toBeDefined();
+  });
+  it('파생상품(레버리지/인버스) 제외', () => {
+    const lev = krStock({ symbol: 'LEV', name: 'KODEX 레버리지', price: 20000, volume: 2_000_000, changePct: 8 });
+    const inv = krStock({ symbol: 'INV', name: 'KODEX 인버스2X', price: 5000, volume: 10_000_000, changePct: 8 });
+    const normal = krStock({ symbol: 'NORM', name: '정상주', price: 10000, volume: 1_000_000, changePct: 5 });
+    const scored = scoreMarketItems([lev, inv, normal], { krwRate: KRW, recentNews: [] });
+    expect(scored.find((s) => s.symbol === 'LEV')).toBeUndefined();
+    expect(scored.find((s) => s.symbol === 'INV')).toBeUndefined();
+    expect(scored.find((s) => s.symbol === 'NORM')).toBeDefined();
+  });
+  it('COIN 100억 미달 제외 / 충족 통과', () => {
+    const small = coin({ symbol: 'SMALL', accTradePrice24h: 5e9, change24h: 10 }); // 50억
+    const big = coin({ symbol: 'BTC', accTradePrice24h: 5e11, change24h: 5 });     // 5000억
+    const scored = scoreMarketItems([small, big], { krwRate: KRW, recentNews: [] });
+    expect(scored.find((s) => s.symbol === 'SMALL')).toBeUndefined();
+    expect(scored.find((s) => s.symbol === 'BTC')).toBeDefined();
+  });
+});
+
+// ─── scoreLeading 분해 ────────────────────────────────────────
+describe('scoreLeading', () => {
+  it('변동폭 클수록 move 점수 상승(상한 15%)', () => {
+    const ctx = { krwRate: KRW, ratioPercentileOf: () => 50, weights: SCORE_WEIGHTS.primary };
+    const small = scoreLeading(krStock({ changePct: 2 }), ctx);
+    const big = scoreLeading(krStock({ changePct: 12 }), ctx);
+    const over = scoreLeading(krStock({ changePct: 30 }), ctx);
+    expect(big.breakdown.move).toBeGreaterThan(small.breakdown.move);
+    expect(over.breakdown.move).toBe(100); // 15% 상한
+  });
+  it('하락 방향 dir = -1', () => {
+    const ctx = { krwRate: KRW, ratioPercentileOf: () => 50 };
+    expect(scoreLeading(krStock({ changePct: -7 }), ctx).dir).toBe(-1);
+  });
+  it('휴장 마켓 penalty(P_closed) 적용', () => {
+    const ctx = { krwRate: KRW, ratioPercentileOf: () => 50 };
+    const open = scoreLeading(krStock({ changePct: 5 }), { ...ctx, isClosed: false });
+    const closed = scoreLeading(krStock({ changePct: 5 }), { ...ctx, isClosed: true });
+    expect(closed.breakdown.penalty).toBe(40);
+    expect(closed.score).toBeLessThan(open.score);
+  });
+  it('뉴스 매칭 + 핫섹터 소속 시 news 점수 가산', () => {
+    const item = krStock({ symbol: '005930', name: '삼성전자', sector: '반도체', changePct: 3 });
+    const news = [{ title: '삼성전자 HBM 신규 수주', summary: '' }];
+    const res = scoreLeading(item, {
+      krwRate: KRW, ratioPercentileOf: () => 50,
+      recentNews: news, hotSectors: ['반도체'],
+    });
+    // 뉴스 1건(70/3≈23.3) + 핫섹터(30) = 53.3
+    expect(res.breakdown.news).toBeGreaterThan(50);
+    expect(res.newsCount).toBe(1);
+  });
+});
+
+// ─── clusterThemes ────────────────────────────────────────────
+describe('clusterThemes', () => {
+  const scored = [
+    { symbol: 'A', name: 'A', sector: '반도체', _leadScore: 80 },
+    { symbol: 'B', name: 'B', sector: '반도체', _leadScore: 60 },
+    { symbol: 'C', name: 'C', sector: '바이오', _leadScore: 50 },
+    { symbol: 'D', name: 'D', sector: undefined, _leadScore: 70 }, // 무섹터
+  ];
+
+  it('정적 sector로 테마 묶기 + 대장주 상위 1~3', () => {
+    const { themes } = clusterThemes(scored, []);
+    const semi = themes.find((t) => t.theme === '반도체');
+    expect(semi.members.length).toBe(2);
+    expect(semi.leaders[0].symbol).toBe('A');
+    expect(semi.leaders.length).toBeLessThanOrEqual(3);
+  });
+
+  it('무섹터 종목은 soloMovers(단일카드 폴백)로 분리', () => {
+    const { themes, soloMovers } = clusterThemes(scored, []);
+    expect(soloMovers.map((s) => s.symbol)).toContain('D');
+    expect(themes.every((t) => t.theme)).toBe(true); // 무섹터가 테마로 새지 않음
+  });
+
+  it('핫섹터(뉴스) newsBoost 1.3배 반영', () => {
+    const hotNews = [{ title: 'HBM 반도체 슈퍼사이클' }]; // detectNewsSectors → 반도체
+    const cold = clusterThemes(scored, []);
+    const hot = clusterThemes(scored, hotNews);
+    const coldSemi = cold.themes.find((t) => t.theme === '반도체');
+    const hotSemi = hot.themes.find((t) => t.theme === '반도체');
+    expect(hotSemi.hot).toBe(true);
+    expect(coldSemi.hot).toBe(false);
+    expect(hotSemi.score).toBeGreaterThan(coldSemi.score);
+  });
+});
+
+// ─── decideMorphMode 5종 ──────────────────────────────────────
+describe('decideMorphMode', () => {
+  const st = (phase) => ({ phase });
+  it('KR open → KR_LEAD', () => {
+    expect(decideMorphMode(st('open'), st('closed'))).toBe(MORPH_MODE.KR_LEAD);
+  });
+  it('US open(국장 휴장) → US_LEAD', () => {
+    expect(decideMorphMode(st('closed'), st('open'))).toBe(MORPH_MODE.US_LEAD);
+  });
+  it('US pre/after/dayMarket → US_GAP', () => {
+    expect(decideMorphMode(st('closed'), st('pre'))).toBe(MORPH_MODE.US_GAP);
+    expect(decideMorphMode(st('closed'), st('after'))).toBe(MORPH_MODE.US_GAP);
+    expect(decideMorphMode(st('closed'), st('dayMarket'))).toBe(MORPH_MODE.US_GAP);
+  });
+  it('KR preAuction/preNxt(미장 휴장) → KR_GAP', () => {
+    expect(decideMorphMode(st('preAuction'), st('closed'))).toBe(MORPH_MODE.KR_GAP);
+    expect(decideMorphMode(st('preNxt'), st('closed'))).toBe(MORPH_MODE.KR_GAP);
+  });
+  it('둘 다 closed → COIN_LEAD', () => {
+    expect(decideMorphMode(st('closed'), st('closed'))).toBe(MORPH_MODE.COIN_LEAD);
+  });
+  it('KR open 우선(KR open + US open) → KR_LEAD', () => {
+    expect(decideMorphMode(st('open'), st('open'))).toBe(MORPH_MODE.KR_LEAD);
+  });
+});
+
+// ─── buildTransitionBridge 단정 회피 ──────────────────────────
+describe('buildTransitionBridge', () => {
+  const idx = (ndxPct) => [{ id: 'NDX', name: '나스닥', changePct: ndxPct }];
+
+  it('미장 모드(US_LEAD)는 브릿지 없음(null)', () => {
+    expect(buildTransitionBridge({ mode: MORPH_MODE.US_LEAD, indices: idx(2) })).toBeNull();
+  });
+  it('나스닥 |변동|<0.5% → 보합 표기(단정 회피)', () => {
+    const b = buildTransitionBridge({ mode: MORPH_MODE.KR_LEAD, indices: idx(0.3) });
+    expect(b.tone).toBe('flat');
+    expect(b.line).toContain('보합');
+    expect(b.pair).toBeNull();
+  });
+  it('지수 데이터 없으면 브릿지 생략(null)', () => {
+    expect(buildTransitionBridge({ mode: MORPH_MODE.KR_LEAD, indices: [] })).toBeNull();
+  });
+  it('테마 페어 있으면 국장 동조 함의 + "주목"(확정 금지)', () => {
+    const b = buildTransitionBridge({
+      mode: MORPH_MODE.KR_LEAD, indices: idx(1.8),
+      primaryTheme: { theme: '반도체' },
+    });
+    expect(b.line).toContain('주목');
+    expect(b.line).not.toContain('확정');
+    expect(b.pair).not.toBeNull();
+    expect(b.pair.krSector).toBe('반도체');
+  });
+  it('페어 없으면 지수 한 줄만(테마 단정 회피)', () => {
+    const b = buildTransitionBridge({
+      mode: MORPH_MODE.KR_GAP, indices: idx(-1.5),
+      primaryTheme: { theme: '듣보섹터' },
+    });
+    expect(b.pair).toBeNull();
+    expect(b.tone).toBe('down');
+    expect(b.line).toContain('국장 영향');
+  });
+});
+
+// ─── computeMorphFocus 통합 ───────────────────────────────────
+describe('computeMorphFocus', () => {
+  const st = (phase) => ({ phase });
+
+  it('KR_LEAD: 주도 테마 + 대장주 + 브릿지 동시 반환', () => {
+    const krItems = [
+      krStock({ symbol: '005930', name: '삼성전자', sector: '반도체', price: 80000, volume: 5_000_000, marketCap: 500e12, changePct: 3 }),
+      krStock({ symbol: '000660', name: 'SK하이닉스', sector: '반도체', price: 200000, volume: 3_000_000, marketCap: 150e12, changePct: 4 }),
+      krStock({ symbol: '900000', name: '소형반도체', sector: '반도체', price: 30000, volume: 4_000_000, marketCap: 800e9, changePct: 8 }),
+    ];
+    const res = computeMorphFocus({
+      krItems, usItems: [], coinItems: [],
+      recentNews: [{ title: '반도체 HBM 슈퍼사이클 진입' }],
+      krwRate: KRW, indices: [{ id: 'NDX', changePct: 1.5 }],
+      krStatus: st('open'), usStatus: st('closed'),
+    });
+    expect(res.mode).toBe(MORPH_MODE.KR_LEAD);
+    expect(res.primaryTheme).not.toBeNull();
+    expect(res.primaryTheme.theme).toBe('반도체');
+    expect(res.primaryTheme.leaders.length).toBeGreaterThan(0);
+    expect(res.bridge).not.toBeNull();
+    expect(res.bridge.pair.krSector).toBe('반도체');
+  });
+
+  it('COIN_LEAD: 둘 다 휴장 → 거래대금 상위 코인 movers, 브릿지 없음', () => {
+    const coinItems = [
+      coin({ symbol: 'BTC', accTradePrice24h: 5e11, change24h: 3 }),
+      coin({ symbol: 'ETH', accTradePrice24h: 3e11, change24h: 5 }),
+      coin({ symbol: 'SMALL', accTradePrice24h: 1e9, change24h: 20 }), // 컷 대상
+    ];
+    const res = computeMorphFocus({
+      krItems: [], usItems: [], coinItems,
+      recentNews: [], krwRate: KRW, indices: [],
+      krStatus: st('closed'), usStatus: st('closed'),
+    });
+    expect(res.mode).toBe(MORPH_MODE.COIN_LEAD);
+    expect(res.bridge).toBeNull();
+    expect(res.movers.length).toBeGreaterThan(0);
+    expect(res.movers.map((m) => m.symbol)).not.toContain('SMALL');
+    expect(res.movers.map((m) => m.symbol)).toContain('BTC');
+  });
+
+  it('무섹터 종목만 있을 때 단일카드(movers) 폴백 — primaryTheme null', () => {
+    const krItems = [
+      krStock({ symbol: '999999', name: '신규테마무섹터', sector: undefined, price: 50000, volume: 3_000_000, marketCap: 1e12, changePct: 12 }),
+    ];
+    const res = computeMorphFocus({
+      krItems, usItems: [], coinItems: [],
+      recentNews: [], krwRate: KRW, indices: [{ id: 'NDX', changePct: 1.2 }],
+      krStatus: st('open'), usStatus: st('closed'),
+    });
+    expect(res.mode).toBe(MORPH_MODE.KR_LEAD);
+    expect(res.primaryTheme).toBeNull(); // 섹터 없음 → 테마 미분류
+    expect(res.movers.length).toBe(1);
+    expect(res.movers[0].symbol).toBe('999999');
+  });
+
+  it('US_GAP: 미장 프리마켓 → move(갭) 우선 movers', () => {
+    const usItems = [
+      usStock({ symbol: 'AAA', name: 'Big Turnover', price: 100, volume: 5_000_000, marketCap: 500e9, changePct: 2 }),
+      usStock({ symbol: 'BBB', name: 'Big Gap', price: 50, volume: 2_000_000, marketCap: 100e9, changePct: 11 }),
+    ];
+    const res = computeMorphFocus({
+      krItems: [], usItems, coinItems: [],
+      recentNews: [], krwRate: KRW, indices: [],
+      krStatus: st('closed'), usStatus: st('pre'),
+    });
+    expect(res.mode).toBe(MORPH_MODE.US_GAP);
+    // 갭(변동폭) 우선 정렬 → BBB가 상위
+    expect(res.movers[0].symbol).toBe('BBB');
+  });
+
+  it('krwRateLoaded=false면 US 거래대금 하한 폴백(과소 컷 방지)로 종목 보존', () => {
+    const usItems = [
+      usStock({ symbol: 'CCC', name: 'US Stock', price: 100, volume: 1_000_000, marketCap: 100e9, changePct: 5 }),
+    ];
+    const res = computeMorphFocus({
+      krItems: [], usItems, coinItems: [],
+      recentNews: [], krwRate: 0, krwRateLoaded: false, indices: [],
+      krStatus: st('closed'), usStatus: st('open'),
+    });
+    expect(res.mode).toBe(MORPH_MODE.US_LEAD);
+    // 환율 미로드여도 KR 하한 폴백으로 살아남음(price×volume = 1억 > 50억? no)
+    // → 1e8 < 5e9 이므로 컷됨이 정상. movers/테마 비어도 에러 없이 동작.
+    expect(res._scored.us).toBeDefined();
+  });
+
+  it('baselineMap 제공 시 surge 점수 반영(w_surge>0 weights)', () => {
+    const item = krStock({ symbol: '005930', name: '삼성전자', sector: '반도체', price: 80000, volume: 10_000_000, marketCap: 500e12, changePct: 3 });
+    const turn = turnoverKRW(item, KRW); // 8000억
+    const res = computeMorphFocus({
+      krItems: [item], usItems: [], coinItems: [],
+      recentNews: [], krwRate: KRW, indices: [],
+      krStatus: st('open'), usStatus: st('closed'),
+      baselineMap: { '005930': { avg20d: turn / 4 } }, // 4배 급증 → surge 80
+      weights: SCORE_WEIGHTS.secondary,
+    });
+    const scored = res._scored.kr.find((s) => s.symbol === '005930');
+    expect(scored._leadBreakdown.surge).toBeGreaterThan(0);
+    expect(scored._leadBreakdown.surge).toBeCloseTo(80, 0);
+  });
+});
+
+// ─── 상수 무결성 ──────────────────────────────────────────────
+describe('상수', () => {
+  it('1차 가중치 합 = 1, w_surge = 0', () => {
+    const w = SCORE_WEIGHTS.primary;
+    expect(w.turn + w.move + w.news + w.surge).toBeCloseTo(1, 6);
+    expect(w.surge).toBe(0);
+  });
+  it('MIN_TURNOVER 하한값', () => {
+    expect(MIN_TURNOVER.KR).toBe(5_000_000_000);
+    expect(MIN_TURNOVER.US_USD).toBe(50_000_000);
+    expect(MIN_TURNOVER.COIN).toBe(10_000_000_000);
+  });
+});

--- a/src/__tests__/leadingStocks.test.js
+++ b/src/__tests__/leadingStocks.test.js
@@ -190,6 +190,31 @@ describe('clusterThemes', () => {
     expect(coldSemi.hot).toBe(false);
     expect(hotSemi.score).toBeGreaterThan(coldSemi.score);
   });
+
+  it('섹터 별칭: item.sector "2차전지" ↔ 뉴스 "배터리"/"전기차" 핫섹터 매칭', () => {
+    // item.sector(krStockList 표준)는 '2차전지', detectNewsSectors는 '배터리'/'전기차' → 별칭 정규화로 매칭.
+    const batteryScored = [
+      { symbol: '373220', name: 'LG에너지솔루션', sector: '2차전지', _leadScore: 80 },
+      { symbol: '006400', name: '삼성SDI', sector: '2차전지', _leadScore: 60 },
+    ];
+    const batteryNews = [{ title: '전기차 배터리 수요 급증 양극재 강세' }]; // → 배터리/전기차/자동차부품
+    const cold = clusterThemes(batteryScored, []);
+    const hot = clusterThemes(batteryScored, batteryNews);
+    const coldBat = cold.themes.find((t) => t.theme === '2차전지');
+    const hotBat = hot.themes.find((t) => t.theme === '2차전지');
+    expect(coldBat.hot).toBe(false);
+    expect(hotBat.hot).toBe(true); // 별칭 정규화 전이면 false였음(버그)
+    expect(hotBat.score).toBeGreaterThan(coldBat.score);
+  });
+
+  it('음수 _leadScore 테마는 핫섹터 부스트로 더 낮아지지 않음(Math.max 가드)', () => {
+    // 휴장 penalty 등으로 sum이 음수면 newsBoost(1.3)가 점수를 더 낮추던 역효과 방지.
+    const negScored = [{ symbol: 'X', name: 'X', sector: '반도체', _leadScore: -20 }];
+    const hotNews = [{ title: 'HBM 반도체 슈퍼사이클' }];
+    const hot = clusterThemes(negScored, hotNews).themes.find((t) => t.theme === '반도체');
+    expect(hot.hot).toBe(true);
+    expect(hot.score).toBe(0); // Math.max(-20,0)=0 → 부스트가 음수를 더 키우지 않음
+  });
 });
 
 // ─── decideMorphMode 5종 ──────────────────────────────────────
@@ -209,6 +234,9 @@ describe('decideMorphMode', () => {
   it('KR preAuction/preNxt(미장 휴장) → KR_GAP', () => {
     expect(decideMorphMode(st('preAuction'), st('closed'))).toBe(MORPH_MODE.KR_GAP);
     expect(decideMorphMode(st('preNxt'), st('closed'))).toBe(MORPH_MODE.KR_GAP);
+  });
+  it('KR afterNxt(NXT 시간외, 미장 휴장) → KR_GAP (미장 after와 대칭)', () => {
+    expect(decideMorphMode(st('afterNxt'), st('closed'))).toBe(MORPH_MODE.KR_GAP);
   });
   it('둘 다 closed → COIN_LEAD', () => {
     expect(decideMorphMode(st('closed'), st('closed'))).toBe(MORPH_MODE.COIN_LEAD);
@@ -243,6 +271,15 @@ describe('buildTransitionBridge', () => {
     expect(b.line).not.toContain('확정');
     expect(b.pair).not.toBeNull();
     expect(b.pair.krSector).toBe('반도체');
+  });
+  it('2차전지 주도 시 CROSS_MARKET 페어 매칭(별칭 키 추가)', () => {
+    const b = buildTransitionBridge({
+      mode: MORPH_MODE.KR_LEAD, indices: idx(2.1),
+      primaryTheme: { theme: '2차전지' },
+    });
+    expect(b.pair).not.toBeNull();
+    expect(b.pair.krSector).toBe('2차전지');
+    expect(b.line).toContain('2차전지');
   });
   it('페어 없으면 지수 한 줄만(테마 단정 회피)', () => {
     const b = buildTransitionBridge({
@@ -327,8 +364,9 @@ describe('computeMorphFocus', () => {
     expect(res.movers[0].symbol).toBe('BBB');
   });
 
-  it('krwRateLoaded=false면 US 거래대금 하한 폴백(과소 컷 방지)로 종목 보존', () => {
+  it('krwRateLoaded=false면 US는 USD raw($) 하한으로 비교 — $50M 초과 종목 보존', () => {
     const usItems = [
+      // USD raw = 100 × 1,000,000 = $100M > MIN_TURNOVER.US_USD($50M) → 보존
       usStock({ symbol: 'CCC', name: 'US Stock', price: 100, volume: 1_000_000, marketCap: 100e9, changePct: 5 }),
     ];
     const res = computeMorphFocus({
@@ -337,9 +375,23 @@ describe('computeMorphFocus', () => {
       krStatus: st('closed'), usStatus: st('open'),
     });
     expect(res.mode).toBe(MORPH_MODE.US_LEAD);
-    // 환율 미로드여도 KR 하한 폴백으로 살아남음(price×volume = 1억 > 50억? no)
-    // → 1e8 < 5e9 이므로 컷됨이 정상. movers/테마 비어도 에러 없이 동작.
-    expect(res._scored.us).toBeDefined();
+    // 환율 미로드 시 turnoverKRW는 0이지만, passesNoiseGate가 USD raw로 직접 비교 → 컷되지 않음.
+    const ccc = res._scored.us.find((s) => s.symbol === 'CCC');
+    expect(ccc).toBeDefined();
+  });
+
+  it('krwRateLoaded=false여도 US USD raw $50M 미달 종목은 컷(폴백이 잡주를 통과시키지 않음)', () => {
+    const usItems = [
+      // USD raw = 10 × 1,000,000 = $10M < $50M → 컷
+      usStock({ symbol: 'TINY', name: 'Tiny US', price: 10, volume: 1_000_000, marketCap: 5e9, changePct: 7 }),
+    ];
+    const res = computeMorphFocus({
+      krItems: [], usItems, coinItems: [],
+      recentNews: [], krwRate: 0, krwRateLoaded: false, indices: [],
+      krStatus: st('closed'), usStatus: st('open'),
+    });
+    expect(res.mode).toBe(MORPH_MODE.US_LEAD);
+    expect(res._scored.us.find((s) => s.symbol === 'TINY')).toBeUndefined();
   });
 
   it('baselineMap 제공 시 surge 점수 반영(w_surge>0 weights)', () => {

--- a/src/components/home/HOME_CONTRACT.md
+++ b/src/components/home/HOME_CONTRACT.md
@@ -19,7 +19,12 @@
    ├── WatchlistMini       — 관심종목 (마켓 배지 KR/US/COIN + 추가 버튼 + 검색 링크)
    │   └── WatchlistAlertStrip — 이상 신호 스트립 (±3% 변동/시그널 발화 시만 표시, inline)
    └── EventStrip          — EventTicker 세로 롤링 (translateY, 3아이템, 9초 순환)
-2. NotableMoversSection    — 주목할 종목 (WHY 카드)
+2. MorphingFocusSection    — 모핑 포커스 (시간대별 주도주/주목 자동 전환 — NotableMovers 흡수)
+   ├── SessionBar          — 세션 인디케이터 (초록 점멸=라이브 / 회색 정지, 텍스트 라벨)
+   ├── FocusLeadCard       — 대장주/주목 1위 풀폭 카드 (등락률 26px + WHY 정량근거 LEAD 칩)
+   ├── CompactMoverRow     — 2~3위 / 무버 컴팩트 행
+   ├── AltThemeChips       — 동반 테마 칩 (LEAD 모드)
+   └── BridgeLine          — 전이구간 브릿지 (국장 모드, 간밤 나스닥 함의 한 줄)
 3. SignalBoardWidget       — 시그널 보드 (카운터 큰 숫자 + 텍스트 색상 구분) — 인라인 결정 패널(SignalInlinePanel) 포함
 4. AiDebateSection         — AI 종목토론 (별도 섹션, 4종목 칩 선택)
 5. ExploreTabsWidget       — 탐색 탭 (급등/급락 | 섹터)
@@ -111,7 +116,8 @@ BreakingNewsPanel          — 기존 뉴스 패널 (모바일 전용, lg:hidden
 | 파일 | 역할 | 상태 |
 |------|------|------|
 | `EventTicker.jsx` | 경제 이벤트 롤링 | ✅ 활성 (롤링만. 섹션 X) |
-| `NotableMoversSection.jsx` | 수급 이상 종목 | ✅ 활성 |
+| `MorphingFocusSection.jsx` | 모핑 포커스 (시간대별 주도주/주목 — computeMorphFocus #335) | ✅ 활성 (홈 섹션 2) |
+| `NotableMoversSection.jsx` | 주목할 종목 (WHY 카드) | ⏸ MorphingFocusSection으로 흡수 (직접 렌더 X, 영구삭제 아님 — 자산 보존) |
 | `MarketInvestorSection.jsx` | 외국인/기관 수급 | ✅ 활성 |
 | `HotListSection.jsx` | HotList UI (TopMoversWidget의 서브컴포넌트) | ✅ 활성 (직접 렌더 X) |
 | `MarketIndexSection.jsx` | 지수 UI (MarketPulseWidget의 서브컴포넌트) | ✅ 활성 (직접 렌더 X) |

--- a/src/components/home/MorphingFocusSection.jsx
+++ b/src/components/home/MorphingFocusSection.jsx
@@ -1,0 +1,474 @@
+// 모핑 포커스 — 시간대 인지 단일 포커스 (#335, 최유나 디자인)
+// NotableMoversSection 흡수: 시간대(국장/미장/갭/코인)에 따라 주도주 또는 주목 종목으로 자동 전환.
+//
+// 위계 (절대 준수):
+//   1순위 시선 = 등락률 색(빨강 상승 #F04452 / 파랑 하락 #1764ED)
+//   2순위      = WHY 정량근거 (◆ LEAD 칩 + 정량 한 줄)
+//   3순위      = 세션 인디케이터(작게, 색 2개만)
+//
+// computeMorphFocus(#335)가 모드/주도테마/무버/브릿지를 계산하고, 이 컴포넌트는 모드별로 렌더만 한다.
+import { useMemo } from 'react';
+import { DEFAULT_KRW_RATE } from '../../constants/market';
+import { computeMorphFocus, MORPH_MODE } from '../../utils/leadingStocks';
+import { getKoreanMarketStatus, getUsMarketStatus } from '../../utils/marketHours';
+import { findRelatedNews } from './utils';
+import { itemKey } from '../../utils/symbolKey';
+import TickerLogo from './TickerLogo';
+
+// ─── 색상 토큰 (한국식: 빨강 상승 / 파랑 하락) ───────────────────
+const UP = '#F04452';
+const DOWN = '#1764ED';
+const NEUTRAL = '#8B95A1';
+const LIVE_DOT = '#2AC769';   // 세션 라이브 점(초록) — 등락률과 절대 겹치지 않음
+const IDLE_DOT = '#B0B8C1';   // 세션 정지 점(회색)
+
+function dirColor(pct) {
+  if (pct > 0) return UP;
+  if (pct < 0) return DOWN;
+  return NEUTRAL;
+}
+
+// 미세 배경 틴트 — CommandCenter HeroSignalCard heroBg 패턴 재사용
+function tintBg(pct) {
+  if (pct > 0) return 'rgba(240,68,82,0.03)';
+  if (pct < 0) return 'rgba(23,100,237,0.03)';
+  return 'rgba(139,149,161,0.04)';
+}
+
+// 가격 포맷 — 마켓별 통화/소수 처리 (NotableCard 패턴 차용)
+function formatPrice(item, krwRate) {
+  if (!item) return '';
+  if (item._market === 'COIN') {
+    const krw = item.priceKrw || (item.priceUsd ?? 0) * krwRate;
+    return `₩${Math.round(krw).toLocaleString('ko-KR')}`;
+  }
+  if (item._market === 'KR') return `₩${Math.round(item.price || 0).toLocaleString('ko-KR')}`;
+  return `$${(item.price ?? 0).toFixed(2)}`;
+}
+
+// 미니 스파크라인 path 생성 (NotableCard / MiniSparkline 패턴)
+function sparkPath(spark, w, h) {
+  if (!Array.isArray(spark) || spark.length < 3) return '';
+  const min = Math.min(...spark);
+  const max = Math.max(...spark);
+  const range = max - min || 1;
+  return spark.map((v, i) => {
+    const x = (i / (spark.length - 1)) * w;
+    const y = h - 2 - ((v - min) / range) * (h - 4);
+    return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
+  }).join(' ');
+}
+
+// 정량 WHY 한 줄 — 모드별로 단정 강도를 다르게.
+//   LEAD: 실시간 단정 가능 ("거래 회전율 상위 · 뉴스 N건 · +X%")
+//   GAP:  실시간 단정 금지 ("어제 마감 ±X% · 뉴스 N건")
+function buildLeadWhy({ item, pct, newsCount, isGap }) {
+  const parts = [];
+  if (isGap) {
+    // 시간외 — 실시간 체결가 없음 → "어제 마감" 명시 (단정 회피)
+    const sign = pct > 0 ? '+' : '';
+    parts.push(`어제 마감 ${sign}${pct.toFixed(1)}%`);
+    if (newsCount > 0) parts.push(`뉴스 ${newsCount}건`);
+    return parts.join(' · ');
+  }
+  // LEAD/COIN — 회전율 percentile이 높으면 "거래 쏠림" 근거
+  const turnPct = item?._leadBreakdown?.turn;
+  if (Number.isFinite(turnPct) && turnPct >= 70) parts.push('거래 쏠림 상위');
+  else if (Number.isFinite(turnPct) && turnPct >= 50) parts.push('거래 활발');
+  if (newsCount > 0) parts.push(`뉴스 ${newsCount}건`);
+  const sign = pct > 0 ? '+' : '';
+  parts.push(`${sign}${pct.toFixed(1)}%`);
+  return parts.join(' · ');
+}
+
+// ─── SessionDot (3순위, 마이크로) ────────────────────────────────
+// 색 2개만: 초록 점멸(isLive) / 회색 정지(비라이브). 세션 구분은 텍스트 라벨이 담당.
+function SessionDot({ status, align = 'left' }) {
+  if (!status) return null;
+  const live = !!status.isLive;
+  return (
+    <span className={`inline-flex items-center gap-1 ${align === 'right' ? 'flex-row-reverse' : ''}`}>
+      <span className="relative flex items-center justify-center" style={{ width: 7, height: 7 }}>
+        {live && (
+          <span
+            className="absolute inline-flex h-full w-full rounded-full opacity-60 animate-ping"
+            style={{ background: LIVE_DOT }}
+          />
+        )}
+        <span
+          className="relative inline-flex rounded-full"
+          style={{ width: 7, height: 7, background: live ? LIVE_DOT : IDLE_DOT }}
+        />
+      </span>
+      <span className="text-[11px] font-semibold whitespace-nowrap"
+        style={{ color: live ? '#1A7D4B' : '#8B95A1' }}>
+        {status.label}
+      </span>
+    </span>
+  );
+}
+
+// ─── SessionBar — [좌: 주도시장] [중: 시계] [우: 보조시장] ──────────
+function SessionBar({ primaryStatus, secondaryStatus, clockLabel }) {
+  return (
+    <div className="flex items-center justify-between gap-2 mb-3">
+      <SessionDot status={primaryStatus} align="left" />
+      {clockLabel && (
+        <span className="text-[11px] font-medium text-[#B0B8C1] dark:text-[#6B7684] tabular-nums font-mono flex-shrink-0">
+          {clockLabel}
+        </span>
+      )}
+      <SessionDot status={secondaryStatus} align="right" />
+    </div>
+  );
+}
+
+// ─── FocusLeadCard — 대장주 1위 (풀폭) ───────────────────────────
+function FocusLeadCard({ item, pct, newsCount, isGap, krwRate, onClick }) {
+  const color = dirColor(pct);
+  const price = formatPrice(item, krwRate);
+  const spark = item?.sparkline?.length >= 3 ? item.sparkline : null;
+  const path = spark ? sparkPath(spark, 96, 28) : '';
+  const why = buildLeadWhy({ item, pct, newsCount, isGap });
+
+  return (
+    <div
+      onClick={() => onClick?.(item)}
+      className="rounded-2xl px-4 py-4 cursor-pointer transition-all hover:brightness-[0.99] active:scale-[0.995]"
+      style={{ background: tintBg(pct) }}
+      role="button"
+      tabIndex={0}
+    >
+      {/* 상단: 로고 + 종목명 + (우) 가격/스파크 */}
+      <div className="flex items-center gap-2.5 mb-2.5">
+        <TickerLogo item={item} size={36} />
+        <div className="min-w-0 flex-1">
+          <div className="text-[16px] font-bold text-[#191F28] dark:text-[#E5E8EB] truncate leading-tight">
+            {item.name || item.symbol}
+          </div>
+          <div className="text-[11px] font-medium text-[#B0B8C1] dark:text-[#6B7684] font-mono">
+            {item.symbol}
+          </div>
+        </div>
+        {spark && (
+          <svg width={96} height={28} className="flex-shrink-0" aria-hidden="true">
+            <path d={path} fill="none" stroke={color} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+      </div>
+
+      {/* 등락률 (1순위 — 가장 크게) + 가격 */}
+      <div className="flex items-baseline gap-2.5 mb-2.5">
+        <span className="text-[26px] font-bold tabular-nums font-mono leading-none" style={{ color }}>
+          {pct > 0 ? '+' : ''}{pct.toFixed(2)}%
+        </span>
+        {price && (
+          <span className="text-[14px] font-semibold tabular-nums font-mono text-[#6B7684] dark:text-[#8B95A1]">
+            {price}
+          </span>
+        )}
+      </div>
+
+      {/* WHY (2순위 — ◆ LEAD 검정칩 + 정량근거) */}
+      {why && (
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] font-bold px-1.5 py-0.5 rounded flex-shrink-0 bg-[#191F28] text-white tracking-wide">
+            LEAD
+          </span>
+          <span className="text-[12px] font-medium text-[#4E5968] dark:text-[#B0B8C1] truncate">
+            {why}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── CompactMoverRow — 대장주 2~3위 / GAP·COIN 무버 행 ────────────
+function CompactMoverRow({ item, pct, newsCount, isGap, krwRate, onClick, showTopBorder }) {
+  const color = dirColor(pct);
+  const price = formatPrice(item, krwRate);
+  // 행 단위는 근거를 더 짧게 — 뉴스 우선, 없으면 회전율/변동폭
+  let reason = '';
+  if (isGap) {
+    const sign = pct > 0 ? '+' : '';
+    reason = newsCount > 0 ? `어제 마감 ${sign}${pct.toFixed(1)}% · 뉴스 ${newsCount}건` : `어제 마감 ${sign}${pct.toFixed(1)}%`;
+  } else if (newsCount > 0) {
+    reason = `뉴스 ${newsCount}건`;
+  } else {
+    const turnPct = item?._leadBreakdown?.turn;
+    reason = Number.isFinite(turnPct) && turnPct >= 70 ? '거래 쏠림' : '';
+  }
+
+  return (
+    <div
+      onClick={() => onClick?.(item)}
+      className="flex items-center gap-2.5 py-2.5 cursor-pointer hover:bg-[#F7F8FA] dark:hover:bg-[#1C2230] -mx-2 px-2 rounded-lg transition-colors"
+      style={showTopBorder ? { borderTop: '1px solid #F2F3F5' } : undefined}
+      role="button"
+      tabIndex={0}
+    >
+      <TickerLogo item={item} size={24} />
+      <div className="min-w-0 flex-1">
+        <div className="text-[13px] font-semibold text-[#191F28] dark:text-[#E5E8EB] truncate leading-tight">
+          {item.name || item.symbol}
+        </div>
+        {reason && (
+          <div className="text-[11px] font-medium text-[#8B95A1] dark:text-[#6B7684] truncate">{reason}</div>
+        )}
+      </div>
+      {price && (
+        <span className="text-[12px] font-semibold tabular-nums font-mono text-[#6B7684] dark:text-[#8B95A1] flex-shrink-0">
+          {price}
+        </span>
+      )}
+      <span className="text-[14px] font-bold tabular-nums font-mono flex-shrink-0 w-[64px] text-right" style={{ color }}>
+        {pct > 0 ? '+' : ''}{pct.toFixed(2)}%
+      </span>
+    </div>
+  );
+}
+
+// ─── AltThemeChips — 동반 테마 칩 (LEAD 모드) ────────────────────
+function AltThemeChips({ themes }) {
+  if (!Array.isArray(themes) || themes.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1.5 mt-3">
+      <span className="text-[11px] font-medium text-[#B0B8C1] dark:text-[#6B7684] self-center mr-0.5">함께 오른 테마</span>
+      {themes.map((t) => (
+        <span
+          key={t.theme}
+          className="text-[11px] font-semibold px-2 py-1 rounded-full bg-[#F2F4F6] dark:bg-[#252B38] text-[#4E5968] dark:text-[#B0B8C1]"
+        >
+          {t.theme}
+          {t.hot && <span className="ml-0.5" style={{ color: UP }}>·</span>}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ─── BridgeLine — 전이구간 브릿지 (국장 모드, 한 줄) ──────────────
+function BridgeLine({ bridge }) {
+  if (!bridge?.line) return null;
+  // tone에 따라 좌측 점 색 (up=빨강 / down=파랑 / flat=회색). 텍스트는 보조색(11px).
+  const dot = bridge.tone === 'up' ? UP : bridge.tone === 'down' ? DOWN : NEUTRAL;
+  return (
+    <div className="flex items-center gap-1.5 mt-3 pt-3" style={{ borderTop: '1px solid #F2F3F5' }}>
+      <span className="inline-block rounded-full flex-shrink-0" style={{ width: 5, height: 5, background: dot }} />
+      <span className="text-[11px] font-medium text-[#6B7684] dark:text-[#8B95A1] leading-snug">
+        {bridge.line}
+      </span>
+    </div>
+  );
+}
+
+// ─── 헤더 (모드별 타이틀 + 서브) ─────────────────────────────────
+function SectionHeader({ title, subtitle, themeDir }) {
+  return (
+    <div className="mb-3">
+      <h2 className="text-[19px] font-bold text-[#191F28] dark:text-[#E5E8EB] tracking-tight flex items-center gap-1.5">
+        {title}
+        {themeDir != null && (
+          <span className="text-[15px]" style={{ color: themeDir >= 0 ? UP : DOWN }}>
+            {themeDir >= 0 ? '▲' : '▼'}
+          </span>
+        )}
+      </h2>
+      {subtitle && <p className="text-[13px] text-[#8B95A1] dark:text-[#6B7684] mt-0.5">{subtitle}</p>}
+    </div>
+  );
+}
+
+// ─── 카드 셸 ─────────────────────────────────────────────────────
+function Shell({ children }) {
+  return <div className="bg-white dark:bg-[#171B24] rounded-2xl p-5 pt-6">{children}</div>;
+}
+
+// ─── 메인 ────────────────────────────────────────────────────────
+export default function MorphingFocusSection({
+  krItems = [],
+  usItems = [],
+  coinItems = [],
+  recentNews = [],
+  krwRate = DEFAULT_KRW_RATE,
+  indices = [],
+  onItemClick,
+}) {
+  // 세션 상태 — 컴포넌트 내부에서 직접 조회 (NotableMovers 패턴)
+  const krStatus = getKoreanMarketStatus();
+  const usStatus = getUsMarketStatus();
+
+  const focus = useMemo(
+    () => computeMorphFocus({
+      krItems, usItems, coinItems, recentNews, krwRate, indices, krStatus, usStatus,
+    }),
+    // krStatus/usStatus는 매 렌더 새 객체지만 phase만 의존 → phase 문자열로 안정화
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [krItems, usItems, coinItems, recentNews, krwRate, indices, krStatus.phase, usStatus.phase],
+  );
+
+  const { mode, primaryTheme, altThemes, movers, bridge } = focus;
+  const isGap = mode === MORPH_MODE.US_GAP || mode === MORPH_MODE.KR_GAP;
+  const isCoin = mode === MORPH_MODE.COIN_LEAD;
+
+  // 뉴스 매칭 카운트 — item별 (LEAD 카드/행 근거용). _leadNewsCount가 이미 있으면 그것 사용.
+  const newsCountOf = (it) => {
+    if (Number.isFinite(it?._leadNewsCount)) return it._leadNewsCount;
+    return findRelatedNews(it, recentNews) ? 1 : 0;
+  };
+
+  const pctOf = (it) => (Number.isFinite(it?._leadPct) ? it._leadPct : 0);
+
+  // 세션 바 구성 — 모드별 주도/보조 시장 매핑
+  let primaryStatus = null;
+  let secondaryStatus = null;
+  let clockLabel = null;
+  if (mode === MORPH_MODE.KR_LEAD || mode === MORPH_MODE.KR_GAP) {
+    primaryStatus = krStatus;
+    secondaryStatus = usStatus;
+  } else if (mode === MORPH_MODE.US_LEAD || mode === MORPH_MODE.US_GAP) {
+    primaryStatus = usStatus;
+    secondaryStatus = krStatus;
+  } else {
+    // COIN_LEAD — 코인은 24시간이므로 라이브 점 없이 양쪽 휴장 표시
+    primaryStatus = krStatus;
+    secondaryStatus = usStatus;
+  }
+  try {
+    clockLabel = new Date().toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false });
+  } catch { clockLabel = null; }
+
+  // ── LEAD 모드: 주도 테마가 있으면 테마형, 없으면 단일 폴백 ──
+  if (mode === MORPH_MODE.KR_LEAD || mode === MORPH_MODE.US_LEAD) {
+    const leaders = primaryTheme?.leaders || [];
+
+    // 주도 테마가 있는 경우
+    if (primaryTheme && leaders.length > 0) {
+      const lead = leaders[0];
+      const rest = leaders.slice(1, 3);
+      const themeDir = pctOf(lead);
+      return (
+        <Shell>
+          <SectionHeader
+            title={`지금 주도 테마 ─ ${primaryTheme.theme}`}
+            subtitle={mode === MORPH_MODE.KR_LEAD ? '국내 장중 · 거래 쏠림 기준' : '미국 장중 · 거래 쏠림 기준'}
+            themeDir={themeDir}
+          />
+          <SessionBar primaryStatus={primaryStatus} secondaryStatus={secondaryStatus} clockLabel={clockLabel} />
+          <FocusLeadCard
+            item={lead} pct={pctOf(lead)} newsCount={newsCountOf(lead)}
+            isGap={false} krwRate={krwRate} onClick={onItemClick}
+          />
+          {rest.length > 0 && (
+            <div className="mt-1">
+              {rest.map((it) => (
+                <CompactMoverRow
+                  key={itemKey(it)} item={it} pct={pctOf(it)} newsCount={newsCountOf(it)}
+                  isGap={false} krwRate={krwRate} onClick={onItemClick} showTopBorder
+                />
+              ))}
+            </div>
+          )}
+          <AltThemeChips themes={altThemes} />
+          <BridgeLine bridge={bridge} />
+        </Shell>
+      );
+    }
+
+    // 무섹터 graceful degrade — primaryTheme 없음 → movers 단일 폴백
+    if (movers.length > 0) {
+      const lead = movers[0].item;
+      const rest = movers.slice(1, 4);
+      return (
+        <Shell>
+          <SectionHeader title="주목할 종목" subtitle="지금 시장에서 눈여겨볼 움직임" />
+          <SessionBar primaryStatus={primaryStatus} secondaryStatus={secondaryStatus} clockLabel={clockLabel} />
+          <FocusLeadCard
+            item={lead} pct={movers[0].pct} newsCount={movers[0].newsCount}
+            isGap={false} krwRate={krwRate} onClick={onItemClick}
+          />
+          {rest.length > 0 && (
+            <div className="mt-1">
+              {rest.map((m) => (
+                <CompactMoverRow
+                  key={itemKey(m.item)} item={m.item} pct={m.pct} newsCount={m.newsCount}
+                  isGap={false} krwRate={krwRate} onClick={onItemClick} showTopBorder
+                />
+              ))}
+            </div>
+          )}
+          <BridgeLine bridge={bridge} />
+        </Shell>
+      );
+    }
+    return null;
+  }
+
+  // ── GAP 모드: 시간외/프리/데이마켓 — 변동폭 무버 (실시간 단정 금지) ──
+  if (isGap) {
+    if (movers.length === 0) return null;
+    const lead = movers[0];
+    const rest = movers.slice(1, 5);
+    const sessionWord = mode === MORPH_MODE.US_GAP
+      ? (usStatus.label || '시간외')
+      : (krStatus.label || '시간외');
+    return (
+      <Shell>
+        <SectionHeader title={`지금 주목 · ${sessionWord}`} subtitle="정규장 밖 — 어제 마감 대비 움직임" />
+        <SessionBar primaryStatus={primaryStatus} secondaryStatus={secondaryStatus} clockLabel={clockLabel} />
+        <FocusLeadCard
+          item={lead.item} pct={lead.pct} newsCount={lead.newsCount}
+          isGap krwRate={krwRate} onClick={onItemClick}
+        />
+        {rest.length > 0 && (
+          <div className="mt-1">
+            {rest.map((m) => (
+              <CompactMoverRow
+                key={itemKey(m.item)} item={m.item} pct={m.pct} newsCount={m.newsCount}
+                isGap krwRate={krwRate} onClick={onItemClick} showTopBorder
+              />
+            ))}
+          </div>
+        )}
+        <BridgeLine bridge={bridge} />
+      </Shell>
+    );
+  }
+
+  // ── COIN_LEAD 모드: 코인 무버 + 다음 개장 안내 ──
+  if (isCoin) {
+    if (movers.length === 0) return null;
+    const lead = movers[0];
+    const rest = movers.slice(1, 5);
+    return (
+      <Shell>
+        <SectionHeader title="지금은 코인 시간" subtitle="증시 마감 · 24시간 거래대금 기준" />
+        <SessionBar primaryStatus={primaryStatus} secondaryStatus={secondaryStatus} clockLabel={clockLabel} />
+        <FocusLeadCard
+          item={lead.item} pct={lead.pct} newsCount={lead.newsCount}
+          isGap={false} krwRate={krwRate} onClick={onItemClick}
+        />
+        {rest.length > 0 && (
+          <div className="mt-1">
+            {rest.map((m) => (
+              <CompactMoverRow
+                key={itemKey(m.item)} item={m.item} pct={m.pct} newsCount={m.newsCount}
+                isGap={false} krwRate={krwRate} onClick={onItemClick} showTopBorder
+              />
+            ))}
+          </div>
+        )}
+        {/* 다음 개장 안내 — 작게 */}
+        <div className="flex items-center gap-1.5 mt-3 pt-3" style={{ borderTop: '1px solid #F2F3F5' }}>
+          <span className="inline-block rounded-full flex-shrink-0" style={{ width: 5, height: 5, background: IDLE_DOT }} />
+          <span className="text-[11px] font-medium text-[#6B7684] dark:text-[#8B95A1]">
+            국장 08:00 · 미장 22:30 개장 예정
+          </span>
+        </div>
+      </Shell>
+    );
+  }
+
+  return null;
+}

--- a/src/components/home/MorphingFocusSection.jsx
+++ b/src/components/home/MorphingFocusSection.jsx
@@ -138,6 +138,7 @@ function FocusLeadCard({ item, pct, newsCount, isGap, krwRate, onClick }) {
       style={{ background: tintBg(pct) }}
       role="button"
       tabIndex={0}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick?.(item); } }}
     >
       {/* 상단: 로고 + 종목명 + (우) 가격/스파크 */}
       <div className="flex items-center gap-2.5 mb-2.5">
@@ -207,6 +208,7 @@ function CompactMoverRow({ item, pct, newsCount, isGap, krwRate, onClick, showTo
       style={showTopBorder ? { borderTop: '1px solid #F2F3F5' } : undefined}
       role="button"
       tabIndex={0}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick?.(item); } }}
     >
       <TickerLogo item={item} size={24} />
       <div className="min-w-0 flex-1">
@@ -306,7 +308,7 @@ export default function MorphingFocusSection({
     }),
     // krStatus/usStatus는 매 렌더 새 객체지만 phase만 의존 → phase 문자열로 안정화
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [krItems, usItems, coinItems, recentNews, krwRate, krwRateLoaded, indices, krStatus.phase, usStatus.phase],
+    [krItems, usItems, coinItems, recentNews, krwRate, krwRateLoaded, indices, krStatus?.phase, usStatus?.phase],
   );
 
   const { mode, primaryTheme, altThemes, movers, bridge } = focus;

--- a/src/components/home/MorphingFocusSection.jsx
+++ b/src/components/home/MorphingFocusSection.jsx
@@ -292,6 +292,7 @@ export default function MorphingFocusSection({
   coinItems = [],
   recentNews = [],
   krwRate = DEFAULT_KRW_RATE,
+  krwRateLoaded = false,
   indices = [],
   onItemClick,
 }) {
@@ -301,11 +302,11 @@ export default function MorphingFocusSection({
 
   const focus = useMemo(
     () => computeMorphFocus({
-      krItems, usItems, coinItems, recentNews, krwRate, indices, krStatus, usStatus,
+      krItems, usItems, coinItems, recentNews, krwRate, krwRateLoaded, indices, krStatus, usStatus,
     }),
     // krStatus/usStatus는 매 렌더 새 객체지만 phase만 의존 → phase 문자열로 안정화
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [krItems, usItems, coinItems, recentNews, krwRate, indices, krStatus.phase, usStatus.phase],
+    [krItems, usItems, coinItems, recentNews, krwRate, krwRateLoaded, indices, krStatus.phase, usStatus.phase],
   );
 
   const { mode, primaryTheme, altThemes, movers, bridge } = focus;

--- a/src/components/home/MorphingFocusSection.jsx
+++ b/src/components/home/MorphingFocusSection.jsx
@@ -337,7 +337,11 @@ export default function MorphingFocusSection({
     secondaryStatus = usStatus;
   }
   try {
-    clockLabel = new Date().toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false });
+    // [STYLE7 수정] KST 고정(timeZone:'Asia/Seoul') — 해외 접속 시 클라이언트 로컬타임존
+    // 으로 부정확하던 문제 보정. 세션 라벨(국장/미장)이 KST 기준이라 시계도 KST로 통일.
+    clockLabel = new Date().toLocaleTimeString('ko-KR', {
+      hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'Asia/Seoul',
+    });
   } catch { clockLabel = null; }
 
   // ── LEAD 모드: 주도 테마가 있으면 테마형, 없으면 단일 폴백 ──

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -6,7 +6,7 @@ import { useWatchlist } from '../../hooks/useWatchlist';
 import { getPct } from './utils';
 import { itemKey, isPreferredOrSpecial } from '../../utils/symbolKey';
 import NewsFeedWidget from './widgets/NewsFeedWidget';
-import NotableMoversSection from './NotableMoversSection';
+import MorphingFocusSection from './MorphingFocusSection';
 import { useInvestorSignals } from '../../hooks/useInvestorSignals';
 import { useDerivativeSignals } from '../../hooks/useDerivativeSignals';
 import { useNewsSignals } from '../../hooks/useNewsSignals';
@@ -223,12 +223,15 @@ export default function HomeDashboard({
         onShowScorecard={handleShowScorecard}
       />
 
-      {/* ─── 2. 주목할 종목 (WHY 카드) ───────────────────── */}
+      {/* ─── 2. 모핑 포커스 (시간대별 주도주/주목 — NotableMovers 흡수) ─── */}
       {hasData && (
-        <NotableMoversSection
-          allItems={allItems}
+        <MorphingFocusSection
+          krItems={krItems}
+          usItems={usItems}
+          coinItems={coinItems}
           recentNews={recentNews}
           krwRate={krwRate}
+          indices={indices}
           onItemClick={onItemClick}
         />
       )}

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -231,6 +231,7 @@ export default function HomeDashboard({
           coinItems={coinItems}
           recentNews={recentNews}
           krwRate={krwRate}
+          krwRateLoaded={krwRateLoaded}
           indices={indices}
           onItemClick={onItemClick}
         />

--- a/src/hooks/useCoins.js
+++ b/src/hooks/useCoins.js
@@ -25,10 +25,13 @@ function loadCoinCache() {
 function saveCoinCache(coins) {
   try {
     // priceKrw/priceUsd/change24h 핵심 필드만 저장 (용량 최적화)
+    // [HIGH1 수정] accTradePrice24h 추가 — #335 MorphingFocusSection이 COIN_LEAD에서 거래대금 기준
+    // 컷(MIN_TURNOVER.COIN=100억)을 적용. 캐시에 빠지면 재방문 시 movers=[]→섹션 빈화면.
     const slim = coins.map(c => ({
       id: c.id, symbol: c.symbol, name: c.name, market: c.market,
       priceKrw: c.priceKrw, priceUsd: c.priceUsd, change24h: c.change24h,
       marketCap: c.marketCap, volume24h: c.volume24h,
+      accTradePrice24h: c.accTradePrice24h,
       image: c.image, sector: c.sector, sparkline: c.sparkline ?? [],
     }));
     localStorage.setItem(COIN_CACHE_KEY, JSON.stringify({ data: slim, ts: Date.now() }));

--- a/src/utils/leadingStocks.js
+++ b/src/utils/leadingStocks.js
@@ -1,0 +1,538 @@
+// 주도주 캐치 + 모핑 포커스 — 알고리즘 순수 모듈 (#335)
+// architect(Opus) 확정 스펙(.tmp/spec-C-leading-stocks.md). UI 미포함(후속 #D).
+//
+// 핵심 아이디어:
+//   "시총 대비 거래대금 쏠림(회전율)"으로 중소형 주도주를 포착한다.
+//   삼성전자 같은 대형 저회전주가 상시 1위를 차지하는 문제를 회피하기 위해
+//   거래대금 절대값이 아닌 회전율(turnover/marketCap) percentile을 1차 가중치로 둔다.
+//
+// 데이터 제약(설계 전제):
+//   - 코인 marketCap=0 영구 → 회전율 불가 → 거래대금(accTradePrice24h) 절대 percentile로 대체.
+//   - volume24h=0 영구 → 코인 거래량은 accTradePrice24h(거래대금)만 신뢰.
+//   - 시간외 실시간 체결가 없음(스냅샷=정규장 종가) → GAP 모드는 "전일종가 갭+뉴스" 근사.
+//   - 스냅샷 무섹터 → sector는 클라 정적맵 주입분만 존재 → 무섹터 주도주는 단일카드 폴백.
+//   - baseline(20영업일 평균 거래대금) 없음 → 1차는 회전율로 대체, 2차에 KV 도입(w_surge).
+
+import { DERIVATIVE_RE, getPct, isCoinItem } from '../components/home/utils';
+import { buildStockKeywords, matchesKeywords } from './newsAlias';
+import { detectNewsSectors } from './newsTopicMap';
+
+// ─── 상수 ────────────────────────────────────────────────────
+
+// 잡주 컷 하한 (KRW 환산 거래대금). 초저시총 노이즈 제거.
+// KR 50억 / US $50M(환율 환산) / COIN 100억
+export const MIN_TURNOVER = {
+  KR: 5_000_000_000,        // 50억 원
+  US_USD: 50_000_000,       // $50M (turnoverKRW가 이미 KRW 환산이므로 비교 시 krwRate 곱)
+  COIN: 10_000_000_000,     // 100억 원
+};
+
+// 스코어링 가중치. 1차는 baseline 부재로 w_surge=0(회전율로 대체).
+export const SCORE_WEIGHTS = {
+  primary:   { turn: 0.45, move: 0.35, news: 0.20, surge: 0.0 },
+  secondary: { turn: 0.20, move: 0.25, news: 0.15, surge: 0.40 },
+};
+
+// 패널티
+const PENALTY_DERIV = 60;   // 파생상품(레버리지/인버스 등)
+const PENALTY_CLOSED = 40;  // 휴장 마켓 종목
+
+// 핫섹터 부스트(테마 클러스터링)
+const HOT_SECTOR_BOOST = 1.3;
+const BREADTH_DENOM = 5;    // breadth = min(종목수/5, 1)
+
+// 모핑 모드 식별자
+export const MORPH_MODE = {
+  KR_LEAD:   'KR_LEAD',
+  US_LEAD:   'US_LEAD',
+  US_GAP:    'US_GAP',
+  KR_GAP:    'KR_GAP',
+  COIN_LEAD: 'COIN_LEAD',
+};
+
+// ─── 기초 계산 ────────────────────────────────────────────────
+
+// 거래대금(KRW 환산) — KR=price×volume / US=price×volume×krwRate / COIN=accTradePrice24h
+// 음수/NaN/누락은 0으로 방어. 코인은 이미 KRW 기준 거래대금이므로 환율 미적용.
+export function turnoverKRW(item, krwRate = 0) {
+  if (!item) return 0;
+  if (isCoinItem(item)) {
+    const acc = Number(item.accTradePrice24h);
+    return Number.isFinite(acc) && acc > 0 ? acc : 0;
+  }
+  const price = Number(item.price);
+  const volume = Number(item.volume);
+  if (!Number.isFinite(price) || !Number.isFinite(volume) || price <= 0 || volume <= 0) return 0;
+  const raw = price * volume;
+  if (item._market === 'US') {
+    const rate = Number(krwRate);
+    return Number.isFinite(rate) && rate > 0 ? raw * rate : 0;
+  }
+  return raw; // KR
+}
+
+// 회전율 = 거래대금 / 시가총액. 코인(marketCap=0)은 null 반환 → 절대 percentile로 대체.
+export function turnoverRatio(item, krwRate = 0) {
+  if (isCoinItem(item)) return null;
+  const cap = Number(item?.marketCap);
+  if (!Number.isFinite(cap) || cap <= 0) return null;
+  return turnoverKRW(item, krwRate) / cap;
+}
+
+// percentile rank(0~100) — value가 values 중 몇 %ile인지. values 비거나 단일값이면 50 중립.
+function percentileRank(value, values) {
+  if (!Array.isArray(values) || values.length === 0) return 50;
+  if (values.length === 1) return 50;
+  let below = 0;
+  let equal = 0;
+  for (const v of values) {
+    if (v < value) below += 1;
+    else if (v === value) equal += 1;
+  }
+  // 중앙값 보정(동점 분산) — (below + 0.5·equal) / n
+  return ((below + 0.5 * equal) / values.length) * 100;
+}
+
+// 잡주 컷 — 스코어링 전 필터. 통과 시 true.
+// 제외: 거래대금 하한 미달 / 파생상품 / (무변동 & 회전율 percentile<50)
+function passesNoiseGate(item, ctx) {
+  if (!item) return false;
+  const name = item.name || '';
+  if (DERIVATIVE_RE.test(name)) return false;
+
+  const turn = turnoverKRW(item, ctx.krwRate);
+  const market = item._market;
+  let minTurn;
+  if (market === 'US') minTurn = MIN_TURNOVER.US_USD * (Number(ctx.krwRate) || 0);
+  else if (isCoinItem(item) || market === 'COIN') minTurn = MIN_TURNOVER.COIN;
+  else minTurn = MIN_TURNOVER.KR;
+  // US 하한은 krwRate 필요 — 환율 미로드 시(0) 하한 비교 불가 → KR 기준으로 폴백(과소 컷 방지).
+  if (market === 'US' && minTurn <= 0) minTurn = MIN_TURNOVER.KR;
+  if (turn < minTurn) return false;
+
+  // 무변동 + 회전율 하위 → 거래대금만 큰 비주류 → 제외
+  const pct = getPct(item);
+  if (pct === 0) {
+    const ratioPct = ctx.ratioPercentileOf ? ctx.ratioPercentileOf(item) : 50;
+    if (ratioPct < 50) return false;
+  }
+  return true;
+}
+
+// ─── 스코어링 ────────────────────────────────────────────────
+
+// 뉴스 매칭 건수 + 핫섹터 소속 점수(0~100)
+//   S_news = min(newsCount,3)/3·70 + (핫섹터 소속 시 30)
+function scoreNews(item, recentNews, hotSectors) {
+  let newsCount = 0;
+  if (Array.isArray(recentNews) && recentNews.length > 0) {
+    const market = item._market === 'COIN' ? 'COIN' : item._market === 'KR' ? 'KR' : 'US';
+    const kws = buildStockKeywords(item.symbol, item.name, market);
+    for (const n of recentNews) {
+      if (newsCount >= 3) break;
+      const text = `${n.title || ''} ${n.summary || ''}`;
+      if (matchesKeywords(text, kws)) newsCount += 1;
+    }
+  }
+  const base = (Math.min(newsCount, 3) / 3) * 70;
+  const sector = item.sector || '';
+  const inHot = sector && Array.isArray(hotSectors)
+    && hotSectors.some((s) => sector.includes(s) || s.includes(sector));
+  return { score: base + (inHot ? 30 : 0), newsCount };
+}
+
+// 방향가중 변동폭 점수 — min(|pct|,15)/15·100, 부호는 dir로 분리.
+function scoreMove(item) {
+  const pct = getPct(item);
+  const mag = (Math.min(Math.abs(pct), 15) / 15) * 100;
+  return { score: mag, dir: Math.sign(pct), pct };
+}
+
+/**
+ * scoreLeading — 단일 종목 주도주 점수.
+ * @param {object} item   _market 태그된 종목/코인
+ * @param {object} ctx    {
+ *   krwRate, recentNews, hotSectors,
+ *   ratioPercentileOf(item)→0~100,        // 회전율 percentile(주식)
+ *   turnoverPercentileOf(item)→0~100,     // 거래대금 절대 percentile(코인 대체)
+ *   isClosed,                              // 휴장 마켓 여부 → P_closed
+ *   weights                                // SCORE_WEIGHTS.primary | secondary
+ * }
+ * @returns {object} { score, breakdown:{turn,move,news,surge,penalty}, dir, pct, newsCount, turnover }
+ */
+export function scoreLeading(item, ctx = {}) {
+  const w = ctx.weights || SCORE_WEIGHTS.primary;
+  const turnover = turnoverKRW(item, ctx.krwRate);
+
+  // S_turnover — 주식은 회전율 percentile, 코인은 거래대금 절대 percentile로 대체.
+  let S_turnover;
+  if (isCoinItem(item)) {
+    S_turnover = ctx.turnoverPercentileOf ? ctx.turnoverPercentileOf(item) : 50;
+  } else {
+    S_turnover = ctx.ratioPercentileOf ? ctx.ratioPercentileOf(item) : 50;
+  }
+
+  const move = scoreMove(item);
+  const news = scoreNews(item, ctx.recentNews, ctx.hotSectors);
+
+  // S_surge(2차) — baseline 부재 시 0. weights.surge=0이면 무영향.
+  const S_surge = ctx.surgeScoreOf ? ctx.surgeScoreOf(item) : 0;
+
+  let penalty = 0;
+  if (DERIVATIVE_RE.test(item.name || '')) penalty += PENALTY_DERIV;
+  if (ctx.isClosed) penalty += PENALTY_CLOSED;
+
+  const score =
+    w.turn * S_turnover +
+    w.move * move.score +
+    w.news * news.score +
+    w.surge * S_surge -
+    penalty;
+
+  return {
+    score,
+    breakdown: { turn: S_turnover, move: move.score, news: news.score, surge: S_surge, penalty },
+    dir: move.dir,
+    pct: move.pct,
+    newsCount: news.newsCount,
+    turnover,
+  };
+}
+
+// 한 마켓의 종목 배열을 스코어링 — 잡주 컷 통과분만 _leadScore 부여해 반환(내림차순).
+//   ctx 내부 percentile 함수를 마켓 모수 기준으로 미리 구성한다.
+export function scoreMarketItems(items, baseCtx = {}) {
+  if (!Array.isArray(items) || items.length === 0) return [];
+
+  // 회전율/거래대금 모수 — percentile 계산용(잡주 컷 전 전체 모수로 계산해야 안정적).
+  const ratios = [];
+  const turnovers = [];
+  for (const it of items) {
+    const r = turnoverRatio(it, baseCtx.krwRate);
+    if (r != null && Number.isFinite(r)) ratios.push(r);
+    const t = turnoverKRW(it, baseCtx.krwRate);
+    if (Number.isFinite(t) && t > 0) turnovers.push(t);
+  }
+  const ratioPercentileOf = (it) => {
+    const r = turnoverRatio(it, baseCtx.krwRate);
+    if (r == null || !Number.isFinite(r)) return 0;
+    return percentileRank(r, ratios);
+  };
+  const turnoverPercentileOf = (it) => {
+    const t = turnoverKRW(it, baseCtx.krwRate);
+    if (!Number.isFinite(t) || t <= 0) return 0;
+    return percentileRank(t, turnovers);
+  };
+
+  const ctx = { ...baseCtx, ratioPercentileOf, turnoverPercentileOf };
+
+  const scored = [];
+  for (const it of items) {
+    if (!passesNoiseGate(it, ctx)) continue;
+    const res = scoreLeading(it, ctx);
+    scored.push({
+      ...it,
+      _leadScore: res.score,
+      _leadBreakdown: res.breakdown,
+      _leadDir: res.dir,
+      _leadPct: res.pct,
+      _leadNewsCount: res.newsCount,
+      _leadTurnover: res.turnover,
+    });
+  }
+  scored.sort((a, b) => b._leadScore - a._leadScore);
+  return scored;
+}
+
+// ─── 테마 클러스터링 ──────────────────────────────────────────
+
+/**
+ * clusterThemes — 정적 item.sector로 묶고, 뉴스 핫섹터로 부스트.
+ * 무섹터 고득점 종목은 별도 "단일 종목" 그룹으로 graceful degrade.
+ * @param {object[]} scoredItems  scoreMarketItems 결과(_leadScore 보유)
+ * @param {object[]} recentNews
+ * @returns {object} { themes:[{theme, score, breadth, hot, leaders, members}], soloMovers:[item], hotSectors:[string] }
+ */
+export function clusterThemes(scoredItems, recentNews = []) {
+  const hotSectors = new Set();
+  if (Array.isArray(recentNews)) {
+    for (const n of recentNews) {
+      for (const s of detectNewsSectors(n.title || '')) hotSectors.add(s);
+    }
+  }
+  const hotList = [...hotSectors];
+  const isHot = (sector) =>
+    !!sector && hotList.some((h) => sector.includes(h) || h.includes(sector));
+
+  // sector별 그룹화. 무섹터는 solo로.
+  const groups = new Map();
+  const solo = [];
+  for (const it of scoredItems) {
+    const sector = it.sector || '';
+    if (!sector) { solo.push(it); continue; }
+    if (!groups.has(sector)) groups.set(sector, []);
+    groups.get(sector).push(it);
+  }
+
+  const themes = [];
+  for (const [sector, members] of groups.entries()) {
+    members.sort((a, b) => b._leadScore - a._leadScore);
+    const sum = members.reduce((acc, m) => acc + (m._leadScore || 0), 0);
+    const breadth = Math.min(members.length / BREADTH_DENOM, 1);
+    const hot = isHot(sector);
+    const newsBoost = hot ? HOT_SECTOR_BOOST : 1;
+    const score = sum * breadth * newsBoost;
+    themes.push({
+      theme: sector,
+      score,
+      breadth,
+      hot,
+      leaders: members.slice(0, 3),
+      members,
+    });
+  }
+  themes.sort((a, b) => b.score - a.score);
+
+  return { themes, soloMovers: solo, hotSectors: hotList };
+}
+
+// ─── 모핑 모드 결정 ───────────────────────────────────────────
+
+/**
+ * decideMorphMode — marketHours phase 기반 5모드.
+ *   KR open → KR_LEAD / US open → US_LEAD
+ *   US pre·after·dayMarket → US_GAP / KR preAuction·preNxt → KR_GAP
+ *   둘 다 closed → COIN_LEAD
+ * 우선순위: 정규장(LEAD) > 갭(GAP) > 코인. KR LEAD를 US LEAD보다 우선(국내 사용자 기준).
+ */
+export function decideMorphMode(krStatus, usStatus) {
+  const krPhase = krStatus?.phase;
+  const usPhase = usStatus?.phase;
+
+  if (krPhase === 'open') return MORPH_MODE.KR_LEAD;
+  if (usPhase === 'open') return MORPH_MODE.US_LEAD;
+  if (usPhase === 'pre' || usPhase === 'after' || usPhase === 'dayMarket') return MORPH_MODE.US_GAP;
+  if (krPhase === 'preAuction' || krPhase === 'preNxt') return MORPH_MODE.KR_GAP;
+  return MORPH_MODE.COIN_LEAD;
+}
+
+// ─── 전이구간 브릿지 ──────────────────────────────────────────
+
+// 지수 배열에서 id로 changePct 추출(없으면 null).
+function indexChangePct(indices, id) {
+  if (!Array.isArray(indices)) return null;
+  const found = indices.find((i) => i.id === id);
+  const v = Number(found?.changePct);
+  return Number.isFinite(v) ? v : null;
+}
+
+// cross-market 섹터 페어(역인덱싱) — relatedAssets.js NVDA↔삼성/하이닉스 패턴의 소형 테이블.
+//   미장 섹터 → 국장 동조 섹터/대표주 함의. 1차는 반도체 중심 최소 셋(2차에 확장).
+const CROSS_MARKET_SECTOR_PAIRS = {
+  반도체: { krSector: '반도체', krLeaders: ['삼성전자', 'SK하이닉스'] },
+  AI:     { krSector: '반도체', krLeaders: ['삼성전자', 'SK하이닉스'] },
+  전기차: { krSector: '배터리', krLeaders: ['LG에너지솔루션', '삼성SDI'] },
+  배터리: { krSector: '배터리', krLeaders: ['LG에너지솔루션', '삼성SDI'] },
+  바이오: { krSector: '바이오', krLeaders: ['삼성바이오로직스', '셀트리온'] },
+};
+
+/**
+ * buildTransitionBridge — 전이구간(국장 모드) 직전 미장 함의 한 줄.
+ * 단정 회피 가드(필수):
+ *   - |NASDAQ changePct| < 0.5% → "보합" 표기 또는 생략.
+ *   - "확정" 금지 → "주목"(상관≠인과).
+ *   - 페어 없으면 지수 한 줄만.
+ * KR 모드(KR_LEAD/KR_GAP)에서만 의미. 그 외 모드는 null.
+ * @param {object} p { mode, indices, primaryTheme }
+ * @returns {object|null} { line, nasdaqPct, tone, pair } | null
+ */
+export function buildTransitionBridge({ mode, indices, primaryTheme } = {}) {
+  if (mode !== MORPH_MODE.KR_LEAD && mode !== MORPH_MODE.KR_GAP) return null;
+
+  const nasdaqPct = indexChangePct(indices, 'NDX');
+  if (nasdaqPct == null) return null; // 지수 데이터 없음 → 브릿지 생략
+
+  const abs = Math.abs(nasdaqPct);
+  const sign = nasdaqPct > 0 ? '+' : nasdaqPct < 0 ? '' : '';
+  const pctText = `${sign}${nasdaqPct.toFixed(1)}%`;
+
+  // 보합/약변동(<0.5%) → 단정 회피. 지수 한 줄만(테마 함의 생략).
+  if (abs < 0.5) {
+    return {
+      line: `간밤 나스닥 보합(${pctText}) — 방향성 제한적`,
+      nasdaqPct,
+      tone: 'flat',
+      pair: null,
+    };
+  }
+
+  // 테마 페어 매칭 — 있으면 국장 동조 함의, 없으면 지수 한 줄만.
+  const themeName = primaryTheme?.theme || '';
+  const pair = themeName
+    ? (CROSS_MARKET_SECTOR_PAIRS[themeName]
+       || Object.entries(CROSS_MARKET_SECTOR_PAIRS)
+            .find(([k]) => themeName.includes(k) || k.includes(themeName))?.[1])
+    : null;
+
+  const dirWord = nasdaqPct > 0 ? '강세' : '약세';
+  if (pair) {
+    // "주목" 사용(상관≠인과). "확정" 금지.
+    const leadersText = pair.krLeaders.slice(0, 2).join('·');
+    return {
+      line: `간밤 나스닥 ${pctText} ${dirWord} — 오늘 ${pair.krSector}(${leadersText}) 주목`,
+      nasdaqPct,
+      tone: nasdaqPct > 0 ? 'up' : 'down',
+      pair,
+    };
+  }
+
+  // 페어 없음 → 지수 한 줄만(테마 단정 회피).
+  return {
+    line: `간밤 나스닥 ${pctText} ${dirWord} — 오늘 국장 영향 주목`,
+    nasdaqPct,
+    tone: nasdaqPct > 0 ? 'up' : 'down',
+    pair: null,
+  };
+}
+
+// ─── 진입점: computeMorphFocus ────────────────────────────────
+
+// 단일 종목 → solo card용 경량 표현(무섹터 graceful degrade).
+function toSoloMover(item) {
+  return {
+    symbol: item.symbol,
+    name: item.name,
+    market: item._market,
+    pct: item._leadPct,
+    dir: item._leadDir,
+    newsCount: item._leadNewsCount,
+    turnover: item._leadTurnover,
+    score: item._leadScore,
+    item,
+  };
+}
+
+/**
+ * computeMorphFocus — 모핑 포커스 진입점. 모드 분기 후 주도 테마/무버/브릿지 조합.
+ * @param {object} p {
+ *   krItems, usItems, coinItems,   // _market 태그된 배열
+ *   recentNews, krwRate, indices,
+ *   krStatus, usStatus,            // getKoreanMarketStatus()/getUsMarketStatus() 결과(.phase 사용)
+ *   krwRateLoaded = true,          // false면 fx 의존 컷(US turnover 하한)
+ *   baselineMap = null,            // 2차: {symbol: {avg20d}} → w_surge 활성
+ *   weights = SCORE_WEIGHTS.primary
+ * }
+ * @returns {object} {
+ *   mode,                                      // MORPH_MODE
+ *   primaryTheme: {theme,score,leaders,members,hot}|null,
+ *   altThemes: [...],                          // 동반 테마(primary 제외 상위)
+ *   movers: [soloMover],                       // 갭/무섹터 단일 종목 카드용
+ *   bridge: {line,nasdaqPct,tone,pair}|null,
+ *   _scored: {...}                             // 디버그/UI 보조(마켓별 스코어 결과)
+ * }
+ */
+export function computeMorphFocus(params = {}) {
+  const {
+    krItems = [],
+    usItems = [],
+    coinItems = [],
+    recentNews = [],
+    krwRate = 0,
+    indices = [],
+    krStatus = null,
+    usStatus = null,
+    krwRateLoaded = true,
+    baselineMap = null,
+    weights = SCORE_WEIGHTS.primary,
+  } = params;
+
+  const mode = decideMorphMode(krStatus, usStatus);
+
+  // 휴장 여부 — P_closed 부여용.
+  const krClosed = krStatus?.phase === 'closed';
+  const usClosed = usStatus?.phase === 'closed';
+
+  // 핫섹터(뉴스) — scoreNews와 clusterThemes에 공유.
+  const hotSectors = new Set();
+  for (const n of (recentNews || [])) {
+    for (const s of detectNewsSectors(n.title || '')) hotSectors.add(s);
+  }
+  const hotList = [...hotSectors];
+
+  // baseline → w_surge용 surgeScoreOf. 부재 시 null(점수 0).
+  const surgeScoreOf = baselineMap
+    ? (item) => {
+        const base = baselineMap[item.symbol]?.avg20d;
+        const turn = turnoverKRW(item, krwRate);
+        if (!base || base <= 0 || turn <= 0) return 0;
+        const ratio = turn / base;
+        if (ratio <= 1) return 0;
+        return Math.min(Math.log2(ratio) * 40, 100); // 2배→40, 4배→80
+      }
+    : null;
+
+  const baseCtxFor = (market, isClosed) => ({
+    krwRate: krwRateLoaded ? krwRate : 0,
+    recentNews,
+    hotSectors: hotList,
+    isClosed,
+    weights,
+    surgeScoreOf,
+    _market: market,
+  });
+
+  const scoredKr = scoreMarketItems(krItems, baseCtxFor('KR', krClosed));
+  const scoredUs = scoreMarketItems(usItems, baseCtxFor('US', usClosed));
+  const scoredCoin = scoreMarketItems(coinItems, baseCtxFor('COIN', false));
+
+  const result = {
+    mode,
+    primaryTheme: null,
+    altThemes: [],
+    movers: [],
+    bridge: null,
+    _scored: { kr: scoredKr, us: scoredUs, coin: scoredCoin },
+  };
+
+  // ── 모드별 분기 ──
+  if (mode === MORPH_MODE.KR_LEAD || mode === MORPH_MODE.US_LEAD) {
+    // LEAD: 주도 테마 + 대장주 + 동반 테마.
+    const scored = mode === MORPH_MODE.KR_LEAD ? scoredKr : scoredUs;
+    const { themes, soloMovers } = clusterThemes(scored, recentNews);
+    result.primaryTheme = themes[0] || null;
+    result.altThemes = themes.slice(1, 4);
+    // 무섹터 고득점 종목 → 단일카드 폴백(상위 5).
+    result.movers = soloMovers.slice(0, 5).map(toSoloMover);
+  } else if (mode === MORPH_MODE.US_GAP || mode === MORPH_MODE.KR_GAP) {
+    // GAP: 시간외 실시간 체결가 없음 → 변동폭(전일종가 갭) 우선, 테마 약화.
+    //   move 우선 정렬로 재배치(거래대금보다 갭 폭 + 뉴스).
+    const scored = mode === MORPH_MODE.US_GAP ? scoredUs : scoredKr;
+    const gapSorted = [...scored].sort((a, b) => {
+      const am = Math.abs(a._leadPct || 0);
+      const bm = Math.abs(b._leadPct || 0);
+      if (bm !== am) return bm - am;
+      return (b._leadNewsCount || 0) - (a._leadNewsCount || 0);
+    });
+    result.movers = gapSorted.slice(0, 6).map(toSoloMover);
+    // 갭 모드에서도 테마가 뚜렷하면 보조 표시(약화).
+    const { themes } = clusterThemes(scored, recentNews);
+    result.primaryTheme = themes[0] || null;
+    result.altThemes = themes.slice(1, 3);
+  } else {
+    // COIN_LEAD: 거래대금(accTradePrice24h) + move. 코인 테마(암호화폐 단일).
+    const { themes, soloMovers } = clusterThemes(scoredCoin, recentNews);
+    result.primaryTheme = themes[0] || null;
+    result.altThemes = themes.slice(1, 3);
+    // 코인은 대부분 무섹터 → 거래대금 상위가 곧 주도 코인.
+    result.movers = (soloMovers.length ? soloMovers : scoredCoin).slice(0, 6).map(toSoloMover);
+  }
+
+  // ── 전이 브릿지(국장 모드만) ──
+  result.bridge = buildTransitionBridge({
+    mode,
+    indices,
+    primaryTheme: result.primaryTheme,
+  });
+
+  return result;
+}

--- a/src/utils/leadingStocks.js
+++ b/src/utils/leadingStocks.js
@@ -41,6 +41,42 @@ const PENALTY_CLOSED = 40;  // 휴장 마켓 종목
 const HOT_SECTOR_BOOST = 1.3;
 const BREADTH_DENOM = 5;    // breadth = min(종목수/5, 1)
 
+// 섹터 어휘 정규화 — item.sector(krStockList/usStockList 표준)와
+// detectNewsSectors(newsTopicMap) 어휘가 달라 substring 매칭이 양방향 실패하는 문제 해소.
+//   예) item.sector '2차전지' ↔ 뉴스 '배터리'/'전기차' → 둘 다 includes 실패 → 핫섹터·브릿지 무력화.
+// 같은 캐노니컬 그룹으로 묶어 isHot 비교와 CROSS_MARKET 키 조회 양쪽에 적용한다.
+const SECTOR_ALIASES = {
+  // KR item.sector 어휘
+  '2차전지': 'battery',
+  '자동차': 'auto',
+  // US item.sector 어휘
+  '전기차': 'battery',
+  '소프트웨어': 'software',
+  'AI/소프트웨어': 'software',
+  'IT소프트웨어': 'software',
+  '핀테크': 'fintech',
+  '미디어': 'media',
+  '리츠': 'reit',
+  '산업': 'industrial',
+  // detectNewsSectors(newsTopicMap) 어휘
+  '배터리': 'battery',
+  '자동차부품': 'auto',
+  'AI': 'software',
+};
+
+// 섹터명 → 캐노니컬 키(별칭 없으면 원문 유지). isHot/CROSS_MARKET 비교 정규화용.
+function canonicalSector(sector) {
+  if (!sector) return '';
+  return SECTOR_ALIASES[sector] || sector;
+}
+
+// 두 섹터가 같은 테마인지 — 캐노니컬 일치 또는 (원문) 양방향 substring.
+function sectorMatches(a, b) {
+  if (!a || !b) return false;
+  if (canonicalSector(a) === canonicalSector(b)) return true;
+  return a.includes(b) || b.includes(a);
+}
+
 // 모핑 모드 식별자
 export const MORPH_MODE = {
   KR_LEAD:   'KR_LEAD',
@@ -73,6 +109,7 @@ export function turnoverKRW(item, krwRate = 0) {
 
 // 회전율 = 거래대금 / 시가총액. 코인(marketCap=0)은 null 반환 → 절대 percentile로 대체.
 export function turnoverRatio(item, krwRate = 0) {
+  if (!item) return null; // turnoverKRW와 방어 일관성(null 유입 시 isCoinItem의 .id 접근 방지)
   if (isCoinItem(item)) return null;
   const cap = Number(item?.marketCap);
   if (!Number.isFinite(cap) || cap <= 0) return null;
@@ -100,15 +137,26 @@ function passesNoiseGate(item, ctx) {
   const name = item.name || '';
   if (DERIVATIVE_RE.test(name)) return false;
 
-  const turn = turnoverKRW(item, ctx.krwRate);
   const market = item._market;
-  let minTurn;
-  if (market === 'US') minTurn = MIN_TURNOVER.US_USD * (Number(ctx.krwRate) || 0);
-  else if (isCoinItem(item) || market === 'COIN') minTurn = MIN_TURNOVER.COIN;
-  else minTurn = MIN_TURNOVER.KR;
-  // US 하한은 krwRate 필요 — 환율 미로드 시(0) 하한 비교 불가 → KR 기준으로 폴백(과소 컷 방지).
-  if (market === 'US' && minTurn <= 0) minTurn = MIN_TURNOVER.KR;
-  if (turn < minTurn) return false;
+  const rate = Number(ctx.krwRate) || 0;
+
+  // US 하한은 krwRate로 KRW 환산 비교가 기본. 단 환율 미로드(rate<=0)면
+  // turnoverKRW가 0을 반환해 KRW 비교가 무력화되므로(죽은 폴백), USD raw(price×volume)를
+  // MIN_TURNOVER.US_USD와 직접 비교해 종목을 실제 보존한다.
+  if (market === 'US' && rate <= 0) {
+    const price = Number(item.price);
+    const volume = Number(item.volume);
+    const rawUsd = (Number.isFinite(price) && Number.isFinite(volume) && price > 0 && volume > 0)
+      ? price * volume : 0;
+    if (rawUsd < MIN_TURNOVER.US_USD) return false;
+  } else {
+    const turn = turnoverKRW(item, ctx.krwRate);
+    let minTurn;
+    if (market === 'US') minTurn = MIN_TURNOVER.US_USD * rate;
+    else if (isCoinItem(item) || market === 'COIN') minTurn = MIN_TURNOVER.COIN;
+    else minTurn = MIN_TURNOVER.KR;
+    if (turn < minTurn) return false;
+  }
 
   // 무변동 + 회전율 하위 → 거래대금만 큰 비주류 → 제외
   const pct = getPct(item);
@@ -137,7 +185,7 @@ function scoreNews(item, recentNews, hotSectors) {
   const base = (Math.min(newsCount, 3) / 3) * 70;
   const sector = item.sector || '';
   const inHot = sector && Array.isArray(hotSectors)
-    && hotSectors.some((s) => sector.includes(s) || s.includes(sector));
+    && hotSectors.some((s) => sectorMatches(sector, s));
   return { score: base + (inHot ? 30 : 0), newsCount };
 }
 
@@ -179,6 +227,8 @@ export function scoreLeading(item, ctx = {}) {
   const S_surge = ctx.surgeScoreOf ? ctx.surgeScoreOf(item) : 0;
 
   let penalty = 0;
+  // 통합경로(scoreMarketItems)에선 passesNoiseGate가 파생상품을 선컷하므로 이 분기는 dead path.
+  // scoreLeading 직접 호출(단위 테스트 등) 시 방어용으로 유지.
   if (DERIVATIVE_RE.test(item.name || '')) penalty += PENALTY_DERIV;
   if (ctx.isClosed) penalty += PENALTY_CLOSED;
 
@@ -262,7 +312,7 @@ export function clusterThemes(scoredItems, recentNews = []) {
   }
   const hotList = [...hotSectors];
   const isHot = (sector) =>
-    !!sector && hotList.some((h) => sector.includes(h) || h.includes(sector));
+    !!sector && hotList.some((h) => sectorMatches(sector, h));
 
   // sector별 그룹화. 무섹터는 solo로.
   const groups = new Map();
@@ -281,7 +331,9 @@ export function clusterThemes(scoredItems, recentNews = []) {
     const breadth = Math.min(members.length / BREADTH_DENOM, 1);
     const hot = isHot(sector);
     const newsBoost = hot ? HOT_SECTOR_BOOST : 1;
-    const score = sum * breadth * newsBoost;
+    // 음수 sum(휴장 penalty 등)에 newsBoost(1.3)를 곱하면 핫섹터가 오히려 더 낮아지는 역효과 →
+    // 부스트는 양수 점수에만 적용(Math.max).
+    const score = Math.max(sum, 0) * breadth * newsBoost;
     themes.push({
       theme: sector,
       score,
@@ -312,7 +364,9 @@ export function decideMorphMode(krStatus, usStatus) {
   if (krPhase === 'open') return MORPH_MODE.KR_LEAD;
   if (usPhase === 'open') return MORPH_MODE.US_LEAD;
   if (usPhase === 'pre' || usPhase === 'after' || usPhase === 'dayMarket') return MORPH_MODE.US_GAP;
-  if (krPhase === 'preAuction' || krPhase === 'preNxt') return MORPH_MODE.KR_GAP;
+  // afterNxt(정규장 마감 후 NXT 시간외, marketHours.js:255)도 국장 연장거래 → KR_GAP.
+  // 미장 after를 US_GAP으로 잡는 것과 대칭(afterNxt 누락 시 COIN_LEAD로 오폴백).
+  if (krPhase === 'preAuction' || krPhase === 'preNxt' || krPhase === 'afterNxt') return MORPH_MODE.KR_GAP;
   return MORPH_MODE.COIN_LEAD;
 }
 
@@ -328,12 +382,14 @@ function indexChangePct(indices, id) {
 
 // cross-market 섹터 페어(역인덱싱) — relatedAssets.js NVDA↔삼성/하이닉스 패턴의 소형 테이블.
 //   미장 섹터 → 국장 동조 섹터/대표주 함의. 1차는 반도체 중심 최소 셋(2차에 확장).
+// krSector는 krStockList.js 표준 어휘(예 '2차전지') — UI 라벨/findStocksBySectors 정합.
 const CROSS_MARKET_SECTOR_PAIRS = {
-  반도체: { krSector: '반도체', krLeaders: ['삼성전자', 'SK하이닉스'] },
-  AI:     { krSector: '반도체', krLeaders: ['삼성전자', 'SK하이닉스'] },
-  전기차: { krSector: '배터리', krLeaders: ['LG에너지솔루션', '삼성SDI'] },
-  배터리: { krSector: '배터리', krLeaders: ['LG에너지솔루션', '삼성SDI'] },
-  바이오: { krSector: '바이오', krLeaders: ['삼성바이오로직스', '셀트리온'] },
+  반도체:   { krSector: '반도체', krLeaders: ['삼성전자', 'SK하이닉스'] },
+  AI:       { krSector: '반도체', krLeaders: ['삼성전자', 'SK하이닉스'] },
+  전기차:   { krSector: '2차전지', krLeaders: ['LG에너지솔루션', '삼성SDI'] },
+  배터리:   { krSector: '2차전지', krLeaders: ['LG에너지솔루션', '삼성SDI'] },
+  '2차전지': { krSector: '2차전지', krLeaders: ['LG에너지솔루션', '삼성SDI'] },
+  바이오:   { krSector: '바이오', krLeaders: ['삼성바이오로직스', '셀트리온'] },
 };
 
 /**
@@ -367,11 +423,12 @@ export function buildTransitionBridge({ mode, indices, primaryTheme } = {}) {
   }
 
   // 테마 페어 매칭 — 있으면 국장 동조 함의, 없으면 지수 한 줄만.
+  // 페어 키 조회 — 직접 매칭 우선, 없으면 섹터 별칭 정규화 경유(예 '2차전지' ↔ '배터리'/'전기차').
   const themeName = primaryTheme?.theme || '';
   const pair = themeName
     ? (CROSS_MARKET_SECTOR_PAIRS[themeName]
        || Object.entries(CROSS_MARKET_SECTOR_PAIRS)
-            .find(([k]) => themeName.includes(k) || k.includes(themeName))?.[1])
+            .find(([k]) => sectorMatches(themeName, k))?.[1])
     : null;
 
   const dirWord = nasdaqPct > 0 ? '강세' : '약세';
@@ -501,7 +558,8 @@ export function computeMorphFocus(params = {}) {
     const { themes, soloMovers } = clusterThemes(scored, recentNews);
     result.primaryTheme = themes[0] || null;
     result.altThemes = themes.slice(1, 4);
-    // 무섹터 고득점 종목 → 단일카드 폴백(상위 5).
+    // 무섹터 고득점 종목 → 단일카드 폴백(상위 5). 단 primaryTheme이 있으면 UI는 테마 카드만
+    // 렌더하고 soloMovers는 미표시(테마 중심 의도) — 무섹터 종목 폴백은 primaryTheme 부재 시에만 노출.
     result.movers = soloMovers.slice(0, 5).map(toSoloMover);
   } else if (mode === MORPH_MODE.US_GAP || mode === MORPH_MODE.KR_GAP) {
     // GAP: 시간외 실시간 체결가 없음 → 변동폭(전일종가 갭) 우선, 테마 약화.

--- a/src/utils/leadingStocks.js
+++ b/src/utils/leadingStocks.js
@@ -45,15 +45,21 @@ const BREADTH_DENOM = 5;    // breadth = min(종목수/5, 1)
 // detectNewsSectors(newsTopicMap) 어휘가 달라 substring 매칭이 양방향 실패하는 문제 해소.
 //   예) item.sector '2차전지' ↔ 뉴스 '배터리'/'전기차' → 둘 다 includes 실패 → 핫섹터·브릿지 무력화.
 // 같은 캐노니컬 그룹으로 묶어 isHot 비교와 CROSS_MARKET 키 조회 양쪽에 적용한다.
+//
+// [W1 수정] newsTopicMap.ai_tech.sectors는 ['AI','IT소프트웨어','반도체']로 '소프트웨어'(범용)를
+// 의도적으로 분리한다. 별칭이 AI/IT소프트웨어/소프트웨어를 모두 software로 통합하면 AI 뉴스 1건이
+// 모든 범용 '소프트웨어' 섹터 종목을 isHot으로 만들어 ×1.3 부스트되는 과대평가 문제 발생.
+// → 'AI'·'IT소프트웨어'·'AI/소프트웨어'는 software_ai(AI 뉴스 직접 영향), '소프트웨어'(범용)는
+// software_generic(별도)로 분리해 newsTopicMap 어휘와 정합.
 const SECTOR_ALIASES = {
   // KR item.sector 어휘
   '2차전지': 'battery',
   '자동차': 'auto',
   // US item.sector 어휘
   '전기차': 'battery',
-  '소프트웨어': 'software',
-  'AI/소프트웨어': 'software',
-  'IT소프트웨어': 'software',
+  '소프트웨어': 'software_generic',     // 범용 SW — AI 뉴스에 자동 휩쓸리지 않음
+  'AI/소프트웨어': 'software_ai',
+  'IT소프트웨어': 'software_ai',
   '핀테크': 'fintech',
   '미디어': 'media',
   '리츠': 'reit',
@@ -61,7 +67,7 @@ const SECTOR_ALIASES = {
   // detectNewsSectors(newsTopicMap) 어휘
   '배터리': 'battery',
   '자동차부품': 'auto',
-  'AI': 'software',
+  'AI': 'software_ai',
 };
 
 // 섹터명 → 캐노니컬 키(별칭 없으면 원문 유지). isHot/CROSS_MARKET 비교 정규화용.
@@ -71,9 +77,14 @@ function canonicalSector(sector) {
 }
 
 // 두 섹터가 같은 테마인지 — 캐노니컬 일치 또는 (원문) 양방향 substring.
+// [W1 보강] 둘 중 하나라도 SECTOR_ALIASES에 명시된 어휘라면 substring 폴백을 끄고
+// 캐노니컬 일치만 인정 — 별칭 정의로 분리한 의도(예 '소프트웨어' vs 'IT소프트웨어')를
+// substring("IT소프트웨어".includes("소프트웨어")=true)가 우회하는 버그 방지.
 function sectorMatches(a, b) {
   if (!a || !b) return false;
   if (canonicalSector(a) === canonicalSector(b)) return true;
+  // 한쪽이라도 별칭 사전에 정의되어 있으면 substring 매칭 비활성(분리 의도 보존).
+  if (SECTOR_ALIASES[a] !== undefined || SECTOR_ALIASES[b] !== undefined) return false;
   return a.includes(b) || b.includes(a);
 }
 
@@ -116,26 +127,47 @@ export function turnoverRatio(item, krwRate = 0) {
   return turnoverKRW(item, krwRate) / cap;
 }
 
-// percentile rank(0~100) — value가 values 중 몇 %ile인지. values 비거나 단일값이면 50 중립.
-function percentileRank(value, values) {
-  if (!Array.isArray(values) || values.length === 0) return 50;
-  if (values.length === 1) return 50;
-  let below = 0;
-  let equal = 0;
-  for (const v of values) {
-    if (v < value) below += 1;
-    else if (v === value) equal += 1;
+// [W3/STYLE perf 수정] percentileRankSorted — 정렬된 모수 + 이진탐색으로 O(log n).
+// 대량 모수(usItems 최대 ~2700, scoreMarketItems가 종목당 2회 percentile 계산) 시
+// 기존 O(n²) → O(n log n). 동점 분산 보정(below + 0.5·equal) / n 동일.
+// sortedValues는 오름차순 정렬되어 있어야 함.
+function lowerBound(arr, target) {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid] < target) lo = mid + 1;
+    else hi = mid;
   }
-  // 중앙값 보정(동점 분산) — (below + 0.5·equal) / n
-  return ((below + 0.5 * equal) / values.length) * 100;
+  return lo;
+}
+function upperBound(arr, target) {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid] <= target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+function percentileRankSorted(value, sortedValues) {
+  if (!Array.isArray(sortedValues) || sortedValues.length === 0) return 50;
+  if (sortedValues.length === 1) return 50;
+  const below = lowerBound(sortedValues, value);          // value 미만 개수
+  const equal = upperBound(sortedValues, value) - below;  // value와 같은 개수
+  return ((below + 0.5 * equal) / sortedValues.length) * 100;
 }
 
 // 잡주 컷 — 스코어링 전 필터. 통과 시 true.
-// 제외: 거래대금 하한 미달 / 파생상품 / (무변동 & 회전율 percentile<50)
+// 제외: 거래대금 하한 미달 / 파생상품 / 지수 ETF / (무변동 & 회전율 percentile<50)
 function passesNoiseGate(item, ctx) {
   if (!item) return false;
   const name = item.name || '';
   if (DERIVATIVE_RE.test(name)) return false;
+  // [HIGH3 수정] 지수 ETF(SPY/QQQ/KODEX200 등) 배제. 주도주/테마는 개별주여야 함.
+  // index.jsx에서 _isEtf=true로 표시된 항목은 LEAD/GAP/COIN 분기 어디에도 진입 금지.
+  if (item._isEtf) return false;
 
   const market = item._market;
   const rate = Number(ctx.krwRate) || 0;
@@ -159,10 +191,14 @@ function passesNoiseGate(item, ctx) {
   }
 
   // 무변동 + 회전율 하위 → 거래대금만 큰 비주류 → 제외
+  // [W2/STYLE4 수정] 코인은 turnoverRatio가 항상 null → ratioPercentileOf=0 → pct===0(데이터 지연 포함)
+  // 코인이 거래대금 무관하게 컷되는 문제. 코인은 turnoverPercentileOf 기준으로 판정.
   const pct = getPct(item);
   if (pct === 0) {
-    const ratioPct = ctx.ratioPercentileOf ? ctx.ratioPercentileOf(item) : 50;
-    if (ratioPct < 50) return false;
+    const isCoin = isCoinItem(item) || market === 'COIN';
+    const pctileFn = isCoin ? ctx.turnoverPercentileOf : ctx.ratioPercentileOf;
+    const pctile = pctileFn ? pctileFn(item) : 50;
+    if (pctile < 50) return false;
   }
   return true;
 }
@@ -255,6 +291,7 @@ export function scoreMarketItems(items, baseCtx = {}) {
   if (!Array.isArray(items) || items.length === 0) return [];
 
   // 회전율/거래대금 모수 — percentile 계산용(잡주 컷 전 전체 모수로 계산해야 안정적).
+  // [W3/perf 수정] 1회 정렬 후 이진탐색으로 종목당 O(log n) — 대량 모수(usItems ~2700) 대응.
   const ratios = [];
   const turnovers = [];
   for (const it of items) {
@@ -263,15 +300,17 @@ export function scoreMarketItems(items, baseCtx = {}) {
     const t = turnoverKRW(it, baseCtx.krwRate);
     if (Number.isFinite(t) && t > 0) turnovers.push(t);
   }
+  ratios.sort((a, b) => a - b);
+  turnovers.sort((a, b) => a - b);
   const ratioPercentileOf = (it) => {
     const r = turnoverRatio(it, baseCtx.krwRate);
     if (r == null || !Number.isFinite(r)) return 0;
-    return percentileRank(r, ratios);
+    return percentileRankSorted(r, ratios);
   };
   const turnoverPercentileOf = (it) => {
     const t = turnoverKRW(it, baseCtx.krwRate);
     if (!Number.isFinite(t) || t <= 0) return 0;
-    return percentileRank(t, turnovers);
+    return percentileRankSorted(t, turnovers);
   };
 
   const ctx = { ...baseCtx, ratioPercentileOf, turnoverPercentileOf };
@@ -299,18 +338,30 @@ export function scoreMarketItems(items, baseCtx = {}) {
 /**
  * clusterThemes — 정적 item.sector로 묶고, 뉴스 핫섹터로 부스트.
  * 무섹터 고득점 종목은 별도 "단일 종목" 그룹으로 graceful degrade.
+ *
+ * [의도 — W5/STYLE6 명시] 핫섹터는 종목 점수(scoreNews에서 +30, 가중 0.20=실효 +6)와
+ * 테마 점수(여기서 ×1.3) 양쪽에 의도적으로 이중 반영한다.
+ * 종목 단위에선 "뉴스 관련주" 신호, 테마 단위에선 "전체 테마 무게"를 분리해 강화하기 위함.
+ *
  * @param {object[]} scoredItems  scoreMarketItems 결과(_leadScore 보유)
  * @param {object[]} recentNews
+ * @param {string[]} [precomputedHotList] computeMorphFocus에서 미리 계산한 핫섹터 — 중복계산 회피용 옵셔널.
  * @returns {object} { themes:[{theme, score, breadth, hot, leaders, members}], soloMovers:[item], hotSectors:[string] }
  */
-export function clusterThemes(scoredItems, recentNews = []) {
-  const hotSectors = new Set();
-  if (Array.isArray(recentNews)) {
-    for (const n of recentNews) {
-      for (const s of detectNewsSectors(n.title || '')) hotSectors.add(s);
+export function clusterThemes(scoredItems, recentNews = [], precomputedHotList = null) {
+  // [W5 수정] precomputedHotList가 주어지면 detectNewsSectors 중복 계산 회피.
+  let hotList;
+  if (Array.isArray(precomputedHotList)) {
+    hotList = precomputedHotList;
+  } else {
+    const hotSectors = new Set();
+    if (Array.isArray(recentNews)) {
+      for (const n of recentNews) {
+        for (const s of detectNewsSectors(n.title || '')) hotSectors.add(s);
+      }
     }
+    hotList = [...hotSectors];
   }
-  const hotList = [...hotSectors];
   const isHot = (sector) =>
     !!sector && hotList.some((h) => sectorMatches(sector, h));
 
@@ -353,9 +404,16 @@ export function clusterThemes(scoredItems, recentNews = []) {
 /**
  * decideMorphMode — marketHours phase 기반 5모드.
  *   KR open → KR_LEAD / US open → US_LEAD
- *   US pre·after·dayMarket → US_GAP / KR preAuction·preNxt → KR_GAP
- *   둘 다 closed → COIN_LEAD
- * 우선순위: 정규장(LEAD) > 갭(GAP) > 코인. KR LEAD를 US LEAD보다 우선(국내 사용자 기준).
+ *   KR preAuction·preNxt·afterNxt → KR_GAP (한국 활동시간 우선)
+ *   US pre·after·dayMarket → US_GAP (한국 야간)
+ *   그 외(둘 다 closed) → COIN_LEAD
+ *
+ * [B1/HIGH2 수정] 우선순위: LEAD > KR_GAP > US_GAP > COIN.
+ *   marketHours.js상 평일 ET는 pre→open→after→dayMarket로 24h 빈틈없이 커버 →
+ *   평일에는 usPhase가 'closed'가 될 수 없음. KR_GAP을 US_GAP 뒤에 두면
+ *   평일 afterNxt/preNxt/preAuction이 도달불가(미국 휴장일에만 진입).
+ *   "한국 활동시간엔 국장(LEAD/GAP), 한국 야간엔 미장" 의도를 관철하기 위해
+ *   KR_GAP을 US_GAP보다 먼저 평가한다 (LEAD가 KR 우선인 것과 일관).
  */
 export function decideMorphMode(krStatus, usStatus) {
   const krPhase = krStatus?.phase;
@@ -363,10 +421,10 @@ export function decideMorphMode(krStatus, usStatus) {
 
   if (krPhase === 'open') return MORPH_MODE.KR_LEAD;
   if (usPhase === 'open') return MORPH_MODE.US_LEAD;
-  if (usPhase === 'pre' || usPhase === 'after' || usPhase === 'dayMarket') return MORPH_MODE.US_GAP;
-  // afterNxt(정규장 마감 후 NXT 시간외, marketHours.js:255)도 국장 연장거래 → KR_GAP.
-  // 미장 after를 US_GAP으로 잡는 것과 대칭(afterNxt 누락 시 COIN_LEAD로 오폴백).
+  // KR 활동시간(시간외/프리/동시호가) — 한국 사용자 기준 KR_GAP 우선
   if (krPhase === 'preAuction' || krPhase === 'preNxt' || krPhase === 'afterNxt') return MORPH_MODE.KR_GAP;
+  // 한국 야간(KR closed) — US 시간외/프리/데이마켓
+  if (usPhase === 'pre' || usPhase === 'after' || usPhase === 'dayMarket') return MORPH_MODE.US_GAP;
   return MORPH_MODE.COIN_LEAD;
 }
 
@@ -413,9 +471,10 @@ export function buildTransitionBridge({ mode, indices, primaryTheme } = {}) {
   const pctText = `${sign}${nasdaqPct.toFixed(1)}%`;
 
   // 보합/약변동(<0.5%) → 단정 회피. 지수 한 줄만(테마 함의 생략).
+  // [W6 수정] 'NDX'는 NASDAQ-100(^NDX). Composite(^IXIC)와 등락이 갈리는 날 멘트 어긋남 방지 → '나스닥100'.
   if (abs < 0.5) {
     return {
-      line: `간밤 나스닥 보합(${pctText}) — 방향성 제한적`,
+      line: `간밤 나스닥100 보합(${pctText}) — 방향성 제한적`,
       nasdaqPct,
       tone: 'flat',
       pair: null,
@@ -436,7 +495,7 @@ export function buildTransitionBridge({ mode, indices, primaryTheme } = {}) {
     // "주목" 사용(상관≠인과). "확정" 금지.
     const leadersText = pair.krLeaders.slice(0, 2).join('·');
     return {
-      line: `간밤 나스닥 ${pctText} ${dirWord} — 오늘 ${pair.krSector}(${leadersText}) 주목`,
+      line: `간밤 나스닥100 ${pctText} ${dirWord} — 오늘 ${pair.krSector}(${leadersText}) 주목`,
       nasdaqPct,
       tone: nasdaqPct > 0 ? 'up' : 'down',
       pair,
@@ -445,7 +504,7 @@ export function buildTransitionBridge({ mode, indices, primaryTheme } = {}) {
 
   // 페어 없음 → 지수 한 줄만(테마 단정 회피).
   return {
-    line: `간밤 나스닥 ${pctText} ${dirWord} — 오늘 국장 영향 주목`,
+    line: `간밤 나스닥100 ${pctText} ${dirWord} — 오늘 국장 영향 주목`,
     nasdaqPct,
     tone: nasdaqPct > 0 ? 'up' : 'down',
     pair: null,
@@ -500,8 +559,13 @@ export function computeMorphFocus(params = {}) {
     usStatus = null,
     krwRateLoaded = true,
     baselineMap = null,
-    weights = SCORE_WEIGHTS.primary,
+    weights: weightsOverride = null,
   } = params;
+
+  // [W4 수정] baselineMap이 주어지면 surge 가중을 활성화한 SECONDARY로 자동 전환.
+  // 명시 override가 있으면 그것 우선. 기존엔 primary 고정이라 surgeScoreOf 결과가 0으로 사장됐음.
+  const weights = weightsOverride
+    || (baselineMap ? SCORE_WEIGHTS.secondary : SCORE_WEIGHTS.primary);
 
   const mode = decideMorphMode(krStatus, usStatus);
 
@@ -509,18 +573,22 @@ export function computeMorphFocus(params = {}) {
   const krClosed = krStatus?.phase === 'closed';
   const usClosed = usStatus?.phase === 'closed';
 
-  // 핫섹터(뉴스) — scoreNews와 clusterThemes에 공유.
+  // 핫섹터(뉴스) — scoreNews와 clusterThemes에 공유(중복 계산 방지: precomputedHotList).
   const hotSectors = new Set();
   for (const n of (recentNews || [])) {
     for (const s of detectNewsSectors(n.title || '')) hotSectors.add(s);
   }
   const hotList = [...hotSectors];
 
+  // [STYLE5 수정] krwRateLoaded=false면 환율 0으로 캡처(baseCtxFor와 일관).
+  // 환율 미로드 구간에서 US turnover 분모를 부정확하게 산정하는 문제 방지.
+  const effectiveKrwRate = krwRateLoaded ? krwRate : 0;
+
   // baseline → w_surge용 surgeScoreOf. 부재 시 null(점수 0).
   const surgeScoreOf = baselineMap
     ? (item) => {
         const base = baselineMap[item.symbol]?.avg20d;
-        const turn = turnoverKRW(item, krwRate);
+        const turn = turnoverKRW(item, effectiveKrwRate);
         if (!base || base <= 0 || turn <= 0) return 0;
         const ratio = turn / base;
         if (ratio <= 1) return 0;
@@ -529,7 +597,7 @@ export function computeMorphFocus(params = {}) {
     : null;
 
   const baseCtxFor = (market, isClosed) => ({
-    krwRate: krwRateLoaded ? krwRate : 0,
+    krwRate: effectiveKrwRate,
     recentNews,
     hotSectors: hotList,
     isClosed,
@@ -555,7 +623,7 @@ export function computeMorphFocus(params = {}) {
   if (mode === MORPH_MODE.KR_LEAD || mode === MORPH_MODE.US_LEAD) {
     // LEAD: 주도 테마 + 대장주 + 동반 테마.
     const scored = mode === MORPH_MODE.KR_LEAD ? scoredKr : scoredUs;
-    const { themes, soloMovers } = clusterThemes(scored, recentNews);
+    const { themes, soloMovers } = clusterThemes(scored, recentNews, hotList);
     result.primaryTheme = themes[0] || null;
     result.altThemes = themes.slice(1, 4);
     // 무섹터 고득점 종목 → 단일카드 폴백(상위 5). 단 primaryTheme이 있으면 UI는 테마 카드만
@@ -573,16 +641,15 @@ export function computeMorphFocus(params = {}) {
     });
     result.movers = gapSorted.slice(0, 6).map(toSoloMover);
     // 갭 모드에서도 테마가 뚜렷하면 보조 표시(약화).
-    const { themes } = clusterThemes(scored, recentNews);
+    const { themes } = clusterThemes(scored, recentNews, hotList);
     result.primaryTheme = themes[0] || null;
     result.altThemes = themes.slice(1, 3);
   } else {
-    // COIN_LEAD: 거래대금(accTradePrice24h) + move. 코인 테마(암호화폐 단일).
-    const { themes, soloMovers } = clusterThemes(scoredCoin, recentNews);
-    result.primaryTheme = themes[0] || null;
-    result.altThemes = themes.slice(1, 3);
-    // 코인은 대부분 무섹터 → 거래대금 상위가 곧 주도 코인.
-    result.movers = (soloMovers.length ? soloMovers : scoredCoin).slice(0, 6).map(toSoloMover);
+    // COIN_LEAD: 거래대금(accTradePrice24h) + move.
+    // [STYLE6] 코인은 대부분 무섹터(sector 없음) → clusterThemes 결과의 themes/leaders가
+    // 사실상 비어 있고, UI(MorphingFocusSection.jsx isCoin 분기)는 movers만 소비함.
+    // 의도적으로 clusterThemes를 생략하고 거래대금 상위 코인을 그대로 movers로 사용.
+    result.movers = scoredCoin.slice(0, 6).map(toSoloMover);
   }
 
   // ── 전이 브릿지(국장 모드만) ──

--- a/src/utils/leadingStocks.js
+++ b/src/utils/leadingStocks.js
@@ -214,7 +214,7 @@ function scoreNews(item, recentNews, hotSectors) {
     const kws = buildStockKeywords(item.symbol, item.name, market);
     for (const n of recentNews) {
       if (newsCount >= 3) break;
-      const text = `${n.title || ''} ${n.summary || ''}`;
+      const text = `${n?.title || ''} ${n?.summary || ''}`;
       if (matchesKeywords(text, kws)) newsCount += 1;
     }
   }
@@ -357,7 +357,7 @@ export function clusterThemes(scoredItems, recentNews = [], precomputedHotList =
     const hotSectors = new Set();
     if (Array.isArray(recentNews)) {
       for (const n of recentNews) {
-        for (const s of detectNewsSectors(n.title || '')) hotSectors.add(s);
+        for (const s of detectNewsSectors(n?.title || '')) hotSectors.add(s);
       }
     }
     hotList = [...hotSectors];


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-3.1-pro-preview)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #335

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 주도주 대시보드를 개선하여 시장 상태(한국 오픈/마감, 미국 갭/오픈, 코인)에 따라 동적으로 다양한 UI를 표시합니다.
  * 거래대금 기반 스코어링과 섹터 클러스터링을 통해 주도주 및 주도 코인 선정 알고리즘을 개선했습니다.

* **Tests**
  * 주도주 선정 알고리즘 및 UI 컴포넌트에 대한 포괄적인 테스트를 추가했습니다.

* **Documentation**
  * 홈 대시보드 구조 문서를 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->