### PR TITLE
fix(#357): 미장 워런트 universe 진입 차단 — CF Worker update-us NASDAQ 수집 필터

### DIFF
--- a/workers/cron/src/crons/update-us.js
+++ b/workers/cron/src/crons/update-us.js
@@ -34,6 +34,11 @@ async function fetchNasdaqSymbols(limit = 1000) {
       const rows = data?.data?.table?.rows || [];
       for (const row of rows) {
         if (!row.symbol || row.symbol.includes('^') || row.symbol.includes('/')) continue;
+        // #357: 워런트/권리/유닛/트랜치/CVR universe 진입 차단 (정제 전 원본 name 기준).
+        // 클라이언트 필터(#355 isNoiseInstrument / #360 티커규약)와 이중 방어 — 스냅샷 universe 자체를 정화해
+        // 급등 랭킹·시그널 풀에 잡주가 들어오는 것을 근본 차단.
+        // ⚠️ rights/units는 복수형만 — 단수는 정상주 오탐(Unit Corporation=UNT 등). SPAC 유닛/권리주는 항상 복수.
+        if (/\b(warrants?|rights|units|tranche|contingent)\b/i.test(row.name || '')) continue;
         // 시가총액 파싱 (문자열 "1,234,567" → 숫자)
         const mcStr = (row.marketCap || '').replace(/,/g, '');
         const mc = parseInt(mcStr, 10) || 0;


### PR DESCRIPTION
## 독립 리뷰 결과

### code-reviewer (Claude Opus)
지적사항 없음 (PASS)

### Gemini gate (gemini-3.1-pro-preview)
- PASS

---
> ⚠️ PR 후 봇 리뷰 채택/기각 기준: 위 두 리뷰에서 이미 검토된 항목과 일치하면 채택, 상충하면 재검토 후 판단 (사전 승인 결과 원복 방지)

Closes #357

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * NASDAQ 스냅샷 유니버스에서 워런트, 권리, 유닛, 트랜치, 조건부 증권 등 유도 종목이 제외되도록 필터링 강화
  * 보다 정제된 종목 데이터셋 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->