### PR TITLE
fix(#341): 공포탐욕·시장지표 시그널 가짜 종목 카드 차단 — 신뢰 위반

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,6 @@ import SurgeBanner from './components/SurgeBanner';
 import MarketSummaryBar from './components/MarketSummaryBar';
 import WatchlistTable from './components/WatchlistTable';
 import BreakingNewsPanel from './components/BreakingNewsPanel';
-import UnifiedFeedPanel from './components/UnifiedFeedPanel';
 import ChartSidePanel from './components/ChartSidePanel';
 import NewsSidePanel from './components/NewsSidePanel';
 import HomeDashboard from './components/home';
@@ -373,7 +372,7 @@ export default function App() {
         dark={dark} onDarkToggle={toggleDark}
       />
 
-      <div className="max-w-[1440px] mx-auto grid grid-cols-1 lg:grid-cols-[1fr_360px]">
+      <div className="max-w-[1440px] mx-auto">
         <div className={`min-w-0 overflow-hidden ${activeTab === 'news' ? '' : 'p-5 space-y-4'} lg:pb-0 pb-safe-nav`}>
           {activeTab === 'home' ? (
             <>
@@ -405,9 +404,6 @@ export default function App() {
           )}
         </div>
 
-        <div className="hidden lg:block self-start" style={{ position: 'sticky', top: '84px', height: 'calc(100vh - 84px)' }}>
-          <UnifiedFeedPanel onItemClick={handleItemClick} onNewsClick={setSelectedNews} />
-        </div>
       </div>
 
       {selectedItem && (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -388,7 +388,7 @@ export default function App() {
           ) : activeTab === 'sector' ? (
             <SectorRotation krStocks={krStocks} usStocks={usStocks} coins={coins} />
           ) : activeTab === 'news' ? (
-            <div className="lg:hidden h-[calc(100vh-112px)]">
+            <div className="h-[calc(100vh-112px)]">
               <BreakingNewsPanel onItemClick={handleItemClick} onNewsClick={setSelectedNews} />
             </div>
           ) : (

--- a/src/__tests__/marketIndicatorSignal.test.js
+++ b/src/__tests__/marketIndicatorSignal.test.js
@@ -1,0 +1,80 @@
+// #341 — 시장 지표 시그널(공포탐욕 등) 가짜 종목 카드 차단 회귀 테스트
+// 시그널 풀에 종목이 아닌 시장 지표 시그널(symbol='crypto', type='fear_greed_shift')이
+// 들어가도 종목 카드 클릭 가드(isMarketIndicatorSignal)가 차단하는지 검증.
+import { describe, it, expect } from 'vitest';
+import {
+  SIGNAL_TYPES,
+  MARKET_INDICATOR_TYPES,
+  isMarketIndicatorSignal,
+} from '../engine/signalTypes.js';
+
+describe('isMarketIndicatorSignal (#341)', () => {
+  it('FEAR_GREED_SHIFT 타입은 시장 지표로 식별', () => {
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.FEAR_GREED_SHIFT, symbol: 'crypto' })).toBe(true);
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.FEAR_GREED_SHIFT, symbol: 'us' })).toBe(true);
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.FEAR_GREED_SHIFT, symbol: 'kr' })).toBe(true);
+  });
+
+  it('종목 시그널(VOLUME_ANOMALY, FOREIGN_CONSECUTIVE_BUY 등)은 시장 지표 아님', () => {
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.VOLUME_ANOMALY, symbol: 'AAPL' })).toBe(false);
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.FOREIGN_CONSECUTIVE_BUY, symbol: '005930' })).toBe(false);
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.COMPOSITE_SCORE, symbol: 'BTC' })).toBe(false);
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.CAPITULATION, symbol: 'TSLA' })).toBe(false);
+  });
+
+  it('null/undefined/타입 누락 시 false 반환 (안전)', () => {
+    expect(isMarketIndicatorSignal(null)).toBe(false);
+    expect(isMarketIndicatorSignal(undefined)).toBe(false);
+    expect(isMarketIndicatorSignal({})).toBe(false);
+    expect(isMarketIndicatorSignal({ symbol: 'crypto' })).toBe(false);
+  });
+
+  it('MARKET_INDICATOR_TYPES Set에 fear_greed_shift 포함', () => {
+    expect(MARKET_INDICATOR_TYPES.has('fear_greed_shift')).toBe(true);
+  });
+});
+
+describe('시그널 클릭 가드 시뮬레이션 (#341)', () => {
+  // 종목 카드 렌더 컴포넌트(SignalBoardWidget/SignalSummaryWidget/CommandCenterWidget HeroSignalCard)의
+  // 클릭 가능 여부 판정 로직 — `signal.symbol && !isMarketIndicatorSignal(signal)`
+  function isClickableAsStock(signal) {
+    return !!signal?.symbol && !isMarketIndicatorSignal(signal);
+  }
+
+  it('공포탐욕 시그널은 종목 클릭 불가 (symbol="crypto"여도 차단)', () => {
+    const fearGreedSignal = {
+      id: 'sig_test_fg',
+      type: SIGNAL_TYPES.FEAR_GREED_SHIFT,
+      symbol: 'crypto',
+      name: 'crypto 공포탐욕',
+      market: 'crypto',
+      direction: 'bullish',
+      strength: 5,
+      title: 'crypto 극단적 공포 극단값 (23) — 역발상 기회',
+    };
+    expect(isClickableAsStock(fearGreedSignal)).toBe(false);
+  });
+
+  it('실제 종목 시그널은 클릭 가능', () => {
+    const realStockSignal = {
+      id: 'sig_test_aapl',
+      type: SIGNAL_TYPES.VOLUME_ANOMALY,
+      symbol: 'AAPL',
+      name: 'Apple',
+      market: 'us',
+      direction: 'bullish',
+      strength: 3,
+    };
+    expect(isClickableAsStock(realStockSignal)).toBe(true);
+  });
+
+  it('symbol 없는 시그널은 클릭 불가 (기존 동작 유지)', () => {
+    const noSymbolSignal = {
+      id: 'sig_test_mood',
+      type: SIGNAL_TYPES.MARKET_MOOD_SHIFT,
+      direction: 'neutral',
+      strength: 2,
+    };
+    expect(isClickableAsStock(noSymbolSignal)).toBe(false);
+  });
+});

