### PR TITLE
fix(#394): 홈 지속 렉 제거 — WS 틱 1초 코얼레싱 + 뉴스 매칭/시세 분리 + 이중 마운트 제거

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,7 @@ import { usePrices } from './hooks/usePrices';
 import { useCoins } from './hooks/useCoins';
 import { useIndices } from './hooks/useIndices';
 import { useFearGreed } from './hooks/useFearGreed';
+import { useIsMobile } from './hooks/useIsMobile';
 
 // PWA 설치 유도 배너 — standalone이 아닌 환경에서 1회 표시
 function InstallBanner() {
@@ -73,6 +74,7 @@ function InstallBanner() {
 export default function App() {
   // F&G 시그널 발화 단일 인스턴스 — 다중 호출 시 시그널 중복 발화 방지
   useFearGreed();
+  const isMobile = useIsMobile();
   const { dark, toggle: toggleDark } = useDarkMode();
   const { watchlist, krSymbols, usSymbols } = useWatchlist();
   const { indices, krwRate, krwRateLoaded } = useIndices();
@@ -140,12 +142,24 @@ export default function App() {
 
 
   // KIS WebSocket — watchlist KR 우선
+  // #394: 훅이 틱을 1초 코얼레싱한 배치(배열)로 전달 — 배열 재생성·리렌더를 초당 1회로 제한
   const kisSymbols = useMemo(() => {
     const combined = [...new Set([...krSymbols, ...krStocks.map(s => s.symbol)])];
     return combined.slice(0, 40); // H0STCNT0 세션당 최대 40개
   }, [krSymbols, krStocks]);
-  useKisWebSocket(kisSymbols, useCallback((quote) => {
-    setKrStocks(prev => prev.map(s => s.symbol === quote.symbol ? { ...s, ...quote } : s));
+  useKisWebSocket(kisSymbols, useCallback((quotes) => {
+    if (!quotes?.length) return;
+    setKrStocks(prev => {
+      const bySym = new Map(quotes.map(q => [q.symbol, q]));
+      let changed = false;
+      const next = prev.map(s => {
+        const q = bySym.get(s.symbol);
+        if (!q) return s;
+        changed = true;
+        return { ...s, ...q };
+      });
+      return changed ? next : prev;
+    });
   }, []));
 
   // KIS WebSocket HDFSCNT0 — 미장 실시간 (watchlist 우선, 최대 40개)
@@ -155,8 +169,19 @@ export default function App() {
     const combined = [...new Set([...usSymbols, ...defaultTop])];
     return combined.slice(0, 40);
   }, [usSymbols]);
-  useKisUsWebSocket(kisUsSymbols, useCallback((quote) => {
-    setUsStocks(prev => prev.map(s => s.symbol === quote.symbol ? { ...s, ...quote } : s));
+  useKisUsWebSocket(kisUsSymbols, useCallback((quotes) => {
+    if (!quotes?.length) return;
+    setUsStocks(prev => {
+      const bySym = new Map(quotes.map(q => [q.symbol, q]));
+      let changed = false;
+      const next = prev.map(s => {
+        const q = bySym.get(s.symbol);
+        if (!q) return s;
+        changed = true;
+        return { ...s, ...q };
+      });
+      return changed ? next : prev;
+    });
   }, []));
 
   // ETF 폴링 (60초)
@@ -441,7 +466,8 @@ export default function App() {
         </div>
 
         {/* 데스크톱 우측 뉴스 레일 (#353) — 뉴스 탭 제외 전 탭에서 표시. #340 회귀 복원 */}
-        {activeTab !== 'news' && (
+        {/* #394: CSS hidden은 마운트를 막지 못해 모바일에서도 뉴스 매칭 연산 발생 → 렌더 분기 */}
+        {activeTab !== 'news' && !isMobile && (
           <aside className="hidden lg:block self-start sticky top-[84px] pt-5 pr-5 pb-5">
             <NewsFeedWidget
               allNews={allNews}

--- a/src/__tests__/tickBuffer.test.js
+++ b/src/__tests__/tickBuffer.test.js
@@ -1,0 +1,77 @@
+// WS 틱 코얼레싱 버퍼 단위 테스트 (#394)
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTickBuffer, TICK_FLUSH_MS } from '../utils/tickBuffer';
+
+describe('createTickBuffer', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('flushMs 이전에는 플러시하지 않는다', () => {
+    const onFlush = vi.fn();
+    const buf = createTickBuffer(onFlush, 1000);
+    buf.push({ symbol: 'AAPL', price: 100 });
+    vi.advanceTimersByTime(999);
+    expect(onFlush).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it('같은 심볼의 연속 틱은 최신 틱만 배치에 남는다', () => {
+    const onFlush = vi.fn();
+    const buf = createTickBuffer(onFlush, 1000);
+    buf.push({ symbol: 'AAPL', price: 100 });
+    buf.push({ symbol: 'AAPL', price: 101 });
+    buf.push({ symbol: 'AAPL', price: 102 });
+    vi.advanceTimersByTime(1000);
+    expect(onFlush).toHaveBeenCalledWith([{ symbol: 'AAPL', price: 102 }]);
+  });
+
+  it('서로 다른 심볼은 한 배치에 함께 전달된다', () => {
+    const onFlush = vi.fn();
+    const buf = createTickBuffer(onFlush, 1000);
+    buf.push({ symbol: 'AAPL', price: 100 });
+    buf.push({ symbol: 'NVDA', price: 900 });
+    vi.advanceTimersByTime(1000);
+    const batch = onFlush.mock.calls[0][0];
+    expect(batch).toHaveLength(2);
+    expect(batch.map(t => t.symbol).sort()).toEqual(['AAPL', 'NVDA']);
+  });
+
+  it('플러시 후 새 틱은 새 배치로 다시 스케줄된다', () => {
+    const onFlush = vi.fn();
+    const buf = createTickBuffer(onFlush, 1000);
+    buf.push({ symbol: 'AAPL', price: 100 });
+    vi.advanceTimersByTime(1000);
+    buf.push({ symbol: 'AAPL', price: 101 });
+    vi.advanceTimersByTime(1000);
+    expect(onFlush).toHaveBeenCalledTimes(2);
+    expect(onFlush.mock.calls[1][0]).toEqual([{ symbol: 'AAPL', price: 101 }]);
+  });
+
+  it('symbol 없는 틱은 무시한다', () => {
+    const onFlush = vi.fn();
+    const buf = createTickBuffer(onFlush, 1000);
+    buf.push({ price: 100 });
+    buf.push(null);
+    vi.advanceTimersByTime(1000);
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it('destroy는 대기 중인 플러시를 취소하고 버퍼를 비운다', () => {
+    const onFlush = vi.fn();
+    const buf = createTickBuffer(onFlush, 1000);
+    buf.push({ symbol: 'AAPL', price: 100 });
+    buf.destroy();
+    vi.advanceTimersByTime(2000);
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it('기본 플러시 주기는 TICK_FLUSH_MS(1000ms)다', () => {
+    expect(TICK_FLUSH_MS).toBe(1000);
+    const onFlush = vi.fn();
+    const buf = createTickBuffer(onFlush);
+    buf.push({ symbol: 'BTC', price: 1 });
+    vi.advanceTimersByTime(TICK_FLUSH_MS);
+    expect(onFlush).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/home/SignalBoardWidget.jsx
+++ b/src/components/home/SignalBoardWidget.jsx
@@ -38,9 +38,15 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
   const { botMap } = useSignalAccuracy();
   const { toggle: toggleWatch, isWatched } = useWatchlist();
 
+  // #394: allItems는 WS 틱마다 identity가 바뀜 — 내러티브(뉴스 매칭+섹터 동조 카운트)가
+  // 틱마다 재계산되지 않도록 ref로 분리. 섹터 동조 수는 1초 내 stale이어도 무방.
+  const allItemsRef = useRef(allItems);
+  allItemsRef.current = allItems;
+
   // 시그널별 내러티브 사전 계산 — symbol 기준 캐싱
   // sector 보강(KR), ±2시간 뉴스 매칭, 섹터 동조 종목 수 집계
   const narrativeMap = useMemo(() => {
+    const allItems = allItemsRef.current;
     const map = new Map();
     if (!allSignals.length) return map;
     for (const sig of allSignals) {
@@ -77,7 +83,7 @@ export default function SignalBoardWidget({ onItemClick, allItems = [], allNews 
       map.set(sig.id, { narrative, relatedNews });
     }
     return map;
-  }, [allSignals, allItems, allNews]);
+  }, [allSignals, allNews]); // allItems는 ref로 읽음 (#394 — 틱 의존 분리)
 
   // allItems O(1) 조회 맵
   const allItemsLookup = useMemo(() => {

--- a/src/components/home/TopNewsSection.jsx
+++ b/src/components/home/TopNewsSection.jsx
@@ -1,6 +1,6 @@
 // 시장을 움직이는 뉴스 — 종목 연결 카드형 뉴스 피드
 // 뉴스와 관련 종목을 뱃지로 연결, 종목 등락률 표시
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 
 // timeAgo를 렌더 시점에 동적 계산 — 캐시된 정적 문자열 대신 사용
 function computeTimeAgo(pubDate) {
@@ -30,32 +30,26 @@ function cleanDesc(raw) {
     .replace(/\s+/g, ' ').trim();
 }
 
-// 뉴스와 매칭되는 종목 찾기 (allItems에서)
-function findMatchedStocks(newsTitle, allItems, max = 3) {
-  if (!newsTitle || !allItems.length) return [];
+// 뉴스와 매칭되는 종목 찾기 — 키워드가 사전 빌드된 경량 종목 목록 사용 (#394)
+// 가격(pct)은 여기서 캡처하지 않는다 — 렌더 시점에 pctMap으로 lookup (매칭 ↔ 시세 분리)
+function findMatchedStocks(newsTitle, matchableItems, max = 3) {
+  if (!newsTitle || !matchableItems.length) return [];
   const matched = [];
   const seen = new Set();
 
-  for (const item of allItems) {
+  for (const item of matchableItems) {
     if (matched.length >= max) break;
-    const key = item.symbol || item.id;
-    if (seen.has(key)) continue;
+    if (seen.has(item.key) || !item.keywords.length) continue;
 
-    const keywords = buildStockKeywords(
-      item.symbol, item.name,
-      item._market === 'KR' ? 'KR' : item._market === 'COIN' ? 'COIN' : 'US'
-    );
-    if (keywords.length > 0 && matchesKeywords(newsTitle, keywords)) {
-      const confidence = getMatchConfidence(newsTitle, keywords, item.symbol);
+    if (matchesKeywords(newsTitle, item.keywords)) {
+      const confidence = getMatchConfidence(newsTitle, item.keywords, item.symbol);
       // WEAK 매칭은 제외
       if (confidence === 'WEAK') continue;
-      seen.add(key);
-      const pct = item._market === 'COIN' ? (item.change24h ?? 0) : (item.changePct ?? 0);
+      seen.add(item.key);
       matched.push({
-        symbol: item.symbol || item.id,
+        symbol: item.key,
         name: item.name,
         market: item._market,
-        pct,
         confidence,
       });
     }
@@ -87,6 +81,40 @@ function StockBadge({ stock, onClick }) {
 }
 
 export default function TopNewsSection({ allNews = [], onNewsClick, onItemClick, allItems = [] }) {
+  // #394 매칭 ↔ 시세 분리: allItems는 WS 틱마다 identity가 바뀌므로 그대로 의존하면
+  // 틱마다 뉴스 전건 × 종목 전체 키워드 매칭이 재실행된다(렉 주범).
+  // → 종목 "구성"(심볼 목록)이 바뀔 때만 매칭을 재계산하고, 시세는 렌더 시 lookup.
+
+  // 종목 구성 지문 — 가격이 아니라 심볼 집합이 바뀔 때만 변경
+  const itemsKey = useMemo(
+    () => allItems.map(i => i.symbol || i.id).join(','),
+    [allItems],
+  );
+
+  // 매칭용 경량 종목 + 키워드 사전 빌드 — 종목당 1회 (기존: 뉴스 × 종목마다 빌드)
+  const matchableItems = useMemo(() => allItems.map(it => ({
+    key: it.symbol || it.id,
+    symbol: it.symbol,
+    name: it.name,
+    _market: it._market,
+    keywords: buildStockKeywords(
+      it.symbol, it.name,
+      it._market === 'KR' ? 'KR' : it._market === 'COIN' ? 'COIN' : 'US',
+    ),
+  })), [itemsKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // 시세 lookup — 틱마다 갱신되지만 O(n) Map 생성이라 저렴
+  const pctMap = useMemo(() => {
+    const m = new Map();
+    for (const it of allItems) {
+      m.set(it.symbol || it.id, it._market === 'COIN' ? (it.change24h ?? 0) : (it.changePct ?? 0));
+    }
+    return m;
+  }, [allItems]);
+  // 점수 계산용 — memo 의존성에 넣지 않고 ref로 읽어 매칭 재계산과 분리
+  const pctMapRef = useRef(pctMap);
+  pctMapRef.current = pctMap;
+
   // 24시간 이내 뉴스 중 시그널 점수 + 종목 매칭 기준 상위 5건
   const topNews = useMemo(() => {
     const cutoff = 24 * 60 * 60 * 1000;
@@ -101,9 +129,10 @@ export default function TopNewsSection({ allNews = [], onNewsClick, onItemClick,
         const signals = extractNewsSignals(n.title, n.pubDate);
         const impact = getNewsImpact(n.title);
         const importanceScore = getNewsImportanceScore(n);
-        // 종목 실제 움직임 점수 (연결된 종목의 변동폭 합산)
-        const matchedStocks = findMatchedStocks(n.title, allItems);
-        const movementScore = matchedStocks.reduce((sum, s) => sum + Math.abs(s.pct), 0);
+        // 종목 실제 움직임 점수 (연결된 종목의 변동폭 합산) — 정렬용이므로 memo 시점 시세로 충분
+        const matchedStocks = findMatchedStocks(n.title, matchableItems);
+        const movementScore = matchedStocks.reduce(
+          (sum, s) => sum + Math.abs(pctMapRef.current.get(s.symbol) ?? 0), 0);
         // 점수: 중요도 점수 + 종목 움직임 가산
         const score = importanceScore + Math.min(movementScore * 0.5, 3);
         return { ...n, _signals: signals, _impact: impact, _score: score, _matchedStocks: matchedStocks };
@@ -122,7 +151,7 @@ export default function TopNewsSection({ allNews = [], onNewsClick, onItemClick,
         return b._score - a._score || aAge - bAge;
       })
       .slice(0, 5);
-  }, [allNews, allItems]);
+  }, [allNews, matchableItems]);
 
   if (!topNews.length) return null;
 
@@ -192,7 +221,11 @@ export default function TopNewsSection({ allNews = [], onNewsClick, onItemClick,
               {item._matchedStocks?.length > 0 && (
                 <div className="flex flex-wrap gap-1.5 mt-1.5">
                   {item._matchedStocks.map(stock => (
-                    <StockBadge key={stock.symbol} stock={stock} onClick={onItemClick} />
+                    <StockBadge
+                      key={stock.symbol}
+                      stock={{ ...stock, pct: pctMap.get(stock.symbol) ?? 0 }}
+                      onClick={onItemClick}
+                    />
                   ))}
                 </div>
               )}

--- a/src/components/home/index.jsx
+++ b/src/components/home/index.jsx
@@ -3,6 +3,7 @@ import { useState, useRef, useMemo, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAllNewsQuery } from '../../hooks/useNewsQuery';
 import { useWatchlist } from '../../hooks/useWatchlist';
+import { useIsMobile } from '../../hooks/useIsMobile';
 import { getPct, isNoiseInstrument } from './utils';
 import { itemKey, isPreferredOrSpecial } from '../../utils/symbolKey';
 import NewsFeedWidget from './widgets/NewsFeedWidget';
@@ -24,6 +25,7 @@ export default function HomeDashboard({
   dataReady = true,
 }) {
   const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
   const { data: allNews = [] } = useAllNewsQuery();
   const { watchlist, toggle, isWatched } = useWatchlist();
 
@@ -268,9 +270,10 @@ export default function HomeDashboard({
       <SignalLabWidget />
 
       {/* ─── 5. 뉴스 (모바일 전용 — 데스크톱은 App.jsx 우측 뉴스 레일 #353) ── */}
-      <div className="lg:hidden">
+      {/* #394: lg:hidden은 데스크톱에서도 마운트되어 뉴스 매칭 연산 2배 → 렌더 분기로 교체 */}
+      {isMobile && (
         <NewsFeedWidget allNews={allNews} onNewsClick={onNewsClick} onItemClick={onItemClick} allItems={allItems} />
-      </div>
+      )}
 
     </div>
   );

--- a/src/hooks/useCoins.js
+++ b/src/hooks/useCoins.js
@@ -214,7 +214,9 @@ export function useCoins(krwRateRef) {
       if (tick._connected) { wsConnectedRef.current = true; return; }
       if (tick._disconnected) { wsConnectedRef.current = false; return; }
       wsTickBufRef.current[tick.symbol] = tick;
-      if (!wsFlushTimer.current) wsFlushTimer.current = setTimeout(flushTicks, 200);
+      // 200ms → 1000ms (#394): 코인 WS 플러시가 200ms마다 setCoins → 홈 전체 리렌더 폭풍의 1차 트리거.
+      // 시세 체감(1초)을 해치지 않는 선에서 리렌더 빈도를 1/5로 제한.
+      if (!wsFlushTimer.current) wsFlushTimer.current = setTimeout(flushTicks, 1000);
     };
     wsHandlerRef.current = wsHandler;
     // 전체 심볼 목록으로 한 번만 구독 (이중 구독 방지)

--- a/src/hooks/useIsMobile.js
+++ b/src/hooks/useIsMobile.js
@@ -1,0 +1,20 @@
+// 뷰포트 모바일 여부 — Tailwind lg(1024px) 미만 기준
+// CSS hidden 이중 마운트 제거용 (#394): lg:hidden/hidden lg:block으로 숨겨도
+// 컴포넌트는 마운트되어 연산(뉴스 매칭 등)을 계속하므로, 렌더 자체를 분기한다.
+import { useSyncExternalStore } from 'react';
+
+const QUERY = '(max-width: 1023px)';
+
+function subscribe(onChange) {
+  const mql = window.matchMedia(QUERY);
+  mql.addEventListener('change', onChange);
+  return () => mql.removeEventListener('change', onChange);
+}
+
+function getSnapshot() {
+  return window.matchMedia(QUERY).matches;
+}
+
+export function useIsMobile() {
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}

--- a/src/hooks/useKisUsWebSocket.js
+++ b/src/hooks/useKisUsWebSocket.js
@@ -4,6 +4,7 @@
 
 import { useEffect, useRef } from 'react';
 import { fetchWsApproval } from '../api/_gateway.js';
+import { createTickBuffer } from '../utils/tickBuffer.js';
 
 const KIS_WS_URL  = 'wss://ops.koreainvestment.com:21000';
 const TR_ID       = 'HDFSCNT0';
@@ -82,10 +83,10 @@ function parseSymbol(trKey) {
 /**
  * KIS WebSocket HDFSCNT0 — 해외주식 실시간 체결 구독 훅
  * @param {string[]} symbols  - 종목코드 배열 (예: ['AAPL', 'NVDA']) 최대 40개
- * @param {Function} onQuote  - 콜백: ({ symbol, price, change, changePct }) => void
+ * @param {Function} onQuotes - 콜백: 1초 코얼레싱 배치 [{ symbol, price, change, changePct }, ...] (#394)
  */
-export function useKisUsWebSocket(symbols, onQuote) {
-  const onQuoteRef      = useRef(onQuote);
+export function useKisUsWebSocket(symbols, onQuotes) {
+  const onQuotesRef     = useRef(onQuotes);
   const symbolsRef      = useRef(symbols);
   const prevSymbolsRef  = useRef([]);
   const wsRef           = useRef(null);
@@ -95,7 +96,7 @@ export function useKisUsWebSocket(symbols, onQuote) {
   const keyRefreshTimer = useRef(null);
   const mountedRef      = useRef(true);
 
-  useEffect(() => { onQuoteRef.current = onQuote; }, [onQuote]);
+  useEffect(() => { onQuotesRef.current = onQuotes; }, [onQuotes]);
   useEffect(() => { symbolsRef.current = symbols; }, [symbols]);
 
   // ── 구독/해제 헬퍼 ──────────────────────────────────────────────
@@ -177,6 +178,8 @@ export function useKisUsWebSocket(symbols, onQuote) {
   // ── WebSocket 연결 관리 ─────────────────────────────────────────
   useEffect(() => {
     mountedRef.current = true;
+    // 틱 1초 코얼레싱 — 심볼별 최신 틱만 배치로 전달 (#394 리렌더 폭풍 차단)
+    const tickBuffer = createTickBuffer(batch => onQuotesRef.current?.(batch));
 
     async function fetchApprovalKey() {
       try {
@@ -206,7 +209,7 @@ export function useKisUsWebSocket(symbols, onQuote) {
         const raw = event.data;
         if (typeof raw !== 'string' || raw.startsWith('{')) return;
         const quote = parsePipeMessage(raw);
-        if (quote) onQuoteRef.current?.(quote);
+        if (quote) tickBuffer.push(quote);
       };
 
       ws.onerror = (e) => {
@@ -280,6 +283,7 @@ export function useKisUsWebSocket(symbols, onQuote) {
 
     return () => {
       mountedRef.current = false;
+      tickBuffer.destroy();
       clearTimeout(retryTimer.current);
       clearTimeout(keyRefreshTimer.current);
       document.removeEventListener('visibilitychange', handleVisibility);

--- a/src/hooks/useKisWebSocket.js
+++ b/src/hooks/useKisWebSocket.js
@@ -5,6 +5,7 @@
 
 import { useEffect, useRef } from 'react';
 import { fetchWsApproval } from '../api/_gateway.js';
+import { createTickBuffer } from '../utils/tickBuffer.js';
 
 const KIS_WS_URL     = 'wss://ops.koreainvestment.com:21000';
 const TR_ID          = 'H0STCNT0';
@@ -15,11 +16,11 @@ const KEY_TTL_MS     = 23 * 60 * 60 * 1000; // 23h — 한투 approval_key 24h �
 /**
  * KIS WebSocket 실시간 체결 가격 구독 훅
  * @param {string[]} symbols    - 종목코드 배열 (예: ['005930', '000660'])
- * @param {Function} onQuote    - 콜백: ({ symbol, price, change, changePct }) => void
+ * @param {Function} onQuotes   - 콜백: 1초 코얼레싱 배치 [{ symbol, price, change, changePct }, ...] (#394)
  */
-export function useKisWebSocket(symbols, onQuote) {
+export function useKisWebSocket(symbols, onQuotes) {
   // 최신 콜백·symbols을 ref로 유지 → 재연결 시 클로저 문제 방지
-  const onQuoteRef      = useRef(onQuote);
+  const onQuotesRef     = useRef(onQuotes);
   const symbolsRef      = useRef(symbols);
   const wsRef           = useRef(null);
   const retryRef        = useRef(0);
@@ -29,12 +30,14 @@ export function useKisWebSocket(symbols, onQuote) {
   const approvalKeyRef  = useRef(null);
 
   // 콜백·symbols 최신값 동기화 (재연결 없이)
-  useEffect(() => { onQuoteRef.current = onQuote; }, [onQuote]);
+  useEffect(() => { onQuotesRef.current = onQuotes; }, [onQuotes]);
   useEffect(() => { symbolsRef.current = symbols; }, [symbols]);
 
   useEffect(() => {
     mountedRef.current = true;
     let approvalKey = null;
+    // 틱 1초 코얼레싱 — 심볼별 최신 틱만 배치로 전달 (#394 리렌더 폭풍 차단)
+    const tickBuffer = createTickBuffer(batch => onQuotesRef.current?.(batch));
 
     // ── approval_key 취득 ──────────────────────────────────────
     async function fetchApprovalKey() {
@@ -141,7 +144,7 @@ export function useKisWebSocket(symbols, onQuote) {
 
         const quote = parsePipeMessage(raw);
         if (quote) {
-          onQuoteRef.current?.(quote);
+          tickBuffer.push(quote);
         }
       };
 
@@ -218,6 +221,7 @@ export function useKisWebSocket(symbols, onQuote) {
     // ── 클린업: 구독 해제 + 소켓 닫기 ───────────────────────
     return () => {
       mountedRef.current = false;
+      tickBuffer.destroy();
       clearTimeout(retryTimer.current);
       clearTimeout(keyRefreshTimer.current);
       document.removeEventListener('visibilitychange', handleVisibility);

--- a/src/utils/tickBuffer.js
+++ b/src/utils/tickBuffer.js
@@ -1,0 +1,28 @@
+// WS 틱 코얼레싱 버퍼 — 심볼별 최신 틱만 유지, 주기 플러시로 setState 횟수 제한
+// 렉 근본 수정(#394): 틱당 전체 배열 재생성 → 1초 배치 1회로 리렌더 폭풍 차단
+export const TICK_FLUSH_MS = 1000;
+
+export function createTickBuffer(onFlush, flushMs = TICK_FLUSH_MS) {
+  let buf = new Map();
+  let timer = null;
+
+  function flush() {
+    timer = null;
+    if (!buf.size) return;
+    const batch = [...buf.values()];
+    buf = new Map();
+    onFlush(batch);
+  }
+
+  return {
+    push(tick) {
+      if (!tick?.symbol) return;
+      buf.set(tick.symbol, tick); // 같은 심볼은 최신 틱으로 덮어씀
+      if (!timer) timer = setTimeout(flush, flushMs);
+    },
+    destroy() {
+      if (timer) { clearTimeout(timer); timer = null; }
+      buf = new Map();
+    },
+  };
+}


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-3.1-pro-preview)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #394

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모바일 기기 자동 감지 및 최적화된 반응형 레이아웃 제공

* **성능 개선**
  * 실시간 시세 데이터 배치 처리로 업데이트 효율성 향상
  * 불필요한 화면 새로고침 감소로 앱 반응성 개선
  * 종목-뉴스 매칭 로직 최적화

* **테스트**
  * 실시간 데이터 처리 기능 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->