### PR TITLE
fix(#345): data-trust 정합성 P2 6건 — ₩0/$0·거짓 알람·정렬·뉴스 오분류·펀딩비 클릭

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -179,10 +179,11 @@ export default function App() {
     clearTimeout(titleTimerRef.current);
     titleTimerRef.current = setTimeout(() => {
       const all = [
-        ...krStocks.map(s => ({ name: s.name || s.symbol, pct: s.changePct ?? 0 })),
-        ...usStocks.map(s => ({ name: s.name || s.symbol, pct: s.changePct ?? 0 })),
-        ...coins.map(c =>   ({ name: c.name  || c.symbol, pct: c.change24h ?? 0 })),
-      ].sort((a, b) => Math.abs(b.pct) - Math.abs(a.pct));
+        ...krStocks.map(s => ({ name: s.name || s.symbol, pct: s.changePct })),
+        ...usStocks.map(s => ({ name: s.name || s.symbol, pct: s.changePct })),
+        ...coins.map(c =>   ({ name: c.name  || c.symbol, pct: c.change24h })),
+      ].filter(x => Number.isFinite(x.pct))
+       .sort((a, b) => Math.abs(b.pct) - Math.abs(a.pct));
       const top = all[0];
       if (top?.pct >= 3)       document.title = `⚡ ${top.name} +${top.pct.toFixed(1)}% — 마켓레이더`;
       else if (top?.pct <= -3) document.title = `📉 ${top.name} ${top.pct.toFixed(1)}% — 마켓레이더`;

--- a/src/__tests__/marketIndicatorSignal.test.js
+++ b/src/__tests__/marketIndicatorSignal.test.js
@@ -7,7 +7,7 @@ import {
   MARKET_INDICATOR_TYPES,
   isMarketIndicatorSignal,
 } from '../engine/signalTypes.js';
-import { isStockClickable } from '../utils/signalStockResolver.js';
+import { isStockClickable, shouldRenderStockCard } from '../utils/signalStockResolver.js';
 
 describe('isMarketIndicatorSignal (#341)', () => {
   it('FEAR_GREED_SHIFT 타입은 시장 지표로 식별', () => {
@@ -131,5 +131,40 @@ describe('시그널 클릭 가드 시뮬레이션 (#341)', () => {
     expect(isClickableAsStock(fxSignal)).toBe(false);
     // #343 — 공통 유틸 isStockClickable(lookup 미제공)도 동일 차단 (UnifiedFeedPanel 실제 사용 형태)
     expect(isStockClickable(fxSignal)).toBe(false);
+  });
+});
+
+// #345 — FUNDING_RATE_EXTREME 클릭 예외: 시장 지표지만 코인 종목(BTC)으로 라우팅 가능.
+// signalTypes.js의 kind는 'market' 유지(가짜 종목 카드 방지) — isStockClickable만 화이트셋 예외.
+describe('FUNDING_RATE_EXTREME 클릭 예외 (#345)', () => {
+  const fundingSignal = {
+    id: 'sig_test_funding',
+    type: SIGNAL_TYPES.FUNDING_RATE_EXTREME,
+    symbol: 'BTC',
+    name: 'BTC 펀딩비',
+    market: 'crypto',
+    direction: 'bearish',
+    strength: 4,
+  };
+
+  it('실제 BTC 종목이 풀에 있으면 클릭 가능 (crypto→coin 정규화)', () => {
+    expect(isStockClickable(fundingSignal, [{ symbol: 'BTC', _market: 'COIN' }])).toBe(true);
+  });
+
+  it('종목 풀이 비어 있으면 클릭 불가 (lookup 실패)', () => {
+    expect(isStockClickable(fundingSignal, [])).toBe(false);
+  });
+
+  it('lookup 미제공(allItems 없음)이면 보수적 차단', () => {
+    expect(isStockClickable(fundingSignal)).toBe(false);
+  });
+
+  it('펀딩비는 종목 카드 렌더는 여전히 차단 (클릭만 허용, 카드 X)', () => {
+    expect(shouldRenderStockCard(fundingSignal, [{ symbol: 'BTC', _market: 'COIN' }])).toBe(false);
+  });
+
+  it('FX_IMPACT는 화이트셋 아님 — 종목 풀 있어도 클릭 불가 (불변)', () => {
+    const fxSignal = { type: SIGNAL_TYPES.FX_IMPACT, symbol: 'USDKRW', market: 'kr' };
+    expect(isStockClickable(fxSignal, [{ symbol: 'USDKRW', _market: 'KR' }])).toBe(false);
   });
 });

--- a/src/__tests__/newsAlias.test.js
+++ b/src/__tests__/newsAlias.test.js
@@ -1,0 +1,41 @@
+// #345 — getMatchConfidence 단어 경계 매칭 회귀 테스트
+// substring(includes) → matchesKeywords(단어 경계) 전환 후, 짧은 심볼(arm 등)이
+// 다른 단어의 부분 문자열로 잘못 DIRECT 승격되던 오분류가 차단되는지 검증.
+import { describe, it, expect } from 'vitest';
+import { getMatchConfidence, buildStockKeywords } from '../utils/newsAlias.js';
+
+describe('getMatchConfidence 단어 경계 매칭 (#345)', () => {
+  const armKeys = buildStockKeywords('ARM', 'ARM Holdings', 'US'); // ['arm','arm holdings','arm chip']
+  const aaplKeys = buildStockKeywords('AAPL', 'Apple Inc', 'US');  // ['aapl','apple','애플']
+
+  it('심볼 직접 언급은 DIRECT', () => {
+    expect(getMatchConfidence('AAPL 신제품 출시', aaplKeys, 'AAPL')).toBe('DIRECT');
+    expect(getMatchConfidence('ARM 신제품 발표', armKeys, 'ARM')).toBe('DIRECT');
+  });
+
+  it('짧은 심볼이 다른 단어의 부분 문자열이면 DIRECT 오분류 차단 (arm ⊄ warm)', () => {
+    // 과거 substring: 'warm'.includes('arm') → DIRECT 오분류
+    // 단어 경계: 'arm'이 독립 단어가 아니므로 WEAK
+    expect(getMatchConfidence('글로벌 warm 트렌드 분석', armKeys, 'ARM')).toBe('WEAK');
+  });
+
+  it('한국어 별칭(slice(2) 키워드)은 SECTOR 등급', () => {
+    // '애플'은 keywords[2] → directKeys(symbol+slice(0,2))에 미포함 → SECTOR
+    expect(getMatchConfidence('애플 신제품 발표', aaplKeys, 'AAPL')).toBe('SECTOR');
+  });
+
+  it('섹터 키워드(유가 등)는 SECTOR', () => {
+    const xomKeys = buildStockKeywords('XOM', 'Exxon Mobil', 'US');
+    expect(getMatchConfidence('국제 유가 급등', xomKeys, 'XOM')).toBe('SECTOR');
+  });
+
+  it('관련 없는 제목은 WEAK', () => {
+    expect(getMatchConfidence('부동산 시장 전망', aaplKeys, 'AAPL')).toBe('WEAK');
+  });
+
+  it('빈/null 입력에 안전 (WEAK 반환, throw 없음)', () => {
+    expect(getMatchConfidence('', aaplKeys, 'AAPL')).toBe('WEAK');
+    expect(getMatchConfidence(null, aaplKeys, 'AAPL')).toBe('WEAK');
+    expect(getMatchConfidence('아무 제목', [], undefined)).toBe('WEAK');
+  });
+});

--- a/src/components/DataHealthBadge.jsx
+++ b/src/components/DataHealthBadge.jsx
@@ -14,7 +14,7 @@ export default function DataHealthBadge({ dataErrors = {}, coinError = false }) 
     issues.push('미국 시세 일부 지연');
   }
   if (coinError) issues.push('코인 시세 일부 지연');
-  if (serverMeta.stale) issues.push('시그널 업데이트 지연');
+  if (serverMeta.stale) issues.push('시그널 업데이트 지연 — 최신 아님');
 
   if (!issues.length) return null;
 

--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -23,9 +23,13 @@ function getPrice(item, krwRate) {
     if (p < 100) return `₩${fmt(p, 2)}`;
     return `₩${fmt(Math.round(p))}`;
   }
-  if (item.market === 'kr') return `₩${fmt(item.price)}`;
-  if (item.market === 'us') return `₩${fmt(Math.round((item.price ?? 0) * krwRate))}`;
-  return `₩${fmt(item.price)}`;
+  if (item.market === 'kr') return Number.isFinite(item.price) ? `₩${fmt(item.price)}` : '—';
+  if (item.market === 'us') {
+    return Number.isFinite(item.price) && Number.isFinite(krwRate)
+      ? `₩${fmt(Math.round(item.price * krwRate))}`
+      : '—';
+  }
+  return Number.isFinite(item.price) ? `₩${fmt(item.price)}` : '—';
 }
 
 const MARKET_LABEL = { kr: '국내', us: '미장', coin: '코인', etf: 'ETF' };

--- a/src/components/MarketSummaryBar.jsx
+++ b/src/components/MarketSummaryBar.jsx
@@ -114,7 +114,7 @@ export default function MarketSummaryBar({ indices = [], krwRate = DEFAULT_KRW_R
           <span className="text-[10px] text-[#8B95A1] font-medium">USD/KRW</span>
         </div>
         <div className="text-[17px] font-bold text-[#191F28] tabular-nums font-mono">
-          ₩{' '}{(krwRate || 0).toLocaleString('ko-KR')}
+          ₩{' '}{Number.isFinite(krwRate) ? krwRate.toLocaleString('ko-KR') : '—'}
         </div>
       </div>
     </div>

--- a/src/components/NewsSidePanel.jsx
+++ b/src/components/NewsSidePanel.jsx
@@ -45,11 +45,16 @@ function RelatedRow({ item, krwRate, onItemClick }) {
   const isDown = pct < 0;
   const color = isUp ? '#F04452' : isDown ? '#1764ED' : '#8B95A1';
 
+  const coinKrw = Number.isFinite(item.priceKrw)
+    ? item.priceKrw
+    : Number.isFinite(item.priceUsd)
+      ? item.priceUsd * (krwRate || DEFAULT_KRW_RATE)
+      : NaN;
   const price = isCoin
-    ? `₩${fmt(Math.round(item.priceKrw || (item.priceUsd ?? 0) * (krwRate || DEFAULT_KRW_RATE)))}`
+    ? (Number.isFinite(coinKrw) ? `₩${fmt(Math.round(coinKrw))}` : '—')
     : item._market === 'KR' || item.market === 'kr'
       ? `₩${fmt(item.price)}`
-      : `$${(item.price ?? 0).toFixed(2)}`;
+      : Number.isFinite(item.price) ? `$${item.price.toFixed(2)}` : '—';
 
   const mktBadge = isCoin
     ? { label: 'COIN', bg: '#FFF4E6', color: '#FF9500' }

--- a/src/utils/newsAlias.js
+++ b/src/utils/newsAlias.js
@@ -292,18 +292,14 @@ function escapeRe(s) {
 
 // ─── 뉴스 매칭 신뢰도 등급 ─────────────────────────────────
 // DIRECT: 심볼/종목명 직접 언급, SECTOR: 섹터 키워드 매칭, WEAK: 약한 매칭
+// substring(includes) 대신 matchesKeywords(단어 경계)를 재사용 — 짧은 심볼(arm, op 등)이
+// 다른 단어의 부분 문자열로 잘못 DIRECT 승격되는 오분류 차단 (#345)
 export function getMatchConfidence(title, keywords, symbol) {
   const t = (title || '').toLowerCase();
-  // DIRECT: 심볼 또는 주요 키워드(처음 2개) 직접 매칭
-  if (
-    (symbol && t.includes(symbol.toLowerCase())) ||
-    keywords.slice(0, 2).some(k => t.includes(k.toLowerCase()))
-  ) {
-    return 'DIRECT';
-  }
-  // SECTOR: 나머지 키워드(섹터/별칭) 매칭
-  if (keywords.slice(2).some(k => t.includes(k.toLowerCase()))) {
-    return 'SECTOR';
-  }
+  // DIRECT: 심볼 또는 주요 키워드(처음 2개) 단어 경계 매칭
+  const directKeys = [...(symbol ? [symbol.toLowerCase()] : []), ...keywords.slice(0, 2)];
+  if (matchesKeywords(t, directKeys)) return 'DIRECT';
+  // SECTOR: 나머지 키워드(섹터/별칭) 단어 경계 매칭
+  if (matchesKeywords(t, keywords.slice(2))) return 'SECTOR';
   return 'WEAK';
 }

--- a/src/utils/priceAlert.js
+++ b/src/utils/priceAlert.js
@@ -127,11 +127,11 @@ export function checkAndAlert(item, type) {
 
   let priceStr = '';
   if (type === 'kr') {
-    priceStr = `₩${(item.price ?? 0).toLocaleString()}`;
-  } else if (type === 'coin' && item.priceKrw) {
+    priceStr = Number.isFinite(item.price) ? `₩${item.price.toLocaleString()}` : '—';
+  } else if (type === 'coin' && Number.isFinite(item.priceKrw)) {
     priceStr = `₩${Math.round(item.priceKrw).toLocaleString()}`;
   } else {
-    priceStr = `$${(item.price ?? 0).toLocaleString()}`;
+    priceStr = Number.isFinite(item.price) ? `$${item.price.toLocaleString()}` : '—';
   }
 
   sendAlert(
@@ -152,13 +152,16 @@ export function checkAndAlertBatch(items, type, krwRate = 1400) {
   const watched = items.filter(i => _watchlistIds.has(i.id) || _watchlistIds.has(i.symbol));
   watched.forEach(item => {
     checkAndAlert(item, type);
-    // 목표가 알림: 현재가를 KRW로 변환 후 체크
+    // 목표가 알림: 현재가를 KRW로 변환 후 체크 — 유효 가격일 때만 발화 (₩0 거짓 알람 차단)
+    const priceUsd = item.priceUsd;
     const currentKrwPrice = item.id
-      ? (item.priceKrw || (item.priceUsd ?? 0) * krwRate)
+      ? (item.priceKrw ?? (Number.isFinite(priceUsd) ? priceUsd * krwRate : NaN))
       : item.market === 'us'
-        ? (item.price ?? 0) * krwRate
-        : (item.price ?? 0);
-    checkTargetAlertForItem(item, type, currentKrwPrice);
+        ? (Number.isFinite(item.price) ? item.price * krwRate : NaN)
+        : item.price;
+    if (Number.isFinite(currentKrwPrice) && currentKrwPrice > 0) {
+      checkTargetAlertForItem(item, type, currentKrwPrice);
+    }
   });
 }
 

--- a/src/utils/signalStockResolver.js
+++ b/src/utils/signalStockResolver.js
@@ -1,5 +1,9 @@
 // 시그널 → 종목 카드 렌더 판정 공통 유틸 (#343)
-import { isMarketIndicatorSignal } from '../engine/signalTypes';
+import { isMarketIndicatorSignal, SIGNAL_TYPES } from '../engine/signalTypes';
+
+// 시장 지표지만 클릭은 허용하는 예외 타입 — 펀딩비는 코인 종목(BTC 등)으로 라우팅 가능 (#345)
+// signalTypes.js의 kind 분류는 'market' 유지(가짜 종목 카드 방지), 클릭 가드만 예외 처리.
+const MARKET_BUT_CLICKABLE = new Set([SIGNAL_TYPES.FUNDING_RATE_EXTREME]);
 
 export function resolveStockItem(signal, allItems) {
   if (!signal?.symbol || !Array.isArray(allItems) || allItems.length === 0) return null;
@@ -15,9 +19,10 @@ export function resolveStockItem(signal, allItems) {
 
 export function isStockClickable(signal, allItems) {
   if (!signal?.symbol) return false;
-  if (isMarketIndicatorSignal(signal)) return false; // kind:'market' 차단(kind 우선)
-  if (allItems == null) return true;                  // undefined/null 모두 lookup 미제공 → 기존 동작
-  return resolveStockItem(signal, allItems) !== null; // 실제 종목 존재해야 클릭 가능
+  // 시장 지표는 차단. 단 화이트셋(펀딩비 등)은 예외 — 코인 종목으로 라우팅 가능 (#345)
+  if (isMarketIndicatorSignal(signal) && !MARKET_BUT_CLICKABLE.has(signal.type)) return false;
+  if (allItems == null) return !isMarketIndicatorSignal(signal); // lookup 미제공 시 시장 지표는 보수적 차단
+  return resolveStockItem(signal, allItems) !== null;            // 실제 종목 존재해야 클릭 가능
 }
 
 export function shouldRenderStockCard(signal, allItems) {


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-3.1-pro-preview)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #345

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 상위 변동폭 종목 계산에서 유효하지 않은 데이터 필터링 강화
  * 뉴스 별칭 매칭 정확도 개선으로 오분류 방지
  * 가격 및 환율 표시에서 유효하지 않은 값이 0으로 표시되는 문제 해결
  * 시장 지표 신호 라우팅 예외 처리 추가

* **테스트**
  * 신호 라우팅 동작에 대한 회귀 테스트 추가
  * 뉴스 별칭 단어 경계 매칭 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->