### PR TITLE
fix(#343): 시그널 kind 도메인 분리 — 가짜 종목 카드 근본 차단

### DIFF
--- a/src/__tests__/marketIndicatorSignal.test.js
+++ b/src/__tests__/marketIndicatorSignal.test.js
@@ -7,6 +7,7 @@ import {
   MARKET_INDICATOR_TYPES,
   isMarketIndicatorSignal,
 } from '../engine/signalTypes.js';
+import { isStockClickable } from '../utils/signalStockResolver.js';
 
 describe('isMarketIndicatorSignal (#341)', () => {
   it('FEAR_GREED_SHIFT 타입은 시장 지표로 식별', () => {
@@ -128,5 +129,7 @@ describe('시그널 클릭 가드 시뮬레이션 (#341)', () => {
       market: 'kr',
     };
     expect(isClickableAsStock(fxSignal)).toBe(false);
+    // #343 — 공통 유틸 isStockClickable(lookup 미제공)도 동일 차단 (UnifiedFeedPanel 실제 사용 형태)
+    expect(isStockClickable(fxSignal)).toBe(false);
   });
 });

--- a/src/__tests__/signalKind.test.js
+++ b/src/__tests__/signalKind.test.js
@@ -1,0 +1,132 @@
+// #343 — 시그널 도메인(kind) 분리 회귀 테스트
+// 모든 시그널 타입이 'stock'|'market'으로 분류되고, createSignal/loadSignals가
+// type 기준으로 kind를 자동 주입하며, isMarketIndicatorSignal이 kind를 우선 사용하는지 검증.
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  SIGNAL_TYPES,
+  SIGNAL_KIND,
+  MARKET_INDICATOR_TYPES,
+  getSignalKind,
+  isMarketIndicatorSignal,
+} from '../engine/signalTypes.js';
+import { createSignal, loadSignals, getActiveSignals, _resetStore } from '../engine/signalEngine.js';
+
+describe('SIGNAL_KIND 완전성 (#343)', () => {
+  it('모든 SIGNAL_TYPES가 stock|market으로 분류됨 (누락 0)', () => {
+    const types = Object.values(SIGNAL_TYPES);
+    // 현 시점 30종(stock 22 + market 8) — 신규 타입 추가 시 IIFE가 로드 단계에서 throw
+    expect(types.length).toBe(30);
+    const missing = types.filter(type => !['stock', 'market'].includes(SIGNAL_KIND[type]));
+    expect(missing).toEqual([]);
+  });
+
+  it('SIGNAL_KIND에 SIGNAL_TYPES 외 잉여 키 없음', () => {
+    const validTypes = new Set(Object.values(SIGNAL_TYPES));
+    const extra = Object.keys(SIGNAL_KIND).filter(t => !validTypes.has(t));
+    expect(extra).toEqual([]);
+  });
+});
+
+describe('getSignalKind (#343)', () => {
+  it('종목 타입은 stock', () => {
+    expect(getSignalKind(SIGNAL_TYPES.VOLUME_ANOMALY)).toBe('stock');
+    expect(getSignalKind(SIGNAL_TYPES.FOREIGN_CONSECUTIVE_BUY)).toBe('stock');
+    expect(getSignalKind(SIGNAL_TYPES.COMPOSITE_SCORE)).toBe('stock');
+    expect(getSignalKind(SIGNAL_TYPES.SECTOR_OUTLIER)).toBe('stock');
+  });
+
+  it('시장 지표 타입은 market', () => {
+    expect(getSignalKind(SIGNAL_TYPES.FEAR_GREED_SHIFT)).toBe('market');
+    expect(getSignalKind(SIGNAL_TYPES.SECTOR_ROTATION)).toBe('market');
+    expect(getSignalKind(SIGNAL_TYPES.REBALANCING_ALERT)).toBe('market');
+    expect(getSignalKind(SIGNAL_TYPES.FX_IMPACT)).toBe('market');
+  });
+
+  it('미등록 타입은 stock 기본', () => {
+    expect(getSignalKind('unknown_type_xyz')).toBe('stock');
+    expect(getSignalKind(undefined)).toBe('stock');
+  });
+});
+
+describe('createSignal kind 자동 주입 (#343)', () => {
+  it('FEAR_GREED_SHIFT → kind:market 자동 주입', () => {
+    const sig = createSignal({ type: SIGNAL_TYPES.FEAR_GREED_SHIFT, symbol: 'crypto', market: 'crypto' });
+    expect(sig.kind).toBe('market');
+  });
+
+  it('VOLUME_ANOMALY → kind:stock 자동 주입', () => {
+    const sig = createSignal({ type: SIGNAL_TYPES.VOLUME_ANOMALY, symbol: 'AAPL', market: 'us' });
+    expect(sig.kind).toBe('stock');
+  });
+});
+
+describe('useFearGreed 간접 — FEAR_GREED_SHIFT createSignal kind (#343)', () => {
+  // useFearGreed.js는 createSignal({ type: FEAR_GREED_SHIFT, ... })로 시그널 생성 → A안 자동 주입
+  it('공포탐욕 시그널은 createSignal 경유 시 kind:market', () => {
+    const fg = createSignal({
+      type: SIGNAL_TYPES.FEAR_GREED_SHIFT,
+      symbol: 'us',
+      name: 'us 공포탐욕',
+      market: 'us',
+      direction: 'bullish',
+      strength: 5,
+    });
+    expect(fg.kind).toBe('market');
+    expect(isMarketIndicatorSignal(fg)).toBe(true);
+  });
+});
+
+describe('loadSignals kind 주입 (#343)', () => {
+  beforeEach(() => _resetStore()); // 전역 _signals 초기화 — signalEngine.test.js:16 패턴
+
+  it('서버 시그널(COMPOSITE_SCORE)에 kind:stock 주입 — 서버가 틀린 kind 보내도 type 기준 덮어쓰기', () => {
+    loadSignals([
+      {
+        id: 'srv_comp_1',
+        type: SIGNAL_TYPES.COMPOSITE_SCORE,
+        symbol: '005930',
+        market: 'kr',
+        direction: 'bullish',
+        strength: 4,
+        kind: 'market', // 서버가 의도적으로 틀린 kind 전송
+      },
+    ]);
+    const loaded = getActiveSignals().find(s => s.id === 'srv_comp_1');
+    expect(loaded).toBeDefined();
+    expect(loaded.kind).toBe('stock'); // type 기준으로 덮어써짐
+  });
+});
+
+describe('isMarketIndicatorSignal kind 우선 + 레거시 fallback (#343)', () => {
+  it('kind:market이면 type 무관하게 true', () => {
+    expect(isMarketIndicatorSignal({ kind: 'market', type: SIGNAL_TYPES.VOLUME_ANOMALY, symbol: 'AAPL' })).toBe(true);
+  });
+
+  it('kind:stock이면 type 무관하게 false (FEAR_GREED_SHIFT여도)', () => {
+    expect(isMarketIndicatorSignal({ kind: 'stock', type: SIGNAL_TYPES.FEAR_GREED_SHIFT, symbol: 'crypto' })).toBe(false);
+  });
+
+  it('kind 없으면 type 기반 레거시 fallback', () => {
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.FEAR_GREED_SHIFT })).toBe(true);
+    expect(isMarketIndicatorSignal({ type: SIGNAL_TYPES.VOLUME_ANOMALY })).toBe(false);
+  });
+});
+
+describe('MARKET_INDICATOR_TYPES 파생 일치 (#343)', () => {
+  it('기존 8종 market 타입 전부 포함', () => {
+    const expected = [
+      SIGNAL_TYPES.FEAR_GREED_SHIFT,
+      SIGNAL_TYPES.MARKET_MOOD_SHIFT,
+      SIGNAL_TYPES.SECTOR_ROTATION,
+      SIGNAL_TYPES.PUT_CALL_RATIO,
+      SIGNAL_TYPES.FUNDING_RATE_EXTREME,
+      SIGNAL_TYPES.FX_IMPACT,
+      SIGNAL_TYPES.CROSS_MARKET_CORRELATION,
+      SIGNAL_TYPES.REBALANCING_ALERT,
+    ];
+    expect(MARKET_INDICATOR_TYPES.size).toBe(8);
+    for (const type of expected) {
+      expect(MARKET_INDICATOR_TYPES.has(type)).toBe(true);
+    }
+  });
+});

