### PR TITLE
fix(#346): 시장지표 가짜 종목 카드 잔존 2건 fix — REBALANCING_ALERT + UnifiedFeedPanel 가드

### DIFF
--- a/src/__tests__/marketIndicatorSignal.test.js
+++ b/src/__tests__/marketIndicatorSignal.test.js
@@ -22,6 +22,30 @@ describe('isMarketIndicatorSignal (#341)', () => {
     expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.CAPITULATION, symbol: 'TSLA' })).toBe(false);
   });
 
+  // #346 — REBALANCING_ALERT 시장지표 가드 추가
+  it('REBALANCING_ALERT 타입은 시장 지표로 식별 (symbol="MARKET")', () => {
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.REBALANCING_ALERT, symbol: 'MARKET' })).toBe(true);
+  });
+
+  it('MARKET_INDICATOR_TYPES Set에 rebalancing_alert 포함 (#346)', () => {
+    expect(MARKET_INDICATOR_TYPES.has('rebalancing_alert')).toBe(true);
+  });
+
+  // #346 — FX_IMPACT, PCR, MARKET_MOOD_SHIFT, CROSS_MARKET_CORRELATION도 회귀 가드
+  it('FX_IMPACT 타입은 시장 지표 (symbol="USDKRW") (#346)', () => {
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.FX_IMPACT, symbol: 'USDKRW' })).toBe(true);
+  });
+
+  it('PUT_CALL_RATIO 타입은 시장 지표 (symbol="SPY") (#346)', () => {
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.PUT_CALL_RATIO, symbol: 'SPY' })).toBe(true);
+  });
+
+  it('MARKET_MOOD_SHIFT/CROSS_MARKET_CORRELATION/SECTOR_ROTATION 모두 시장 지표 (#346)', () => {
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.MARKET_MOOD_SHIFT, symbol: 'MARKET' })).toBe(true);
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.CROSS_MARKET_CORRELATION, symbol: 'BTC_KOSPI' })).toBe(true);
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.SECTOR_ROTATION, symbol: null })).toBe(true);
+  });
+
   it('null/undefined/타입 누락 시 false 반환 (안전)', () => {
     expect(isMarketIndicatorSignal(null)).toBe(false);
     expect(isMarketIndicatorSignal(undefined)).toBe(false);
@@ -76,5 +100,33 @@ describe('시그널 클릭 가드 시뮬레이션 (#341)', () => {
       strength: 2,
     };
     expect(isClickableAsStock(noSymbolSignal)).toBe(false);
+  });
+
+  // #346 — REBALANCING_ALERT는 createRebalancingSignal에서 symbol:'MARKET'으로 생성됨.
+  // signalEngine.js:715-723. 종목 카드 클릭 시 'MARKET' 가짜 종목 카드 → 빈 차트 사고.
+  it('REBALANCING_ALERT(symbol="MARKET")는 종목 클릭 불가 (#346)', () => {
+    const rebalancingSignal = {
+      id: 'sig_test_rebal',
+      type: SIGNAL_TYPES.REBALANCING_ALERT,
+      symbol: 'MARKET',
+      name: '기관 리밸런싱',
+      market: 'kr',
+      direction: 'bearish',
+      strength: 3,
+      title: '월말 D-2 — 기관 리밸런싱 매물 출회 가능',
+    };
+    expect(isClickableAsStock(rebalancingSignal)).toBe(false);
+  });
+
+  // #346 — UnifiedFeedPanel 시그널 항목 가드 (이전 누락분 회귀)
+  it('FX_IMPACT(symbol="USDKRW")는 종목 클릭 불가 — UnifiedFeedPanel 패턴 (#346)', () => {
+    const fxSignal = {
+      id: 'sig_test_fx',
+      type: SIGNAL_TYPES.FX_IMPACT,
+      symbol: 'USDKRW',
+      name: '원/달러 환율',
+      market: 'kr',
+    };
+    expect(isClickableAsStock(fxSignal)).toBe(false);
   });
 });

