### PR TITLE
feat(#358): 시장 레짐 배지 — 하락장/혼조/상승장 컨텍스트

### DIFF
--- a/src/__tests__/marketRegime.test.js
+++ b/src/__tests__/marketRegime.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { computeMarketRegime, REGIME_THRESHOLD } from '../utils/marketRegime.js';
+
+const idx = (id, changePct) => ({ id, changePct });
+
+describe('computeMarketRegime', () => {
+  it('주식 지수 평균 ≤ -2% → 하락장', () => {
+    const r = computeMarketRegime([
+      idx('KOSPI', -5.5), idx('KOSDAQ', -4.5), idx('NDX', -2.6), idx('DJI', -1.3),
+    ]);
+    expect(r.regime).toBe('down');
+    expect(r.label).toBe('하락장');
+    expect(r.avg).toBeLessThan(0);
+  });
+
+  it('주식 지수 평균 ≥ +2% → 상승장', () => {
+    const r = computeMarketRegime([idx('KOSPI', 3), idx('SPX', 2.5)]);
+    expect(r.regime).toBe('up');
+    expect(r.label).toBe('상승장');
+  });
+
+  it('±2% 이내 → 혼조', () => {
+    const r = computeMarketRegime([idx('KOSPI', 0.5), idx('NDX', -0.8)]);
+    expect(r.regime).toBe('mixed');
+    expect(r.label).toBe('혼조');
+  });
+
+  it('DXY(달러인덱스)는 평균에서 제외 — 주식 지수만', () => {
+    // 주식 KOSPI -5는 하락장이지만 DXY +10이 섞이면 평균이 왜곡됨 → DXY 제외 확인
+    const r = computeMarketRegime([idx('KOSPI', -5), idx('NDX', -5), idx('DXY', 10)]);
+    expect(r.regime).toBe('down');
+    expect(r.avg).toBe(-5); // (-5 + -5) / 2, DXY 미포함
+  });
+
+  it('유효 주식 지수 없음 → null (빈 데이터로 가짜 혼조 방지)', () => {
+    expect(computeMarketRegime([])).toBeNull();
+    expect(computeMarketRegime([idx('DXY', 1)])).toBeNull();
+    expect(computeMarketRegime([idx('KOSPI', NaN)])).toBeNull();
+    expect(computeMarketRegime(null)).toBeNull();
+    expect(computeMarketRegime(undefined)).toBeNull();
+  });
+
+  it('changePct null/빈문자열/false는 0으로 강제변환되지 않고 제외 (계약: 가짜 혼조 방지)', () => {
+    // null 단독 → 유효값 없음 → null (Number(null)===0으로 혼조가 되면 안 됨)
+    expect(computeMarketRegime([idx('KOSPI', null)])).toBeNull();
+    expect(computeMarketRegime([idx('KOSPI', '')])).toBeNull();
+    expect(computeMarketRegime([idx('KOSPI', false)])).toBeNull();
+    // 하락 지수 + null 지수 → null은 평균에서 제외, 하락장 유지(0%로 희석 금지)
+    const r = computeMarketRegime([idx('KOSPI', -6), idx('KOSDAQ', null)]);
+    expect(r.regime).toBe('down');
+    expect(r.avg).toBe(-6);
+  });
+
+  it('경계값 정확히 -2% → 하락장 (≤ 경계 포함)', () => {
+    expect(computeMarketRegime([idx('KOSPI', -REGIME_THRESHOLD)]).regime).toBe('down');
+    expect(computeMarketRegime([idx('KOSPI', REGIME_THRESHOLD)]).regime).toBe('up');
+  });
+
+  it('일부 지수 changePct 누락 시 유효값만 평균', () => {
+    const r = computeMarketRegime([idx('KOSPI', -4), idx('KOSDAQ', undefined), idx('NDX', -2)]);
+    expect(r.avg).toBe(-3); // (-4 + -2) / 2
+    expect(r.regime).toBe('down');
+  });
+});

--- a/src/components/home/CommandCenterWidget.jsx
+++ b/src/components/home/CommandCenterWidget.jsx
@@ -11,6 +11,7 @@ import { resolveStockItem, isStockClickable, shouldRenderStockCard } from '../..
 import MarketIndexSection from './MarketIndexSection';
 import EventTicker from './EventTicker';
 import TickerLogo from './TickerLogo';
+import RegimeBadge from './RegimeBadge';
 import { getPct, fmt } from './utils';
 
 // ── 게이지 존 스타일 (5단계) — MarketSentimentWidget에서 재사용 ──
@@ -44,6 +45,8 @@ function TemperatureBar({ indices, krwRate, allItems }) {
       {/* 온도 바 — 인라인 수평 */}
       <div className="flex items-center gap-3">
         <span className="text-[13px] font-semibold text-[#4E5968] flex-shrink-0">시장 온도</span>
+        {/* 시장 레짐 배지 — 지수 평균으로 하락장/혼조/상승장 맥락 (#358) */}
+        <RegimeBadge indices={indices} />
         <div className="flex-1 h-1.5 rounded-[3px] overflow-hidden" style={{ background: 'rgba(23,100,237,0.10)' }}>
           {isPending
             ? <div className="h-full w-full rounded-[3px] bg-[#E5E8EB] animate-pulse" />

--- a/src/components/home/MorphingFocusSection.jsx
+++ b/src/components/home/MorphingFocusSection.jsx
@@ -15,6 +15,7 @@ import { findRelatedNews } from './utils';
 import { itemKey } from '../../utils/symbolKey';
 import { hasLiveExtended, extendedBadgeLabel } from '../../utils/extendedPrice';
 import TickerLogo from './TickerLogo';
+import RegimeBadge from './RegimeBadge';
 
 // ─── 색상 토큰 (한국식: 빨강 상승 / 파랑 하락) ───────────────────
 const UP = '#F04452';
@@ -299,10 +300,12 @@ function BridgeLine({ bridge }) {
 }
 
 // ─── 헤더 (모드별 타이틀 + 서브) ─────────────────────────────────
-function SectionHeader({ title, subtitle, themeDir }) {
+function SectionHeader({ title, subtitle, themeDir, indices }) {
   return (
     <div className="mb-3">
-      <h2 className="text-[19px] font-bold text-[#191F28] dark:text-[#E5E8EB] tracking-tight flex items-center gap-1.5">
+      <h2 className="text-[19px] font-bold text-[#191F28] dark:text-[#E5E8EB] tracking-tight flex items-center gap-1.5 flex-wrap">
+        {/* 시장 레짐 배지 — 하락장/혼조/상승장 맥락 (#358). null 가드는 RegimeBadge 내부 단일 처리 */}
+        <RegimeBadge indices={indices} showAvg={false} />
         {title}
         {themeDir != null && (
           <span className="text-[15px]" style={{ color: themeDir >= 0 ? UP : DOWN }}>
@@ -394,6 +397,7 @@ export default function MorphingFocusSection({
             title={`지금 주도 테마 ─ ${primaryTheme.theme}`}
             subtitle={mode === MORPH_MODE.KR_LEAD ? '국내 장중 · 거래 쏠림 기준' : '미국 장중 · 거래 쏠림 기준'}
             themeDir={themeDir}
+            indices={indices}
           />
           <SessionBar primaryStatus={primaryStatus} secondaryStatus={secondaryStatus} clockLabel={clockLabel} />
           <FocusLeadCard
@@ -422,7 +426,7 @@ export default function MorphingFocusSection({
       const rest = movers.slice(1, 4);
       return (
         <Shell>
-          <SectionHeader title="주목할 종목" subtitle="지금 시장에서 눈여겨볼 움직임" />
+          <SectionHeader title="주목할 종목" subtitle="지금 시장에서 눈여겨볼 움직임" indices={indices} />
           <SessionBar primaryStatus={primaryStatus} secondaryStatus={secondaryStatus} clockLabel={clockLabel} />
           <FocusLeadCard
             item={lead} pct={movers[0].pct} newsCount={movers[0].newsCount}
@@ -455,7 +459,7 @@ export default function MorphingFocusSection({
       : (krStatus.label || '시간외');
     return (
       <Shell>
-        <SectionHeader title={`지금 주목 · ${sessionWord}`} subtitle="정규장 밖 — 어제 마감 대비 움직임" />
+        <SectionHeader title={`지금 주목 · ${sessionWord}`} subtitle="정규장 밖 — 어제 마감 대비 움직임" indices={indices} />
         <SessionBar primaryStatus={primaryStatus} secondaryStatus={secondaryStatus} clockLabel={clockLabel} />
         <FocusLeadCard
           item={lead.item} pct={lead.pct} newsCount={lead.newsCount}
@@ -483,7 +487,7 @@ export default function MorphingFocusSection({
     const rest = movers.slice(1, 5);
     return (
       <Shell>
-        <SectionHeader title="지금은 코인 시간" subtitle="증시 마감 · 24시간 거래대금 기준" />
+        <SectionHeader title="지금은 코인 시간" subtitle="증시 마감 · 24시간 거래대금 기준" indices={indices} />
         <SessionBar primaryStatus={primaryStatus} secondaryStatus={secondaryStatus} clockLabel={clockLabel} />
         <FocusLeadCard
           item={lead.item} pct={lead.pct} newsCount={lead.newsCount}

--- a/src/components/home/RegimeBadge.jsx
+++ b/src/components/home/RegimeBadge.jsx
@@ -1,0 +1,33 @@
+// 시장 레짐 배지 — 하락장/혼조/상승장 컨텍스트 한 줄 (#358)
+// ADR-002 색 컨벤션: 빨강=상승, 파랑=하락 (한국 투자자 체화). mixed=중립 회색.
+import { computeMarketRegime } from '../../utils/marketRegime';
+
+const STYLE = {
+  down:  { glyph: '▼', color: '#1764ED', bg: 'rgba(23,100,237,0.08)' },  // 파랑=하락
+  up:    { glyph: '▲', color: '#F04452', bg: 'rgba(240,68,82,0.08)' },   // 빨강=상승
+  mixed: { glyph: '↔', color: '#8B95A1', bg: 'rgba(139,149,161,0.12)' }, // 다크모드 표면에서도 안전한 알파
+};
+
+/**
+ * @param {Array} indices  useIndices().indices
+ * @param {boolean} [showAvg=true] 평균 등락률(%) 병기 여부
+ */
+export default function RegimeBadge({ indices, showAvg = true, className = '' }) {
+  const regime = computeMarketRegime(indices);
+  if (!regime) return null;
+  const s = STYLE[regime.regime] || STYLE.mixed;
+  // 혼조는 avg(-2~+2) 표기 시 경계 반올림으로 "혼조 -2%" 같은 모순이 보일 수 있어 라벨만 표시.
+  const avgStr = showAvg && regime.regime !== 'mixed'
+    ? ` ${regime.avg > 0 ? '+' : ''}${regime.avg}%`
+    : '';
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-[11px] font-bold px-2 py-0.5 rounded-full flex-shrink-0 ${className}`}
+      style={{ background: s.bg, color: s.color }}
+      title={`주요 지수 평균 ${regime.avg > 0 ? '+' : ''}${regime.avg}% — ${regime.label}`}
+    >
+      <span aria-hidden="true">{s.glyph}</span>
+      {regime.label}{avgStr}
+    </span>
+  );
+}

--- a/src/utils/marketRegime.js
+++ b/src/utils/marketRegime.js
@@ -1,0 +1,42 @@
+// 시장 레짐 — 주요 주식 지수 등락률 평균으로 하락장/혼조/상승장 판정 (#358)
+//
+// 배경: 시그널 엔진은 하락을 잡지만(약세 시그널 발화) 화면이 상승 위주로 보여
+//   "하락장 미반영"으로 체감된다(architect 진단 = 정보위계 갭). 알고리즘을 바꾸지 않고
+//   "오늘 시장이 어느 방향인지"를 한 줄 배지로 명시해 맥락을 복원한다.
+//
+// 설계:
+//   - 주식 지수만 사용(DXY 달러인덱스 제외 — 환율은 주식 레짐과 무관, 평균 왜곡).
+//   - 단순 평균 등락률 → ±REGIME_THRESHOLD(2%) 경계로 3분류.
+//   - 지수 데이터 없으면 null(배지 미표시) — 빈/0 데이터로 가짜 '혼조' 표시 방지.
+
+// 레짐 판정에 쓰는 주식 지수 id (market-indices.js: KOSPI/KOSDAQ/SPX/NDX/DJI, DXY 제외)
+const EQUITY_INDEX_IDS = new Set(['KOSPI', 'KOSDAQ', 'SPX', 'NDX', 'DJI']);
+
+// ±경계(%) — 하루 지수 평균 등락이 이 값을 넘으면 방향성 장세로 판정
+export const REGIME_THRESHOLD = 2;
+
+/**
+ * computeMarketRegime — 주식 지수 평균 등락률로 시장 레짐 판정.
+ * @param {Array<{id?:string, changePct?:number}>} indices useIndices().indices
+ * @returns {{ regime:'down'|'mixed'|'up', label:string, avg:number }|null}
+ *   유효한 주식 지수가 하나도 없으면 null. (색/글리프는 표시 컴포넌트가 소유 — ADR-002 빨강=상승/파랑=하락)
+ */
+export function computeMarketRegime(indices = []) {
+  if (!Array.isArray(indices)) return null;
+
+  // 실제 number 만 채택 — Number(null)/Number('')/Number(false)===0 이 평균에 0%로 섞여
+  // '가짜 혼조'를 만드는 것을 차단(함수 계약). API(market-indices.js)는 changePct를 number로 공급.
+  const pcts = indices
+    .filter(idx => EQUITY_INDEX_IDS.has(idx?.id))
+    .map(idx => idx?.changePct)
+    .filter(v => typeof v === 'number' && Number.isFinite(v));
+
+  if (pcts.length === 0) return null;
+
+  const avg = pcts.reduce((a, b) => a + b, 0) / pcts.length;
+  const rounded = Math.round(avg * 10) / 10; // 소수 1자리
+
+  if (avg <= -REGIME_THRESHOLD) return { regime: 'down', label: '하락장', avg: rounded };
+  if (avg >= REGIME_THRESHOLD) return { regime: 'up', label: '상승장', avg: rounded };
+  return { regime: 'mixed', label: '혼조', avg: rounded };
+}


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-3.1-pro-preview)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #358

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 시장 상황(상승장/하락장/혼조)을 나타내는 레짐 배지가 UI에 추가되었습니다.
  * 주식 지수 평균을 기반으로 시장 레짐이 자동으로 계산되고 화면에 표시됩니다.

* **Tests**
  * 시장 레짐 계산 함수의 반환 값과 동작을 검증하는 테스트 스위트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->