### PR TITLE
fix(#396): '미국 시세 일부 지연' 상시 노출 해소 — us 폴링 축소 + 배지 히스테리시스

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ import HomeDashboard from './components/home';
 import NewsFeedWidget from './components/home/widgets/NewsFeedWidget';
 import DataHealthBadge from './components/DataHealthBadge';
 import GlobalSearch from './components/GlobalSearch';
-import { DEFAULT_KRW_RATE } from './constants/market';
+import { DEFAULT_KRW_RATE, US_CORE_SYMBOLS } from './constants/market';
 import SectorRotation from './components/SectorRotation';
 import { isPreferredOrSpecial } from './utils/symbolKey';
 import { isNoiseInstrument } from './components/home/utils';
@@ -163,10 +163,9 @@ export default function App() {
   }, []));
 
   // KIS WebSocket HDFSCNT0 — 미장 실시간 (watchlist 우선, 최대 40개)
+  // #396: 코어 목록은 US_CORE_SYMBOLS 단일 소스 (usePrices 폴링과 공유)
   const kisUsSymbols = useMemo(() => {
-    const defaultTop = ['AAPL','MSFT','NVDA','GOOGL','AMZN','META','TSLA','AVGO',
-                        'JPM','NFLX','AMD','V','MA','LLY','WMT','XOM','PLTR','ARM'];
-    const combined = [...new Set([...usSymbols, ...defaultTop])];
+    const combined = [...new Set([...usSymbols, ...US_CORE_SYMBOLS])];
     return combined.slice(0, 40);
   }, [usSymbols]);
   useKisUsWebSocket(kisUsSymbols, useCallback((quotes) => {

--- a/src/constants/market.js
+++ b/src/constants/market.js
@@ -1,3 +1,10 @@
 // 시장 관련 공유 상수
 // USD → KRW 기본 환율 fallback (실시간 환율 API 실패 시 사용, 2026-04 기준)
 export const DEFAULT_KRW_RATE = 1466;
+
+// 미장 코어 종목 — 브라우저 폴링·KIS US WS 공통 (#396 단일 소스)
+// 전종목(250)은 스냅샷 크론(update-us, 2분)이 커버하므로 클라 폴링은 코어+watchlist만.
+export const US_CORE_SYMBOLS = [
+  'AAPL', 'MSFT', 'NVDA', 'GOOGL', 'AMZN', 'META', 'TSLA', 'AVGO',
+  'JPM', 'NFLX', 'AMD', 'V', 'MA', 'LLY', 'WMT', 'XOM', 'PLTR', 'ARM',
+];

--- a/src/hooks/usePrices.js
+++ b/src/hooks/usePrices.js
@@ -1,6 +1,7 @@
 // 미국·국내 주식 가격 폴링 훅
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { US_STOCK_LIST } from '../data/usStockList';
+import { US_CORE_SYMBOLS } from '../constants/market';
 import { KR_SECTOR_MAP } from '../data/krStockList';
 import KR_STOCK_NAMES from '../data/krStockNames.json';
 import { fetchSnapshot } from '../api/snapshot';
@@ -72,13 +73,17 @@ export function usePrices() {
   const krSymbolsRef = useRef([]);
   const usSymbolsRef = useRef([]);
 
+  // #396: 배지 히스테리시스 — 단발 실패로 '시세 지연' 배지가 깜빡이지 않게
+  // 연속 2회 실패 시에만 에러 ON, 성공 시 즉시 OFF
+  const usFailStreakRef = useRef(0);
+  const krFailStreakRef = useRef(0);
+  const ERROR_FAIL_STREAK = 2;
+
   const refreshUsStocks = useCallback(async () => {
     try {
-      // 항상 US_STOCK_LIST 전체 심볼 기반 폴링 — snapshot 시드 여부와 무관하게 250개 전체 유지
-      const baseSymbols = US_STOCK_LIST.map(s => s.symbol);
-      const baseSet = new Set(baseSymbols);
-      const extraSymbols = usSymbolsRef.current.filter(sym => !baseSet.has(sym));
-      const symbolsToFetch = [...baseSymbols, ...extraSymbols];
+      // #396: 폴링은 코어+watchlist 소규모만 — 전종목(250)은 snapshot 크론(update-us, 2분)이 커버.
+      // 250종목 fan-out이 /api/d 간헐 502의 원인이었음(국장과 동일 패턴으로 정렬).
+      const symbolsToFetch = [...new Set([...US_CORE_SYMBOLS, ...usSymbolsRef.current])];
       if (symbolsToFetch.length === 0) return;
 
       const data = await fetchUsStocksBatch(symbolsToFetch);
@@ -116,15 +121,20 @@ export function usePrices() {
         // merged 전체 저장 — raw data만 저장 시 재방문에서 sector/nameEn 메타 소실
         if (mergedUs) savePriceCache(CACHE_KEY_US, mergedUs);
         checkAndAlertBatch(data, 'us');
-        setDataErrors(prev => ({ ...prev, us: false }));
+        usFailStreakRef.current = 0;
+        setDataErrors(prev => prev.us ? { ...prev, us: false } : prev);
         // #380: 폴링 성공 = 데이터 갱신 → asOf.us 리셋. ⚠️ 객체 형태 유지(스냅샷도 {kr,us,coins} 객체 —
         // number로 set하면 headerAsOf의 asOf.us가 undefined→null→라벨 소멸. review CRITICAL)
         setAsOf(prev => ({ ...(prev && typeof prev === 'object' ? prev : {}), us: Date.now() }));
       } else {
-        setDataErrors(prev => ({ ...prev, us: true }));
+        usFailStreakRef.current += 1;
+        if (usFailStreakRef.current >= ERROR_FAIL_STREAK) setDataErrors(prev => prev.us ? prev : { ...prev, us: true });
       }
-    } catch { setDataErrors(prev => ({ ...prev, us: true })); }
-  }, []); // ref 패턴 — stocks 의존성 없음 (setAsOf/setUsStocks 등 setter는 안정 참조)
+    } catch {
+      usFailStreakRef.current += 1;
+      if (usFailStreakRef.current >= ERROR_FAIL_STREAK) setDataErrors(prev => prev.us ? prev : { ...prev, us: true });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps — ref 패턴, setter는 안정 참조
 
   const refreshKoreanStocks = useCallback(async () => {
     try {
@@ -159,14 +169,19 @@ export function usePrices() {
         // merged 전체 저장 — 폴링 결과(소규모)만 저장하면 재방문 시 전종목 소실
         if (mergedKr) savePriceCache(CACHE_KEY_KR, mergedKr);
         checkAndAlertBatch(data, 'kr');
-        setDataErrors(prev => ({ ...prev, kr: false }));
+        krFailStreakRef.current = 0;
+        setDataErrors(prev => prev.kr ? { ...prev, kr: false } : prev);
         // #380: 폴링 성공 → asOf.kr 리셋. 객체 형태 유지(review CRITICAL — number set 시 라벨 소멸)
         setAsOf(prev => ({ ...(prev && typeof prev === 'object' ? prev : {}), kr: Date.now() }));
       } else {
-        setDataErrors(prev => ({ ...prev, kr: true }));
+        krFailStreakRef.current += 1;
+        if (krFailStreakRef.current >= ERROR_FAIL_STREAK) setDataErrors(prev => prev.kr ? prev : { ...prev, kr: true });
       }
-    } catch { setDataErrors(prev => ({ ...prev, kr: true })); }
-  }, []); // ref 패턴 — stocks 의존성 없음 (setter는 안정 참조)
+    } catch {
+      krFailStreakRef.current += 1;
+      if (krFailStreakRef.current >= ERROR_FAIL_STREAK) setDataErrors(prev => prev.kr ? prev : { ...prev, kr: true });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps — ref 패턴, setter는 안정 참조
 
   // #185: snapshot 초기 로드 = hot tier(Top 200) 즉시 → full tier lazy merge.
   //        applySnapshot 로 merge 경로 단일화 → hot/full 동일 로직 공유.


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-3.1-pro-preview)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #396

---
🤖 Generated by Claude Code [claude-sonnet-4-6]