--- a/src/__tests__/signalStockResolver.test.js
+++ b/src/__tests__/signalStockResolver.test.js
@@ -1,0 +1,96 @@
+// #343 — 시그널 → 종목 카드 렌더 판정 유틸 회귀 테스트
+import { describe, it, expect } from 'vitest';
+import { SIGNAL_TYPES } from '../engine/signalTypes.js';
+import {
+  resolveStockItem,
+  isStockClickable,
+  shouldRenderStockCard,
+} from '../utils/signalStockResolver.js';
+
+const ALL_ITEMS = [
+  { symbol: 'AAPL', name: 'Apple', _market: 'US', price: 200 },
+  { symbol: '005930', name: '삼성전자', _market: 'KR', price: 70000 },
+  { id: 'BTC', symbol: 'BTC', name: '비트코인', _market: 'COIN', priceKrw: 90000000 },
+];
+
+// crypto market 정규화 검증용 — 동일 ticker가 코인/주식 둘 다 존재하는 경우 (#343 HIGH-1)
+const APE_ITEMS = [
+  { symbol: 'APE', name: 'APE (Stocks)', _market: 'US', price: 1.2 },  // 주식 먼저
+  { id: 'APE', symbol: 'APE', name: 'ApeCoin', _market: 'COIN', priceKrw: 1500 }, // 코인 나중
+];
+
+describe('resolveStockItem (#343)', () => {
+  it('symbol + market 일치 종목 반환', () => {
+    const sig = { type: SIGNAL_TYPES.VOLUME_ANOMALY, symbol: 'AAPL', market: 'us' };
+    expect(resolveStockItem(sig, ALL_ITEMS)?.symbol).toBe('AAPL');
+  });
+
+  it('코인 id 매칭 반환 — crypto→coin 정규화로 1차 정확매칭', () => {
+    const sig = { type: SIGNAL_TYPES.BTC_LEADING, symbol: 'BTC', market: 'crypto' };
+    // crypto→coin 정규화 후 1차 매칭: (i._market||'').toLowerCase()==='coin' 통과
+    expect(resolveStockItem(sig, ALL_ITEMS)?.id).toBe('BTC');
+  });
+
+  it('crypto 정규화 — 동일 ticker 코인/주식 둘 다 존재 시 _market:COIN 종목을 정확히 집음 (#343)', () => {
+    // market:'crypto' 시그널 → 정규화 없으면 배열 앞 US주식 APE를 잘못 집음
+    const sig = { type: SIGNAL_TYPES.BTC_LEADING, symbol: 'APE', market: 'crypto' };
+    const found = resolveStockItem(sig, APE_ITEMS);
+    expect(found?._market).toBe('COIN');  // 코인을 정확히 집어야 함
+    expect(found?.id).toBe('APE');
+  });
+
+  it('종목 풀에 없으면 null', () => {
+    const sig = { type: SIGNAL_TYPES.VOLUME_ANOMALY, symbol: 'NVDA', market: 'us' };
+    expect(resolveStockItem(sig, ALL_ITEMS)).toBeNull();
+  });
+
+  it('symbol 없거나 빈 배열이면 null', () => {
+    expect(resolveStockItem({ type: SIGNAL_TYPES.VOLUME_ANOMALY }, ALL_ITEMS)).toBeNull();
+    expect(resolveStockItem({ symbol: 'AAPL' }, [])).toBeNull();
+  });
+});
+
+describe('isStockClickable (#343)', () => {
+  it('market 시그널은 allItems 무관하게 false', () => {
+    const fg = { type: SIGNAL_TYPES.FEAR_GREED_SHIFT, symbol: 'crypto', market: 'crypto', kind: 'market' };
+    expect(isStockClickable(fg, ALL_ITEMS)).toBe(false);
+    expect(isStockClickable(fg, [])).toBe(false);
+    expect(isStockClickable(fg)).toBe(false);
+  });
+
+  it('stock + 종목 존재 → true', () => {
+    const sig = { type: SIGNAL_TYPES.VOLUME_ANOMALY, symbol: 'AAPL', market: 'us', kind: 'stock' };
+    expect(isStockClickable(sig, ALL_ITEMS)).toBe(true);
+  });
+
+  it('stock + 빈 배열 → false (drop)', () => {
+    const sig = { type: SIGNAL_TYPES.VOLUME_ANOMALY, symbol: 'AAPL', market: 'us', kind: 'stock' };
+    expect(isStockClickable(sig, [])).toBe(false);
+  });
+
+  it('lookup 미제공(undefined) → true (기존 동작 호환)', () => {
+    const sig = { type: SIGNAL_TYPES.VOLUME_ANOMALY, symbol: 'AAPL', market: 'us', kind: 'stock' };
+    expect(isStockClickable(sig)).toBe(true);
+  });
+
+  it('symbol 없으면 false', () => {
+    expect(isStockClickable({ type: SIGNAL_TYPES.MARKET_MOOD_SHIFT })).toBe(false);
+  });
+});
+
+describe('shouldRenderStockCard (#343)', () => {
+  it('market 시그널은 false', () => {
+    const fg = { type: SIGNAL_TYPES.FEAR_GREED_SHIFT, symbol: 'crypto', market: 'crypto', kind: 'market' };
+    expect(shouldRenderStockCard(fg, ALL_ITEMS)).toBe(false);
+  });
+
+  it('stock + 종목 없음 → false', () => {
+    const sig = { type: SIGNAL_TYPES.VOLUME_ANOMALY, symbol: 'NVDA', market: 'us', kind: 'stock' };
+    expect(shouldRenderStockCard(sig, ALL_ITEMS)).toBe(false);
+  });
+
+  it('stock + 종목 있음 → true', () => {
+    const sig = { type: SIGNAL_TYPES.VOLUME_ANOMALY, symbol: 'AAPL', market: 'us', kind: 'stock' };
+    expect(shouldRenderStockCard(sig, ALL_ITEMS)).toBe(true);
+  });
+});