--- a/src/components/home/CommandCenterWidget.jsx
+++ b/src/components/home/CommandCenterWidget.jsx
@@ -223,7 +223,11 @@ function HeroSignalCard({ onItemClick, allItems, onShowScorecard }) {
             key={signal.id || `hero-sub-${idx}`}
             className={`flex items-center gap-2.5 px-3 py-2.5 rounded-xl ${subClickable ? 'cursor-pointer hover:bg-[#F7F8FA]' : ''} transition-colors`}
             style={{ borderTop: '1px solid #F2F3F5' }}
-            onClick={() => subClickable && onItemClick?.({ symbol: signal.symbol, name: signal.name || signal.symbol, market: signal.market === 'crypto' ? 'coin' : signal.market })}
+            role={subClickable ? 'button' : undefined}
+            tabIndex={subClickable ? 0 : undefined}
+            aria-disabled={subClickable ? undefined : true}
+            onClick={subClickable ? () => onItemClick?.({ symbol: signal.symbol, name: signal.name || signal.symbol, market: signal.market === 'crypto' ? 'coin' : signal.market }) : undefined}
+            onKeyDown={subClickable ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onItemClick?.({ symbol: signal.symbol, name: signal.name || signal.symbol, market: signal.market === 'crypto' ? 'coin' : signal.market }); } } : undefined}
           >
             {item && <TickerLogo item={item} size={24} />}
             <span className="text-[14px] font-semibold text-[#191F28] truncate flex-1 min-w-0">{extractName(signal)}</span>

--- a/src/components/home/CommandCenterWidget.jsx
+++ b/src/components/home/CommandCenterWidget.jsx
@@ -6,7 +6,7 @@ import { useWatchlistAlert } from '../../hooks/useWatchlistAlert';
 import { useFearGreedScores } from '../../hooks/useFearGreed';
 import { calcTemperature, calcFallbackTemperature, mergeTemperature } from '../../utils/temperature';
 import { extractName, getEasyLabel } from '../../utils/signalLabel';
