### PR TITLE
fix(#404): 틱 렌더 startTransition 전환 + 플러시 2s — 잔여 렉 블록 분해

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 // 마켓레이더 — 메인 앱 (훅 기반 상태 관리)
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo, startTransition } from 'react';
 import { cycleStart, cycleStep } from './utils/cycleTracker';
 import Header from './components/Header';
 import MobileBottomNav from './components/MobileBottomNav';
@@ -149,7 +149,8 @@ export default function App() {
   }, [krSymbols, krStocks]);
   useKisWebSocket(kisSymbols, useCallback((quotes) => {
     if (!quotes?.length) return;
-    setKrStocks(prev => {
+    // #404: 틱 갱신은 비긴급 — startTransition으로 렌더를 타임슬라이싱(롱태스크 분해, 인터랙션 우선)
+    startTransition(() => setKrStocks(prev => {
       const bySym = new Map(quotes.map(q => [q.symbol, q]));
       let changed = false;
       const next = prev.map(s => {
@@ -159,7 +160,7 @@ export default function App() {
         return { ...s, ...q };
       });
       return changed ? next : prev;
-    });
+    }));
   }, []));
 
   // KIS WebSocket HDFSCNT0 — 미장 실시간 (watchlist 우선, 최대 40개)
@@ -170,7 +171,8 @@ export default function App() {
   }, [usSymbols]);
   useKisUsWebSocket(kisUsSymbols, useCallback((quotes) => {
     if (!quotes?.length) return;
-    setUsStocks(prev => {
+    // #404: 틱 갱신 비긴급 전환 (KR과 동일)
+    startTransition(() => setUsStocks(prev => {
       const bySym = new Map(quotes.map(q => [q.symbol, q]));
       let changed = false;
       const next = prev.map(s => {
@@ -180,7 +182,7 @@ export default function App() {
         return { ...s, ...q };
       });
       return changed ? next : prev;
-    });
+    }));
   }, []));
 
   // ETF 폴링 (60초)

--- a/src/__tests__/tickBuffer.test.js
+++ b/src/__tests__/tickBuffer.test.js
@@ -66,8 +66,8 @@ describe('createTickBuffer', () => {
     expect(onFlush).not.toHaveBeenCalled();
   });
 
-  it('기본 플러시 주기는 TICK_FLUSH_MS(1000ms)다', () => {
-    expect(TICK_FLUSH_MS).toBe(1000);
+  it('기본 플러시 주기는 TICK_FLUSH_MS(2000ms — #404 실측 근거)다', () => {
+    expect(TICK_FLUSH_MS).toBe(2000);
     const onFlush = vi.fn();
     const buf = createTickBuffer(onFlush);
     buf.push({ symbol: 'BTC', price: 1 });

--- a/src/hooks/useCoins.js
+++ b/src/hooks/useCoins.js
@@ -1,8 +1,9 @@
 // 코인 가격 폴링 + Upbit WebSocket 훅
 // 가격: WebSocket(실시간, 우선) + REST fallback(30초)
 // 스파크라인: CoinGecko(5분) — 유일한 소스
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, startTransition } from 'react';
 import { fetchSnapshot } from '../api/snapshot';
+import { TICK_FLUSH_MS } from '../utils/tickBuffer';
 import { fetchCoinsUpbitOnly, fetchUpbitAllSymbols, fetchCoinGecko, getSparklineCache } from '../api/coins';
 import { subscribeCoinPrices, unsubscribeCoinPrices } from '../api/coinWs';
 import { POLLING } from '../constants/polling';
@@ -196,7 +197,8 @@ export function useCoins(krwRateRef) {
       const buf = wsTickBufRef.current;
       if (!Object.keys(buf).length) return;
       wsTickBufRef.current = {};
-      setCoins(prev => {
+      // #404: 틱 갱신 비긴급 — startTransition 타임슬라이싱 (KIS WS와 동일 패턴)
+      startTransition(() => setCoins(prev => {
         const rate    = krwRateRef.current;
         const updated = [...prev];
         let changed   = false;
@@ -208,15 +210,15 @@ export function useCoins(krwRateRef) {
           changed = true;
         }
         return changed ? updated : prev;
-      });
+      }));
     };
     const wsHandler = (tick) => {
       if (tick._connected) { wsConnectedRef.current = true; return; }
       if (tick._disconnected) { wsConnectedRef.current = false; return; }
       wsTickBufRef.current[tick.symbol] = tick;
-      // 200ms → 1000ms (#394): 코인 WS 플러시가 200ms마다 setCoins → 홈 전체 리렌더 폭풍의 1차 트리거.
-      // 시세 체감(1초)을 해치지 않는 선에서 리렌더 빈도를 1/5로 제한.
-      if (!wsFlushTimer.current) wsFlushTimer.current = setTimeout(flushTicks, 1000);
+      // 200ms→1000ms(#394)→TICK_FLUSH_MS 2000ms(#404): 플러시당 전체 트리 렌더 비용 실측 근거.
+      // KIS WS(tickBuffer)와 단일 상수 공유 — 한쪽만 조정되는 사고 방지.
+      if (!wsFlushTimer.current) wsFlushTimer.current = setTimeout(flushTicks, TICK_FLUSH_MS);
     };
     wsHandlerRef.current = wsHandler;
     // 전체 심볼 목록으로 한 번만 구독 (이중 구독 방지)

--- a/src/utils/tickBuffer.js
+++ b/src/utils/tickBuffer.js
@@ -1,6 +1,8 @@
 // WS 틱 코얼레싱 버퍼 — 심볼별 최신 틱만 유지, 주기 플러시로 setState 횟수 제한
-// 렉 근본 수정(#394): 틱당 전체 배열 재생성 → 1초 배치 1회로 리렌더 폭풍 차단
-export const TICK_FLUSH_MS = 1000;
+// 렉 근본 수정(#394): 틱당 전체 배열 재생성 → 배치 1회로 리렌더 폭풍 차단
+// #404: 1s→2s — 라이브 세션 실측에서 플러시당 전체 트리 렌더가 4x 스로틀 기준 500-800ms.
+// 시세 대시보드에서 2초 신선도는 체감 무손실, 렌더 횟수는 절반.
+export const TICK_FLUSH_MS = 2000;
 
 export function createTickBuffer(onFlush, flushMs = TICK_FLUSH_MS) {
   let buf = new Map();


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-3.1-pro-preview)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #404

---
🤖 Generated by Claude Code [claude-sonnet-4-6]