--- a/src/components/UnifiedFeedPanel.jsx
+++ b/src/components/UnifiedFeedPanel.jsx
@@ -6,7 +6,7 @@ import { useSignals } from '../hooks/useSignals';
 import { extractNewsSignals, getNewsImpact, isBreakingNews, getNewsImpactType } from '../utils/newsSignal';
 import { clusterNews } from '../utils/newsCluster';
 import { extractName, getEasyLabel } from '../utils/signalLabel';
-import { isMarketIndicatorSignal } from '../engine/signalTypes';
+import { isStockClickable } from '../utils/signalStockResolver';
 
 // ─── 피드 타입 태그 색상 ────────────────────────────────────
 const FEED_TAG = {
@@ -94,7 +94,7 @@ function SignalFeedItem({ signal, onItemClick }) {
   // 시장 지표 시그널(FX_IMPACT 'USDKRW', PCR 'SPY', MARKET_MOOD_SHIFT 'MARKET',
   // SECTOR_ROTATION null, CROSS_MARKET_CORRELATION 'leader_lagger', REBALANCING_ALERT 'MARKET' 등)은
   // 종목이 아니므로 ChartSidePanel 라우팅 차단 (#346)
-  const clickable = !!signal.symbol && !isMarketIndicatorSignal(signal);
+  const clickable = isStockClickable(signal);
   // market 정규화: 시그널 엔진은 'crypto'를 사용하지만 ChartSidePanel은 'coin' 기대 — SignalSummaryWidget.jsx:33 패턴 일관
   const market = signal.market === 'crypto' ? 'coin' : signal.market;
   return (

--- a/src/components/home/CommandCenterWidget.jsx
+++ b/src/components/home/CommandCenterWidget.jsx
@@ -6,7 +6,8 @@ import { useWatchlistAlert } from '../../hooks/useWatchlistAlert';
 import { useFearGreedScores } from '../../hooks/useFearGreed';
 import { calcTemperature, calcFallbackTemperature, mergeTemperature } from '../../utils/temperature';
 import { extractName, getEasyLabel } from '../../utils/signalLabel';
-import { TYPE_META, isMarketIndicatorSignal } from '../../engine/signalTypes';
+import { TYPE_META } from '../../engine/signalTypes';
+import { resolveStockItem, isStockClickable, shouldRenderStockCard } from '../../utils/signalStockResolver';
 import MarketIndexSection from './MarketIndexSection';
 import EventTicker from './EventTicker';
 import TickerLogo from './TickerLogo';
@@ -80,15 +81,8 @@ function TemperatureBar({ indices, krwRate, allItems }) {
 // HeroSignalCard — D안 하이브리드: 1위 확장 카드 + 2~3위 컴팩트 행
 // ────────────────────────────────────────────────────────
 
-// allItems에서 시그널 symbol로 종목 데이터 매칭
-function findItemBySignal(signal, allItems) {
-  if (!signal?.symbol || !allItems?.length) return null;
-  // symbol 정확 매칭 + _market 우선 비교
-  return allItems.find(i =>
-    (i.symbol === signal.symbol || i.id === signal.symbol) &&
-    (!signal.market || (i._market || '').toLowerCase() === signal.market)
-  ) || allItems.find(i => i.symbol === signal.symbol || i.id === signal.symbol) || null;
-}
+// market 시그널 최대 동시발화 ~10종이 strength 상위 점유해도 stock 시그널 확보 위한 버퍼 — #343 HeroSignalCard 퇴행 방지
+const HERO_SIGNAL_BUFFER = 20;
 
 // 미니 스파크라인 SVG
 function MiniSparkline({ data, color, width = 80, height = 28 }) {
@@ -109,28 +103,41 @@ function MiniSparkline({ data, color, width = 80, height = 28 }) {
 }
 
 function HeroSignalCard({ onItemClick, allItems, onShowScorecard }) {
-  const topSignals = useTopSignals(3);
+  // HERO_SIGNAL_BUFFER건 받아 종목 검증 통과분만 3건 렌더 — market/종목없음 stock은 카드 자리에서 drop (#343)
+  const rawSignals = useTopSignals(HERO_SIGNAL_BUFFER);
   const { botMap } = useSignalAccuracy();
 
+  // Hero는 종목 카드 전용 자리 — 시장 지표 + 종목 못 찾는 stock은 drop (#343)
+  const topSignals = useMemo(
+    () => rawSignals.filter(s => shouldRenderStockCard(s, allItems)).slice(0, 3),
+    [rawSignals, allItems],
+  );
+
   if (!topSignals.length) {
-    return (
-      <div className="space-y-2.5">
-        <div className="h-16 bg-[#F7F8FA] rounded-[14px] animate-pulse" />
-        <div className="h-14 bg-[#F7F8FA] rounded-[14px] animate-pulse" />
-        <p className="text-[11px] text-[#B0B8C1]">시그널 수집 중...</p>
-      </div>
-    );
+    // rawSignals가 0건 → 진짜 수집 중 (스켈레톤 표시)
+    // rawSignals는 있는데 종목 카드 0건 → market 시그널만 활성인 시간대 — 거짓 "수집 중" 금지 (#343)
+    if (!rawSignals.length) {
+      return (
+        <div className="space-y-2.5">
+          <div className="h-16 bg-[#F7F8FA] rounded-[14px] animate-pulse" />
+          <div className="h-14 bg-[#F7F8FA] rounded-[14px] animate-pulse" />
+          <p className="text-[11px] text-[#B0B8C1]">시그널 수집 중...</p>
+        </div>
+      );
+    }
+    // market 시그널만 있는 시간대 — Hero 영역 미렌더 (null)
+    return null;
   }
 
   const [hero, ...rest] = topSignals;
-  const heroItem = findItemBySignal(hero, allItems);
+  const heroItem = resolveStockItem(hero, allItems);
   const isBullHero = hero.direction === 'bullish';
   const heroBotAccuracy = botMap?.get(hero.type)?.accuracy ?? null;
   const heroAccent = isBullHero ? '#F04452' : '#1764ED';
   const heroBg = isBullHero ? 'rgba(240,68,82,0.03)' : 'rgba(23,100,237,0.03)';
   const heroPct = heroItem ? getPct(heroItem) : null;
-  // 시장 지표 시그널(공포탐욕 등)은 종목이 아니므로 클릭 차단 (#341)
-  const heroClickable = !!hero.symbol && !isMarketIndicatorSignal(hero);
+  // 시장 지표 시그널(공포탐욕 등) + 종목 못 찾는 stock은 클릭 차단 (#341, #343)
+  const heroClickable = isStockClickable(hero, allItems);
 
   // 히어로 아이템 가격 포맷
   const heroPrice = heroItem
@@ -204,7 +211,7 @@ function HeroSignalCard({ onItemClick, allItems, onShowScorecard }) {
 
       {/* 2~3위 시그널 — HotRow 스타일 컴팩트 행 */}
       {rest.map((signal, idx) => {
-        const item = findItemBySignal(signal, allItems);
+        const item = resolveStockItem(signal, allItems);
         const isBull = signal.direction === 'bullish';
         const accent = isBull ? '#F04452' : '#1764ED';
         const pct = item ? getPct(item) : null;
@@ -215,8 +222,8 @@ function HeroSignalCard({ onItemClick, allItems, onShowScorecard }) {
                 ? `₩${fmt(item.price)}`
                 : `$${(item.price ?? 0).toFixed(2)}`)
           : null;
-        // 시장 지표 시그널(공포탐욕 등)은 종목이 아니므로 클릭 차단 (#341)
-        const subClickable = !!signal.symbol && !isMarketIndicatorSignal(signal);
+        // 시장 지표 시그널(공포탐욕 등) + 종목 못 찾는 stock은 클릭 차단 (#341, #343)
+        const subClickable = isStockClickable(signal, allItems);
 
         return (
           <div

--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -166,6 +166,8 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
   const handleClick = useCallback((signal) => {
     // 시장 지표 시그널(공포탐욕 등)은 종목이 아니므로 클릭 차단 (#341)
     if (isMarketIndicatorSignal(signal)) return;
+    // matchedItemMap — crypto→COIN 정규화된 O(1) Map 재사용. null이면 가짜 종목 카드 차단 (#343)
+    if (!matchedItemMap.get(signal.id)) return;
     if (signal.symbol && onItemClick) {
       // market 정규화: 시그널 엔진은 'crypto'를 사용하지만 ChartSidePanel은 'coin' 기대
       const market = signal.market === 'crypto' ? 'coin' : signal.market;
@@ -173,7 +175,7 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
       // type 전달 — 상위 핸들러(handleSignalItemClick)의 시장 지표 안전망 작동용 (#341)
       onItemClick({ symbol: signal.symbol, name: signal.name || signal.symbol, market, type: signal.type });
     }
-  }, [onItemClick]);
+  }, [onItemClick, matchedItemMap]);
 
   // 시그널 카드 펼치기/접기 토글 — 펼칠 때만 이벤트 발화 (StrictMode 안전)
   const handleToggleExpand = useCallback((signal) => {
@@ -356,9 +358,10 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
             const isExpanded = expandedId === signal.id;
             const watchedKey = matchedItem?.id || signal.symbol;
             const marketKey = signal.market === 'crypto' ? 'COIN' : signal.market?.toUpperCase();
-            // 시장 지표 시그널(공포탐욕 등)은 종목이 아니므로 클릭/로고/펼치기 비활성 (#341)
-            const isMarketIndicator = isMarketIndicatorSignal(signal);
-            const isClickable = !!signal.symbol && !isMarketIndicator;
+            // 시장 지표 시그널 + 종목 풀에 없는 stock은 클릭/로고/펼치기 비활성 (#341, #343)
+            // matchedItemMap(crypto→COIN 정규화, O(1))을 재사용 — 로고와 클릭 판정 소스 일치 보장
+            // (market 시그널은 리스트에 정보 행으로 남기고 클릭/로고만 차단)
+            const isClickable = !!signal.symbol && !isMarketIndicatorSignal(signal) && !!matchedItem;
             return (
               <div key={signal.id} className={idx > 0 ? 'border-t border-[#F2F3F5]' : ''}>
                 <button

--- a/src/engine/signalEngine.js
+++ b/src/engine/signalEngine.js
@@ -1,5 +1,5 @@
 // 시그널 엔진 — 시그널 생성/관리/만료/구독
-import { SIGNAL_TYPES, DIRECTIONS, getTTL } from './signalTypes';
+import { SIGNAL_TYPES, DIRECTIONS, getTTL, getSignalKind } from './signalTypes';
 import { THRESHOLDS } from '../constants/signalThresholds';
 
 // ─── 내부 저장소 ────────────────────────────────────────────
@@ -53,6 +53,7 @@ export function createSignal({ type, symbol, name, market, direction, strength, 
   return {
     id: _generateId(),
     type,
+    kind: getSignalKind(type), // 종목/시장 도메인 — 렌더 가드 단일 소스 (#343)
     symbol: symbol ?? null,
     name: name ?? null,
     market: market ?? null,
@@ -951,6 +952,7 @@ export function loadSignals(serverArr) {
     seenIds.add(id);
     _signals.push({
       ...raw,
+      kind: getSignalKind(raw.type), // 서버 kind 무시, type 기준 강제 주입 — 신뢰 원천은 type (#343)
       id,
       timestamp: raw.timestamp || now,
       expiresAt: raw.expiresAt || (now + getTTL(raw.type)),

--- a/src/engine/signalTypes.js
+++ b/src/engine/signalTypes.js
@@ -36,24 +36,97 @@ export const SIGNAL_TYPES = {
   SECTOR_OUTLIER: 'sector_outlier',
 };
 
-// 시장 지표 시그널 — 종목이 아닌 시장 전체/섹터/거시 단위 지표 (#341)
-// symbol 필드에 'crypto'/'us'/'kr' 같은 시장 키가 들어가지만 종목 클릭/카드로 변환 금지.
-// 시그널 보드의 정보성 카드 + 봇 성적표 추적 + 다른 시그널 교차 참조용으로만 사용.
-// 매직 스트링 대신 SIGNAL_TYPES 참조로 일관 — 리네이밍 시 가드 무력화 방지 (architect BLOCK 반영)
-export const MARKET_INDICATOR_TYPES = new Set([
-  SIGNAL_TYPES.FEAR_GREED_SHIFT,        // 공포·탐욕 지수 극단값
-  SIGNAL_TYPES.MARKET_MOOD_SHIFT,       // 국장·미장·코인 전체 심리 전환
-  SIGNAL_TYPES.SECTOR_ROTATION,         // 섹터 단위 — 종목 클릭 의미 X
-  SIGNAL_TYPES.PUT_CALL_RATIO,          // 시장 옵션 PCR
-  SIGNAL_TYPES.FUNDING_RATE_EXTREME,    // 코인 펀딩비 극단
-  SIGNAL_TYPES.FX_IMPACT,               // 환율 충격
-  SIGNAL_TYPES.CROSS_MARKET_CORRELATION,// 시장 간 상관성 변화
-  SIGNAL_TYPES.REBALANCING_ALERT,       // 월말/분기말 기관 리밸런싱 — symbol='MARKET' 가짜 종목 카드 방지 (#346)
-]);
+// ── 시그널 도메인(kind) 단일 소스 — type → 'stock' | 'market' (#343) ──
+// 모든 시그널 타입은 종목(stock)이거나 시장 지표(market) 중 하나로 분류된다.
+// stock: 개별 종목 단위 — 종목 카드/클릭/차트 라우팅 대상.
+// market: 시장 전체/섹터/거시 단위 — symbol 필드에 'crypto'/'MARKET'/'USDKRW' 등이 들어가지만
+//         종목 클릭/카드 변환 금지. 시그널 보드 정보 행 + 봇 성적표 추적 + 교차 참조용.
+// createSignal/loadSignals가 이 맵으로 signal.kind를 자동 주입한다 (단일 소스).
+export const SIGNAL_KIND = {
+  // ── stock (개별 종목) ──
+  [SIGNAL_TYPES.FOREIGN_CONSECUTIVE_BUY]: 'stock',
+  [SIGNAL_TYPES.FOREIGN_CONSECUTIVE_SELL]: 'stock',
+  [SIGNAL_TYPES.INSTITUTIONAL_CONSECUTIVE_BUY]: 'stock',
+  [SIGNAL_TYPES.INSTITUTIONAL_CONSECUTIVE_SELL]: 'stock',
+  [SIGNAL_TYPES.VOLUME_ANOMALY]: 'stock',
+  [SIGNAL_TYPES.NEWS_SENTIMENT_CLUSTER]: 'stock',   // 종목 단위 생성
+  [SIGNAL_TYPES.ORDER_FLOW_IMBALANCE]: 'stock',
+  [SIGNAL_TYPES.VWAP_DEVIATION]: 'stock',
+  [SIGNAL_TYPES.SOCIAL_SENTIMENT]: 'stock',
+  [SIGNAL_TYPES.SENTIMENT_DIVERGENCE]: 'stock',
+  [SIGNAL_TYPES.SMART_MONEY_FLOW]: 'stock',
+  [SIGNAL_TYPES.MOMENTUM_DIVERGENCE]: 'stock',
+  [SIGNAL_TYPES.VOLUME_PRICE_DIVERGENCE]: 'stock',
+  [SIGNAL_TYPES.COMPOSITE_SCORE]: 'stock',          // 종목 복합 점수
+  [SIGNAL_TYPES.GAP_ANALYSIS]: 'stock',
+  [SIGNAL_TYPES.CAPITULATION]: 'stock',
+  [SIGNAL_TYPES.STEALTH_ACTIVITY]: 'stock',
+  [SIGNAL_TYPES.BTC_LEADING]: 'stock',
+  [SIGNAL_TYPES.SUPPORT_RESISTANCE_BREAK]: 'stock',
+  [SIGNAL_TYPES.DOUBLE_BOTTOM]: 'stock',
+  [SIGNAL_TYPES.RECOVERY_DETECTION]: 'stock',
+  [SIGNAL_TYPES.SECTOR_OUTLIER]: 'stock',           // 개별 종목의 섹터 이탈 (vs SECTOR_ROTATION)
+  // ── market (시장 지표) — 기존 #341/#346 분류 유지 ──
+  [SIGNAL_TYPES.FEAR_GREED_SHIFT]: 'market',        // 공포·탐욕 지수 극단값
+  [SIGNAL_TYPES.MARKET_MOOD_SHIFT]: 'market',       // 국장·미장·코인 전체 심리 전환
+  [SIGNAL_TYPES.SECTOR_ROTATION]: 'market',         // 섹터 단위 — 종목 클릭 의미 X
+  [SIGNAL_TYPES.PUT_CALL_RATIO]: 'market',          // 시장 옵션 PCR
+  [SIGNAL_TYPES.FUNDING_RATE_EXTREME]: 'market',    // 코인 펀딩비 극단
+  [SIGNAL_TYPES.FX_IMPACT]: 'market',               // 환율 충격
+  [SIGNAL_TYPES.CROSS_MARKET_CORRELATION]: 'market',// 시장 간 상관성 변화
+  [SIGNAL_TYPES.REBALANCING_ALERT]: 'market',       // 월말/분기말 기관 리밸런싱 — symbol='MARKET' 가짜 종목 카드 방지 (#346)
+};
 
-/** 시그널이 시장 지표(종목 아님) 타입인지 검사 — 종목 클릭 핸들러에서 차단용 (#341) */
+// SIGNAL_KIND 완전성 런타임 검증 (#343)
+// ⚠️ `vite build`는 이 IIFE를 실행하지 않아 누락을 잡지 못한다.
+// 발견/차단 경로:
+//   ① npm run test (vitest) — signalTypes import 순간 throw → 테스트 실패.
+//      개발 중 + `npm run ship`(lint && test && build && gate) 체인에서 차단된다.
+//      ⚠️ 단 배포 게이트 pre-deploy-consensus.sh(L95-100)는 test 실패를 "경고만" 하고
+//      배포를 막지 않는다 → 자동 배포 차단은 보장되지 않음 (게이트 강화는 별도 이슈). [Copilot PR#348 반영]
+//   ② 런타임 모듈 로드 시 즉시 크래시 (fail-fast) — "가짜 종목 카드 = 신뢰 위반 = P0"
+//      철학상 의도적 설계. 누락된 채로 서비스가 뜨는 상황을 원천 차단한다.
+// 신규 시그널 타입 추가 시 SIGNAL_KIND에 등록 필수.
+(function assertSignalKindComplete() {
+  const missing = [];
+  const invalid = [];
+  for (const type of Object.values(SIGNAL_TYPES)) {
+    const kind = SIGNAL_KIND[type];
+    if (kind === undefined) missing.push(type);
+    else if (kind !== 'stock' && kind !== 'market') invalid.push(`${type}=${kind}`);
+  }
+  if (missing.length || invalid.length) {
+    throw new Error(
+      `[#343] SIGNAL_KIND 불완전 — 모든 시그널 타입은 'stock' 또는 'market'으로 분류돼야 합니다.\n` +
+      (missing.length ? `  누락: ${missing.join(', ')}\n` : '') +
+      (invalid.length ? `  잘못된 값: ${invalid.join(', ')}\n` : '') +
+      `  해결: src/engine/signalTypes.js의 SIGNAL_KIND 맵에 위 타입을 추가하세요.`,
+    );
+  }
+})();
+
+/** 시그널 타입의 도메인(kind) 조회 — 미등록 타입은 'stock' 기본 (#343) */
+export function getSignalKind(type) {
+  return SIGNAL_KIND[type] === 'market' ? 'market' : 'stock';
+}
+
+// 시장 지표 시그널 타입 집합 — SIGNAL_KIND에서 파생 (수동 관리 종료, 하위호환 export 유지) (#343)
+// 종목이 아닌 시장 전체/섹터/거시 단위 지표 (#341). 종목 클릭/카드로 변환 금지.
+export const MARKET_INDICATOR_TYPES = new Set(
+  Object.entries(SIGNAL_KIND)
+    .filter(([, kind]) => kind === 'market')
+    .map(([type]) => type),
+);
+
+/**
+ * 시그널이 시장 지표(종목 아님)인지 검사 — 종목 클릭 핸들러에서 차단용 (#341, #343)
+ * kind 필드가 있으면 우선 사용(signal.kind==='market'), 없으면 type 기반 레거시 fallback.
+ */
 export function isMarketIndicatorSignal(signal) {
-  return !!signal && MARKET_INDICATOR_TYPES.has(signal.type);
+  if (!signal) return false;
+  if (signal.kind === 'market') return true;
+  if (signal.kind === 'stock') return false;
+  return MARKET_INDICATOR_TYPES.has(signal.type);
 }
 
 // 시그널 방향

--- a/src/utils/signalStockResolver.js
+++ b/src/utils/signalStockResolver.js
@@ -1,0 +1,26 @@
+// 시그널 → 종목 카드 렌더 판정 공통 유틸 (#343)
+import { isMarketIndicatorSignal } from '../engine/signalTypes';
+
+export function resolveStockItem(signal, allItems) {
+  if (!signal?.symbol || !Array.isArray(allItems) || allItems.length === 0) return null;
+  const sym = signal.symbol;
+  // crypto→coin 정규화 — 시그널 엔진은 'crypto', 종목 _market은 'COIN'(소문자 비교 시 'coin') (#343)
+  const mkt = signal.market === 'crypto' ? 'coin' : signal.market;
+  return (
+    allItems.find((i) => (i.symbol === sym || i.id === sym) && (!mkt || (i._market || '').toLowerCase() === mkt)) ||
+    allItems.find((i) => i.symbol === sym || i.id === sym) ||
+    null
+  );
+}
+
+export function isStockClickable(signal, allItems) {
+  if (!signal?.symbol) return false;
+  if (isMarketIndicatorSignal(signal)) return false; // kind:'market' 차단(kind 우선)
+  if (allItems == null) return true;                  // undefined/null 모두 lookup 미제공 → 기존 동작
+  return resolveStockItem(signal, allItems) !== null; // 실제 종목 존재해야 클릭 가능
+}
+
+export function shouldRenderStockCard(signal, allItems) {
+  if (isMarketIndicatorSignal(signal)) return false;
+  return resolveStockItem(signal, allItems) !== null;
+}


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-3.1-pro-preview)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #343

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 신호 타입 분류 및 처리 로직에 대한 종합 회귀 테스트 추가
  * 종목 매칭 및 클릭 가능 여부 판정에 대한 단위 테스트 추가

* **버그 수정**
  * 시장 지표 신호와 종목 미매칭 케이스에 대한 카드 클릭 차단 처리 강화
  * 신호 유형 분류 시스템 개선으로 일관된 신호 처리 보장
  * 히어로 신호 카드에서 렌더링 가능한 종목만 표시하도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->