### PR TITLE
chore: 디스코드 발송 전면 비활성화

### DIFF
--- a/workers/cron/src/crons/watchdog.js
+++ b/workers/cron/src/crons/watchdog.js
@@ -106,6 +106,10 @@ export async function watchdog(env) {
     `조치: [Workers 대시보드](${dashboardUrl}) 에서 tail / 로그 확인`,
   ].join('\n');
 
+  // [디스코드 전면개편] 기존 발송 전부 비활성화 — redesign in progress
+  console.log(`[watchdog] Discord 발송 비활성화(kill switch) — alerts=${alerts.length}건 감지되었으나 발송 안 함`);
+  return { ok: false, reason: 'discord-disabled', alerts: alerts.length, cronsAlerted: alerts.map((a) => a.cron) };
+
   try {
     const res = await fetch(webhookUrl, {
       method: 'POST',


### PR DESCRIPTION
## 요약
디스코드 전면 재설계로 기존 모든 발송(watchdog 크론 장애·coins staleness 경보 등)을 코드 레벨에서 차단했습니다. 배포는 확인 후 진행합니다.

## 변경 사항
- `workers/cron/src/crons/watchdog.js`: Discord webhook POST 직전에 하드 kill switch 추가. 기존 로직(실패 카운트 집계, 알림 대상 판단, 로그)은 그대로 동작하되 실제 발송만 차단. 전면 재설계 완료 후 되돌릴 수 있도록 기존 발송 코드는 그대로 보존.
- 저장소 전체에서 `discord`/`webhook` 검색 결과, 이 파일이 유일한 발송 지점임을 확인.

## 테스트 플랜
- [ ] `node --check`로 문법 검증 완료
- [ ] 로컬에서 watchdog 실행 시 `discord-disabled` 반환 확인 (실제 배포 전 확인 필요)
- [ ] 배포는 이 PR과 별도로 대표 확인 후 진행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 크론 실패 감지 시 외부 알림 전송이 비활성화되었으며, 더 이상 메시지가 발송되지 않습니다.
  * 알림이 감지되더라도 즉시 비활성화 상태로 응답해, 전송 시도 없이 종료됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->