-import { TYPE_META } from '../../engine/signalTypes';
+import { TYPE_META, isMarketIndicatorSignal } from '../../engine/signalTypes';
 import MarketIndexSection from './MarketIndexSection';
 import EventTicker from './EventTicker';
 import TickerLogo from './TickerLogo';
@@ -129,6 +129,8 @@ function HeroSignalCard({ onItemClick, allItems, onShowScorecard }) {
   const heroAccent = isBullHero ? '#F04452' : '#1764ED';
   const heroBg = isBullHero ? 'rgba(240,68,82,0.03)' : 'rgba(23,100,237,0.03)';
   const heroPct = heroItem ? getPct(heroItem) : null;
+  // 시장 지표 시그널(공포탐욕 등)은 종목이 아니므로 클릭 차단 (#341)
+  const heroClickable = !!hero.symbol && !isMarketIndicatorSignal(hero);
 
   // 히어로 아이템 가격 포맷
   const heroPrice = heroItem
@@ -143,11 +145,11 @@ function HeroSignalCard({ onItemClick, allItems, onShowScorecard }) {
     <div className="flex flex-col gap-2">
       {/* 1위 시그널 — 확장 카드 */}
       <div
-        className={`rounded-[14px] p-5 ${hero.symbol ? 'cursor-pointer hover:brightness-[0.98]' : ''} transition-all`}
+        className={`rounded-[14px] p-5 ${heroClickable ? 'cursor-pointer hover:brightness-[0.98]' : ''} transition-all`}
         style={{ background: heroBg }}
-        onClick={() => hero.symbol && onItemClick?.({ symbol: hero.symbol, name: hero.name || hero.symbol, market: hero.market === 'crypto' ? 'coin' : hero.market })}
-        role={hero.symbol ? 'button' : undefined}
-        tabIndex={hero.symbol ? 0 : undefined}
+        onClick={() => heroClickable && onItemClick?.({ symbol: hero.symbol, name: hero.name || hero.symbol, market: hero.market === 'crypto' ? 'coin' : hero.market })}
+        role={heroClickable ? 'button' : undefined}
+        tabIndex={heroClickable ? 0 : undefined}
       >
         {/* 상단: 로고 + 종목명 + 가격 + 변동률 + 스파크라인 */}
         <div className="flex items-center gap-3 mb-3">
@@ -213,13 +215,15 @@ function HeroSignalCard({ onItemClick, allItems, onShowScorecard }) {
                 ? `₩${fmt(item.price)}`
                 : `$${(item.price ?? 0).toFixed(2)}`)
           : null;
+        // 시장 지표 시그널(공포탐욕 등)은 종목이 아니므로 클릭 차단 (#341)
+        const subClickable = !!signal.symbol && !isMarketIndicatorSignal(signal);
 
         return (
           <div
             key={signal.id || `hero-sub-${idx}`}
-            className={`flex items-center gap-2.5 px-3 py-2.5 rounded-xl ${signal.symbol ? 'cursor-pointer hover:bg-[#F7F8FA]' : ''} transition-colors`}
+            className={`flex items-center gap-2.5 px-3 py-2.5 rounded-xl ${subClickable ? 'cursor-pointer hover:bg-[#F7F8FA]' : ''} transition-colors`}
             style={{ borderTop: '1px solid #F2F3F5' }}
-            onClick={() => signal.symbol && onItemClick?.({ symbol: signal.symbol, name: signal.name || signal.symbol, market: signal.market === 'crypto' ? 'coin' : signal.market })}
+            onClick={() => subClickable && onItemClick?.({ symbol: signal.symbol, name: signal.name || signal.symbol, market: signal.market === 'crypto' ? 'coin' : signal.market })}
           >
             {item && <TickerLogo item={item} size={24} />}
             <span className="text-[14px] font-semibold text-[#191F28] truncate flex-1 min-w-0">{extractName(signal)}</span>

--- a/src/components/home/HOME_CONTRACT.md
+++ b/src/components/home/HOME_CONTRACT.md
@@ -30,17 +30,14 @@
 5. ExploreTabsWidget       — 탐색 탭 (급등/급락 | 섹터)
    ├── TopMoversWidget     — 급등/급락 탭 (KR/US/COIN 서브탭)
    └── SectorMiniContent   — 섹터 탭 (HOT/COLD pill 칩 + drill-down)
-6. NewsFeedWidget          — 투자 뉴스 (lg:hidden — 모바일 전용, 데스크톱은 우측 패널)
+6. NewsFeedWidget          — 투자 뉴스 (lg:hidden — 모바일 전용)
 ```
 
-### 우측 패널 (`src/App.jsx` — 데스크톱 전용)
+### 우측 패널 (`src/App.jsx` — 데스크톱 전용) — **비표시** (사용자 피로감 호소로 제거 — #339)
 
 ```
-UnifiedFeedPanel           — 통합 실시간 피드 (BreakingNewsPanel 교체)
-├── FeedHeader             — "실시간" + LIVE dot
-├── 시그널 피드             — 시그널 timestamp 기준 정렬 (최대 5건, 빨강 태그)
-├── 뉴스 탭 헤더            — 속보/국내/해외/코인
-└── 뉴스 목록               — 파랑 태그, 클러스터링 적용
+UnifiedFeedPanel           — [비활성] 통합 실시간 피드 (사용자 피로감 호소로 제거 — #339)
+                             파일(UnifiedFeedPanel.jsx)은 보존, App.jsx에서 렌더 중단
 ```
 
 ### 모바일 뉴스 탭 (`activeTab === 'news'`)
@@ -66,6 +63,7 @@ BreakingNewsPanel          — 기존 뉴스 패널 (모바일 전용, lg:hidden
 | SectorMiniWidget (독립) | ExploreTabsWidget의 SectorMiniContent로 통합됨 |
 | SignalSummaryWidget (독립) | SignalBoardWidget에 통합됨 |
 | SeoulForceSection (인라인) | SignalBoardWidget에 통합됨 |
+| UnifiedFeedPanel (우측 패널) | 사용자 피로감 호소로 App.jsx 렌더 제거 — #339 (파일 보존, 영구삭제 아님) |
 
 ---
 

--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { cycleStep } from '../../utils/cycleTracker';
 import { useTopSignals } from '../../hooks/useSignals';
 import { extractName, getEasyLabel } from '../../utils/signalLabel';
-import { SIGNAL_TYPES } from '../../engine/signalTypes';
+import { SIGNAL_TYPES, isMarketIndicatorSignal } from '../../engine/signalTypes';
 import { useSignalAccuracy } from '../../hooks/useSignalAccuracy';
 import { buildNarrative } from '../../utils/narrativeBuilder';
 import { matchesKeywords, buildStockKeywords } from '../../utils/newsAlias';
@@ -164,17 +164,22 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
   const displayList = expanded ? filteredCombinedList : filteredCombinedList.slice(0, 5);
 
   const handleClick = useCallback((signal) => {
+    // 시장 지표 시그널(공포탐욕 등)은 종목이 아니므로 클릭 차단 (#341)
+    if (isMarketIndicatorSignal(signal)) return;
     if (signal.symbol && onItemClick) {
       // market 정규화: 시그널 엔진은 'crypto'를 사용하지만 ChartSidePanel은 'coin' 기대
       const market = signal.market === 'crypto' ? 'coin' : signal.market;
       cycleStep('signal_click', { market, signal_type: signal.type });
-      onItemClick({ symbol: signal.symbol, name: signal.name || signal.symbol, market });
+      // type 전달 — 상위 핸들러(handleSignalItemClick)의 시장 지표 안전망 작동용 (#341)
+      onItemClick({ symbol: signal.symbol, name: signal.name || signal.symbol, market, type: signal.type });
     }
   }, [onItemClick]);
 
   // 시그널 카드 펼치기/접기 토글 — 펼칠 때만 이벤트 발화 (StrictMode 안전)
   const handleToggleExpand = useCallback((signal) => {
     if (!signal.symbol) return;
+    // 시장 지표 시그널(공포탐욕 등)은 종목 상세 패널이 없으므로 펼치기 차단 (#341)
+    if (isMarketIndicatorSignal(signal)) return;
     const willExpand = expandedId !== signal.id;
     if (willExpand) cycleStep('signal_expand', { market: signal.market, signal_type: signal.type });
     setExpandedId(willExpand ? signal.id : null);
@@ -351,16 +356,19 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
             const isExpanded = expandedId === signal.id;
             const watchedKey = matchedItem?.id || signal.symbol;
             const marketKey = signal.market === 'crypto' ? 'COIN' : signal.market?.toUpperCase();
+            // 시장 지표 시그널(공포탐욕 등)은 종목이 아니므로 클릭/로고/펼치기 비활성 (#341)
+            const isMarketIndicator = isMarketIndicatorSignal(signal);
+            const isClickable = !!signal.symbol && !isMarketIndicator;
             return (
               <div key={signal.id} className={idx > 0 ? 'border-t border-[#F2F3F5]' : ''}>
                 <button
                   onClick={() => handleToggleExpand(signal)}
-                  aria-expanded={signal.symbol ? isExpanded : undefined}
+                  aria-expanded={isClickable ? isExpanded : undefined}
                   className={`w-full text-left flex items-center gap-3 py-[11px] px-2 rounded-[10px] transition-colors ${
-                    signal.symbol ? 'cursor-pointer hover:bg-[#F2F3F5]' : ''
+                    isClickable ? 'cursor-pointer hover:bg-[#F2F3F5]' : ''
                   }`}
                 >
-                  {signal.symbol && (
+                  {isClickable && (
                     <TickerLogo item={matchedItem || { symbol: signal.symbol, name: signal.name, _market: signal.market === 'kr' ? 'KR' : signal.market === 'us' ? 'US' : signal.market === 'crypto' ? 'COIN' : '', id: signal.market === 'crypto' ? signal.symbol : undefined }} size={24} />
                   )}
                   <span className="text-[14px] font-semibold flex-shrink-0" style={{ color: nameColor }}>
@@ -395,8 +403,8 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
                       />
                     ))}
                   </div>
-                  {/* 펼치기 chevron — symbol 있는 시그널에만 표시 */}
-                  {signal.symbol && <svg
+                  {/* 펼치기 chevron — symbol 있고 종목 시그널에만 표시 (#341) */}
+                  {isClickable && <svg
                     width="14"
                     height="14"
                     viewBox="0 0 24 24"

--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -362,10 +362,12 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
             return (
               <div key={signal.id} className={idx > 0 ? 'border-t border-[#F2F3F5]' : ''}>
                 <button
-                  onClick={() => handleToggleExpand(signal)}
+                  onClick={isClickable ? () => handleToggleExpand(signal) : undefined}
                   aria-expanded={isClickable ? isExpanded : undefined}
+                  aria-disabled={isClickable ? undefined : true}
+                  tabIndex={isClickable ? 0 : -1}
                   className={`w-full text-left flex items-center gap-3 py-[11px] px-2 rounded-[10px] transition-colors ${
-                    isClickable ? 'cursor-pointer hover:bg-[#F2F3F5]' : ''
+                    isClickable ? 'cursor-pointer hover:bg-[#F2F3F5]' : 'cursor-default'
                   }`}
                 >
                   {isClickable && (

--- a/src/components/home/SignalSummaryWidget.jsx
+++ b/src/components/home/SignalSummaryWidget.jsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import { useTopSignals } from '../../hooks/useSignals';
 import { extractName, getEasyLabel } from '../../utils/signalLabel';
+import { isMarketIndicatorSignal } from '../../engine/signalTypes';
 
 export default function SignalSummaryWidget({ onItemClick }) {
   const [expanded, setExpanded] = useState(false);
@@ -25,6 +26,8 @@ export default function SignalSummaryWidget({ onItemClick }) {
   const scoreLabel = bullPct >= 60 ? '강세 우세' : bullPct <= 40 ? '약세 우세' : '팽팽';
 
   const handleClick = useCallback((signal) => {
+    // 시장 지표 시그널(공포탐욕 등)은 종목이 아니므로 클릭 차단 (#341)
+    if (isMarketIndicatorSignal(signal)) return;
     if (signal.symbol && onItemClick) {
       // market 정규화: 시그널 엔진은 'crypto'를 사용하지만 ChartSidePanel은 'coin' 기대
       const market = signal.market === 'crypto' ? 'coin' : signal.market;
@@ -94,13 +97,16 @@ export default function SignalSummaryWidget({ onItemClick }) {
             <p className="text-[11px] text-[#B0B8C1]">강세 시그널 없음</p>
           ) : (
             <div className="space-y-1.5">
-              {displayBull.map(signal => (
+              {displayBull.map(signal => {
+                // 시장 지표 시그널(공포탐욕 등)은 종목이 아니므로 클릭 외양 비활성 (#341)
+                const clickable = !!signal.symbol && !isMarketIndicatorSignal(signal);
+                return (
                 <div
                   key={signal.id}
-                  role={signal.symbol ? 'button' : undefined}
-                  tabIndex={signal.symbol ? 0 : undefined}
+                  role={clickable ? 'button' : undefined}
+                  tabIndex={clickable ? 0 : undefined}
                   onClick={() => handleClick(signal)}
-                  className={`w-full text-left flex items-center gap-2 px-2.5 py-2 rounded-lg transition-colors ${signal.symbol ? 'cursor-pointer hover:bg-[#FFF0F1]' : ''}`}
+                  className={`w-full text-left flex items-center gap-2 px-2.5 py-2 rounded-lg transition-colors ${clickable ? 'cursor-pointer hover:bg-[#FFF0F1]' : ''}`}
                   style={{ background: '#FFFAFA' }}
                 >
                   <div className="flex-1 min-w-0">
@@ -113,7 +119,8 @@ export default function SignalSummaryWidget({ onItemClick }) {
                     ))}
                   </div>
                 </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>
@@ -125,13 +132,16 @@ export default function SignalSummaryWidget({ onItemClick }) {
             <p className="text-[11px] text-[#B0B8C1]">약세 시그널 없음</p>
           ) : (
             <div className="space-y-1.5">
-              {displayBear.map(signal => (
+              {displayBear.map(signal => {
+                // 시장 지표 시그널(공포탐욕 등)은 종목이 아니므로 클릭 외양 비활성 (#341)
+                const clickable = !!signal.symbol && !isMarketIndicatorSignal(signal);
+                return (
                 <div
                   key={signal.id}
-                  role={signal.symbol ? 'button' : undefined}
-                  tabIndex={signal.symbol ? 0 : undefined}
+                  role={clickable ? 'button' : undefined}
+                  tabIndex={clickable ? 0 : undefined}
                   onClick={() => handleClick(signal)}
-                  className={`w-full text-left flex items-center gap-2 px-2.5 py-2 rounded-lg transition-colors ${signal.symbol ? 'cursor-pointer hover:bg-[#EDF4FF]' : ''}`}
+                  className={`w-full text-left flex items-center gap-2 px-2.5 py-2 rounded-lg transition-colors ${clickable ? 'cursor-pointer hover:bg-[#EDF4FF]' : ''}`}
                   style={{ background: '#FAFCFF' }}
                 >
                   <div className="flex-1 min-w-0">
@@ -144,7 +154,8 @@ export default function SignalSummaryWidget({ onItemClick }) {
                     ))}
                   </div>
                 </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -11,6 +11,7 @@ import { useInvestorSignals } from '../../hooks/useInvestorSignals';
 import { useDerivativeSignals } from '../../hooks/useDerivativeSignals';
 import { useNewsSignals } from '../../hooks/useNewsSignals';
 import { useServerSignals } from '../../hooks/useServerSignals';
+import { isMarketIndicatorSignal } from '../../engine/signalTypes';
 import CommandCenterWidget from './CommandCenterWidget';
 import SignalBoardWidget from './SignalBoardWidget';
 import AiDebateSection from './AiDebateSection';
@@ -123,6 +124,8 @@ export default function HomeDashboard({
   // 시그널 클릭 → allItems에서 full item 조회 후 ChartSidePanel 오픈
   const handleSignalItemClick = useCallback((sigItem) => {
     if (!sigItem?.symbol || !onItemClick) return;
+    // 시장 지표 시그널(공포탐욕 등)은 종목이 아니므로 차단 (#341, 안전망 — 호출처에서 1차 차단됨)
+    if (isMarketIndicatorSignal(sigItem)) return;
     const marketMap = { crypto: 'COIN', coin: 'COIN', us: 'US', kr: 'KR' };
     const _market = marketMap[(sigItem.market || '').toLowerCase()] ||
                     (sigItem._market || '').toUpperCase() || 'US';

--- a/src/engine/signalTypes.js
+++ b/src/engine/signalTypes.js
@@ -36,11 +36,18 @@ export const SIGNAL_TYPES = {
   SECTOR_OUTLIER: 'sector_outlier',
 };
 
-// 시장 지표 시그널 — 종목이 아닌 시장 전체 심리/지표 (#341)
+// 시장 지표 시그널 — 종목이 아닌 시장 전체/섹터/거시 단위 지표 (#341)
 // symbol 필드에 'crypto'/'us'/'kr' 같은 시장 키가 들어가지만 종목 클릭/카드로 변환 금지.
 // 시그널 보드의 정보성 카드 + 봇 성적표 추적 + 다른 시그널 교차 참조용으로만 사용.
+// 매직 스트링 대신 SIGNAL_TYPES 참조로 일관 — 리네이밍 시 가드 무력화 방지 (architect BLOCK 반영)
 export const MARKET_INDICATOR_TYPES = new Set([
-  'fear_greed_shift',
+  SIGNAL_TYPES.FEAR_GREED_SHIFT,        // 공포·탐욕 지수 극단값
+  SIGNAL_TYPES.MARKET_MOOD_SHIFT,       // 국장·미장·코인 전체 심리 전환
+  SIGNAL_TYPES.SECTOR_ROTATION,         // 섹터 단위 — 종목 클릭 의미 X
+  SIGNAL_TYPES.PUT_CALL_RATIO,          // 시장 옵션 PCR
+  SIGNAL_TYPES.FUNDING_RATE_EXTREME,    // 코인 펀딩비 극단
+  SIGNAL_TYPES.FX_IMPACT,               // 환율 충격
+  SIGNAL_TYPES.CROSS_MARKET_CORRELATION,// 시장 간 상관성 변화
 ]);
 
 /** 시그널이 시장 지표(종목 아님) 타입인지 검사 — 종목 클릭 핸들러에서 차단용 (#341) */

--- a/src/engine/signalTypes.js
+++ b/src/engine/signalTypes.js
@@ -36,6 +36,18 @@ export const SIGNAL_TYPES = {
   SECTOR_OUTLIER: 'sector_outlier',
 };
 
+// 시장 지표 시그널 — 종목이 아닌 시장 전체 심리/지표 (#341)
+// symbol 필드에 'crypto'/'us'/'kr' 같은 시장 키가 들어가지만 종목 클릭/카드로 변환 금지.
+// 시그널 보드의 정보성 카드 + 봇 성적표 추적 + 다른 시그널 교차 참조용으로만 사용.
+export const MARKET_INDICATOR_TYPES = new Set([
+  'fear_greed_shift',
+]);
+
+/** 시그널이 시장 지표(종목 아님) 타입인지 검사 — 종목 클릭 핸들러에서 차단용 (#341) */
+export function isMarketIndicatorSignal(signal) {
+  return !!signal && MARKET_INDICATOR_TYPES.has(signal.type);
+}
+
 // 시그널 방향
 export const DIRECTIONS = {
   BULLISH: 'bullish',


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-3.1-pro-preview)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #341

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 시장 지표 시그널(공포탐욕 지수 등)을 클릭할 수 없도록 개선하여 오류 방지
  * 시장 지표와 종목 신호를 명확히 구분하여 상호작용 로직 강화

* **New Features**
  * 시장 지표 시그널 검증 및 필터링 기능 추가

* **UI/UX**
  * 우측 피드 패널 제거로 레이아웃 간소화

* **Tests**
  * 시장 지표 시그널 식별 및 클릭 차단 동작 검증 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gguloadoong/market-dashboard-v5/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->