--- a/src/components/UnifiedFeedPanel.jsx
+++ b/src/components/UnifiedFeedPanel.jsx
@@ -71,12 +71,12 @@ function timeShort(ts) {
 
 // ─── 3컬럼 피드 항목 (시간 | 태그 | 내용) ────────────────────
 // clickable=false 시 종목 카드 라우팅 불가 시그널(시장 지표 등) — 호버/커서 비활성 + aria-disabled (#346)
-function FeedItem3Col({ time, tagLabel, tagColor, text, onClick, ariaDisabled = false, clickable = true }) {
+// `disabled` 속성 사용 X: UA stylesheet의 GrayText/opacity가 텍스트 색상을 덮어쓰는 부작용 방지 (Gemini 지적 #347)
+function FeedItem3Col({ time, tagLabel, tagColor, text, onClick, clickable = true }) {
   return (
     <button
-      onClick={onClick}
-      disabled={ariaDisabled}
-      aria-disabled={ariaDisabled || undefined}
+      onClick={clickable ? onClick : undefined}
+      aria-disabled={!clickable || undefined}
       tabIndex={clickable ? 0 : -1}
       className={`w-full grid items-baseline gap-1.5 px-5 py-2.5 transition-colors -mx-0 rounded-lg ${clickable ? 'cursor-pointer hover:bg-[#F2F3F5]' : 'cursor-default'}`}
       style={{ gridTemplateColumns: '36px 44px 1fr' }}
@@ -106,7 +106,6 @@ function SignalFeedItem({ signal, onItemClick }) {
       onClick={clickable
         ? () => onItemClick?.({ symbol: signal.symbol, name: signal.name || signal.symbol, market })
         : undefined}
-      ariaDisabled={!clickable}
       clickable={clickable}
     />
   );

--- a/src/components/UnifiedFeedPanel.jsx
+++ b/src/components/UnifiedFeedPanel.jsx
@@ -6,6 +6,7 @@ import { useSignals } from '../hooks/useSignals';
 import { extractNewsSignals, getNewsImpact, isBreakingNews, getNewsImpactType } from '../utils/newsSignal';
 import { clusterNews } from '../utils/newsCluster';
 import { extractName, getEasyLabel } from '../utils/signalLabel';
+import { isMarketIndicatorSignal } from '../engine/signalTypes';
 
 // ─── 피드 타입 태그 색상 ────────────────────────────────────
 const FEED_TAG = {
@@ -69,11 +70,15 @@ function timeShort(ts) {
 }
 
 // ─── 3컬럼 피드 항목 (시간 | 태그 | 내용) ────────────────────
-function FeedItem3Col({ time, tagLabel, tagColor, text, onClick }) {
+// clickable=false 시 종목 카드 라우팅 불가 시그널(시장 지표 등) — 호버/커서 비활성 + aria-disabled (#346)
+function FeedItem3Col({ time, tagLabel, tagColor, text, onClick, ariaDisabled = false, clickable = true }) {
   return (
     <button
       onClick={onClick}
-      className="w-full grid items-baseline gap-1.5 px-5 py-2.5 cursor-pointer hover:bg-[#F2F3F5] transition-colors -mx-0 rounded-lg"
+      disabled={ariaDisabled}
+      aria-disabled={ariaDisabled || undefined}
+      tabIndex={clickable ? 0 : -1}
+      className={`w-full grid items-baseline gap-1.5 px-5 py-2.5 transition-colors -mx-0 rounded-lg ${clickable ? 'cursor-pointer hover:bg-[#F2F3F5]' : 'cursor-default'}`}
       style={{ gridTemplateColumns: '36px 44px 1fr' }}
     >
       <span className="text-[11px] text-[#B0B8C1] font-mono tabular-nums flex-shrink-0">{time}</span>
@@ -86,13 +91,23 @@ function FeedItem3Col({ time, tagLabel, tagColor, text, onClick }) {
 // ─── 시그널 항목 (3컬럼) ────────────────────────────────────
 function SignalFeedItem({ signal, onItemClick }) {
   const tag = FEED_TAG.signal;
+  // 시장 지표 시그널(FX_IMPACT 'USDKRW', PCR 'SPY', MARKET_MOOD_SHIFT 'MARKET',
+  // SECTOR_ROTATION null, CROSS_MARKET_CORRELATION 'leader_lagger', REBALANCING_ALERT 'MARKET' 등)은
+  // 종목이 아니므로 ChartSidePanel 라우팅 차단 (#346)
+  const clickable = !!signal.symbol && !isMarketIndicatorSignal(signal);
+  // market 정규화: 시그널 엔진은 'crypto'를 사용하지만 ChartSidePanel은 'coin' 기대 — SignalSummaryWidget.jsx:33 패턴 일관
+  const market = signal.market === 'crypto' ? 'coin' : signal.market;
   return (
     <FeedItem3Col
       time={timeShort(signal.timestamp || signal.createdAt)}
       tagLabel={tag.label}
       tagColor={tag.color}
       text={`${extractName(signal)} ${getEasyLabel(signal)}`}
-      onClick={() => signal.symbol && onItemClick?.({ symbol: signal.symbol, name: signal.name || signal.symbol, market: signal.market })}
+      onClick={clickable
+        ? () => onItemClick?.({ symbol: signal.symbol, name: signal.name || signal.symbol, market })
+        : undefined}
+      ariaDisabled={!clickable}
+      clickable={clickable}
     />
   );
 }

--- a/src/engine/signalTypes.js
+++ b/src/engine/signalTypes.js
@@ -48,6 +48,7 @@ export const MARKET_INDICATOR_TYPES = new Set([
   SIGNAL_TYPES.FUNDING_RATE_EXTREME,    // 코인 펀딩비 극단
   SIGNAL_TYPES.FX_IMPACT,               // 환율 충격
   SIGNAL_TYPES.CROSS_MARKET_CORRELATION,// 시장 간 상관성 변화
+  SIGNAL_TYPES.REBALANCING_ALERT,       // 월말/분기말 기관 리밸런싱 — symbol='MARKET' 가짜 종목 카드 방지 (#346)
 ]);
 
 /** 시그널이 시장 지표(종목 아님) 타입인지 검사 — 종목 클릭 핸들러에서 차단용 (#341) */


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-3.1-pro-preview)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #346

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시장 지표 신호(리밸런싱 알림 등)에 대한 클릭 차단 기능 추가. 해당 신호들은 이제 선택 불가 상태로 표시됩니다.

* **테스트**
  * 시장 지표 신호 식별 및 클릭 차단 동작에 대한 검증 테스트 케이스 추가.

* **개선**
  * 리밸런싱 알림을 시장 지표로 분류하는 로직 확장.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->