### PR TITLE
fix(#344): US marketCap 폴링 머지 가드 — 회전율 사각지대 해소

### DIFF
--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -92,13 +92,16 @@ export function usePrices() {
               // sector/nameEn 메타 보존 — API가 새 값을 주면 업데이트, null/undefined일 때만 기존 유지
               const sector = u.sector ?? old.sector ?? US_META_MAP.get(u.symbol)?.sector;
               const nameEn = u.nameEn ?? old.nameEn ?? US_META_MAP.get(u.symbol)?.nameEn;
+              // marketCap 보존 — us-price 폴링은 marketCap:0만 주므로, 스냅샷(update-us NASDAQ 수집)의
+              // 정상값을 0으로 덮지 않게 가드. 회전율(leadingStocks turnoverRatio) 사각지대 방지 (#344)
+              const marketCap = Number(u.marketCap) > 0 ? u.marketCap : old.marketCap;
               // sparkline 배열 참조 안정화 — 마지막 값이 같으면 기존 참조 유지 (Sparkline memo 최적화)
               const newSparkline = u.sparkline?.length ? u.sparkline : old.sparkline;
               const oldSparkline = old.sparkline;
               const stableSparkline = (oldSparkline?.length === newSparkline?.length &&
                 oldSparkline?.[oldSparkline.length - 1] === newSparkline?.[newSparkline.length - 1])
                 ? oldSparkline : newSparkline;
-              map.set(u.symbol, { ...old, ...u, sector, nameEn, sparkline: stableSparkline });
+              map.set(u.symbol, { ...old, ...u, marketCap, sector, nameEn, sparkline: stableSparkline });
             } else {
               // 신규 심볼 — US_STOCK_LIST 메타(sector, nameEn) 반영
               const meta = US_META_MAP.get(u.symbol) ?? {};


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-3.1-pro-preview)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #344

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * US 종목의 시가총액 데이터가 0으로 덮어씌워지는 현상 해결
  * 종목 정보 병합 로직 개선으로 시가총액 값 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->